### PR TITLE
CMake: mark 'check' target as using terminal.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,4 +119,5 @@ add_custom_target("check"
                           "-s"
                           "${PROJECT_SOURCE_DIR}/tests"
                   DEPENDS "alive"
+                  USES_TERMINAL
                  )


### PR DESCRIPTION
Else, all the `lit` output is being buffered, and is flushed after
the target finishes 'building'. In particular, that hides the
progress meter.

Same as https://github.com/google/souper/pull/404