### PR TITLE
TransformVerify: only check src instrs that exist in dst too

### DIFF
--- a/tests/unit/lhs-intermediate-variable.opt
+++ b/tests/unit/lhs-intermediate-variable.opt
@@ -1,0 +1,7 @@
+Name: check that an intermediate variable that only exists on LHS does not cause an exception
+%c = udiv %a, %b
+%e = add %c, %d
+  =>
+%e = shl %f, %g
+
+; ERROR: Target is more poisonous than source for i1 %e

--- a/tests/unit/rhs-intermediate-variable.opt
+++ b/tests/unit/rhs-intermediate-variable.opt
@@ -1,0 +1,7 @@
+Name: check that an intermediate variable that only exists on RHS does not cause an exception
+%c = shl %a, %b
+  =>
+%f = udiv %d, %e
+%c = add %f, %g
+
+; ERROR: Target is more poisonous than source for i1 %c

--- a/tools/transform.cpp
+++ b/tools/transform.cpp
@@ -235,10 +235,13 @@ Errors TransformVerify::verify() const {
       if (name[0] != '%' || !dynamic_cast<const Instr*>(var))
         continue;
 
+      auto tgt_i = tgt_instrs.find(name);
+      if (tgt_i == tgt_instrs.end())
+        continue;
+
       // TODO: add data-flow domain tracking for Alive, but not for TV
-      check_refinement(errs, t, src_state, tgt_state, var,
-                       true, val, true, tgt_state.at(*tgt_instrs.at(name)),
-                       check_each_var);
+      check_refinement(errs, t, src_state, tgt_state, var, true, val, true,
+                       tgt_state.at(*tgt_i->second), check_each_var);
       if (errs)
         return errs;
     }
@@ -308,7 +311,9 @@ TypingAssignments TransformVerify::getTypings() const {
 
   if (check_each_var) {
     for (auto &i : t.src.instrs()) {
-      c &= i.eqType(*tgt_instrs.at(i.getName()));
+      auto tgt_i = tgt_instrs.find(i.getName());
+      if (tgt_i != tgt_instrs.end())
+        c &= i.eqType(*tgt_i->second);
     }
   }
   return { move(c) };


### PR DESCRIPTION
At least the lhs-intermediate-variable.opt test causes a crash otherwise.
Because we go through every instruction on the LHS, and verify it against
it's counterpart on RHS. But naturally, if said instruction only exists
on one side, we can't get it's counter-part from the other side
so the std::unordered_map<>::at() throws an exception, and alive crashes.