### PR TITLE
include Z3_INCLUDE_DIR, not Z3_INCLUDE_DIRS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ if (CYGWIN)
 endif()
 
 find_package(Z3 4.8.1 REQUIRED)
-include_directories(${Z3_INCLUDE_DIRS})
+include_directories(${Z3_INCLUDE_DIR})
 
 find_program(RE2C re2c)
 message(STATUS "RE2C: ${RE2C}")

--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ cmake ..
 make
 ```
 
+If CMake cannot find the Z3 include directory (or finds the wrong one) pass
+the ``-DZ3_INCLUDE_DIR=/path/to/z3/include`` argument to CMake
+
 Building and Running Translation Validation
 --------
 


### PR DESCRIPTION
I think this is the right fix, at least it makes me able to build alive2 on my mac where z3 lives in a weird spot