### PR TITLE
Pretty print for FP zeros

### DIFF
--- a/ir/type.cpp
+++ b/ir/type.cpp
@@ -342,6 +342,8 @@ pair<expr, vector<expr>> FloatType::mkInput(State &s, const char *name) const {
 void FloatType::printVal(ostream &os, State &s, const expr &e) const {
   if (e.isNaN().simplify().isTrue()) {
     os << "NaN";
+  } else if (e.isFPZero().simplify().isTrue()) {
+    os << (e.isFPNeg().simplify().isTrue() ? "-0.0" : "+0.0");
   } else if (e.isInf().simplify().isTrue()) {
     os << (e.isFPNeg().simplify().isTrue() ? "-oo" : "+oo");
   } else {

--- a/smt/expr.cpp
+++ b/smt/expr.cpp
@@ -717,6 +717,11 @@ expr expr::isInf() const {
   return Z3_mk_fpa_is_infinite(ctx(), ast());
 }
 
+expr expr::isFPZero() const {
+  C();
+  return Z3_mk_fpa_is_zero(ctx(), ast());
+}
+
 expr expr::isFPNeg() const {
   C();
   return Z3_mk_fpa_is_negative(ctx(), ast());

--- a/smt/expr.h
+++ b/smt/expr.h
@@ -157,6 +157,7 @@ public:
 
   expr isNaN() const;
   expr isInf() const;
+  expr isFPZero() const;
   expr isFPNeg() const;
 
   expr fadd(const expr &rhs) const;


### PR DESCRIPTION
This fixes the issue https://github.com/AliveToolkit/alive2/issues/79#issue-471235675

Example output
```
----------------------------------------
define float @f1(float %abc) {
%0:
  %1 = fadd float %abc, 0.000000
  ret float %1
}
=>
define float @f1(float %abc) {
%0:
  ret float %abc
}
Transformation doesn't verify!
ERROR: Value mismatch

Example:
float %abc = -0.0

Source:
float %1 = +0.0

Target:
Source value: +0.0
Target value: -0.0
```