### PR TITLE
add memcpy to alive2

### DIFF
--- a/ir/instr.cpp
+++ b/ir/instr.cpp
@@ -1518,16 +1518,17 @@ void Memset::print(ostream &os) const {
 }
 
 StateValue Memset::toSMT(State &s) const {
-  auto &[vptr, np] = s[*ptr];
-  auto &[vbytes, np2] = s[*bytes];
-  s.addUB(vbytes.ugt(0).implies(np));
-  s.addUB(vbytes.ugt(0).implies(np2));
+  auto &[vptr, np_ptr] = s[*ptr];
+  auto &[vbytes, np_bytes] = s[*bytes];
+  s.addUB(vbytes.ugt(0).implies(np_ptr));
+  s.addUB(np_bytes);
   s.getMemory().memset(vptr, s[*val], vbytes, align);
   return {};
 }
 
 expr Memset::getTypeConstraints(const Function &f) const {
-  return ptr->getType().enforcePtrType() && bytes->getType().enforceIntType();
+  return ptr->getType().enforcePtrType() &&
+         bytes->getType().enforceIntType();
 }
 
 unique_ptr<Instr> Memset::dup(const string &suffix) const {
@@ -1551,19 +1552,19 @@ void Memcpy::print(ostream &os) const {
 }
 
 StateValue Memcpy::toSMT(State &s) const {
-  auto &[vdst, np] = s[*dst];
-  auto &[vsrc, np2] = s[*src];
-  auto &[vbytes, np3] = s[*bytes];
-  s.addUB(vbytes.ugt(0).implies(np));
-  s.addUB(vbytes.ugt(0).implies(np2));
-  s.addUB(vbytes.ugt(0).implies(np3));
+  auto &[vdst, np_dst] = s[*dst];
+  auto &[vsrc, np_src] = s[*src];
+  auto &[vbytes, np_bytes] = s[*bytes];
+  s.addUB(vbytes.ugt(0).implies(np_dst && np_src));
+  s.addUB(np_bytes);
   s.getMemory().memcpy(vdst, vsrc, vbytes, align_dst, align_src);
   return {};
 }
 
 expr Memcpy::getTypeConstraints(const Function &f) const {
-  return dst->getType().enforcePtrType() && dst->getType().enforcePtrType()
-         && bytes->getType().enforceIntType();
+  return dst->getType().enforcePtrType() &&
+         dst->getType().enforcePtrType() &&
+         bytes->getType().enforceIntType();
 }
 
 unique_ptr<Instr> Memcpy::dup(const string &suffix) const {

--- a/ir/instr.cpp
+++ b/ir/instr.cpp
@@ -1501,4 +1501,52 @@ unique_ptr<Instr> Store::dup(const string &suffix) const {
   return make_unique<Store>(*ptr, *val, align);
 }
 
+
+void Memset::print(std::ostream &os) const {
+  os << "memset " << ptr << " align " << align << ", " << val << ", " << bytes;
+}
+
+StateValue Memset::toSMT(State &s) const {
+  // TODO: check following lines are correct
+  auto &[vptr, np] = s[ptr];
+  auto &[vbytes, np2] = s[bytes];
+  s.addUB(np);
+  s.addUB(np2);
+  s.getMemory().memset(vptr, s[val], vbytes, align);
+  return {};
+}
+
+expr Memset::getTypeConstraints(const Function &f) const {
+  return ptr.getType().enforcePtrType() && bytes.getType().enforceIntType();
+}
+
+unique_ptr<Instr> Memset::dup(const string &suffix) const {
+  return make_unique<Memset>(ptr, val, bytes, align);
+}
+
+
+void Memcpy::print(std::ostream &os) const {
+  os << "memcpy " << dst  << " align " << align_dst << ", " << src  << " align " << align_src << ", " << bytes;
+}
+
+StateValue Memcpy::toSMT(State &s) const {
+  // TODO: check following lines are correct
+  auto &[vdst, np] = s[dst];
+  s.addUB(np);
+  auto &[vsrc, np2] = s[src];
+  s.addUB(np2);
+  auto &[vbytes, np3] = s[bytes];
+  s.addUB(np3);
+  s.getMemory().memcpy(vdst, vsrc, vbytes, align_dst, align_src);
+  return {};
+}
+
+expr Memcpy::getTypeConstraints(const Function &f) const {
+  return dst.getType().enforcePtrType() && dst.getType().enforcePtrType() && bytes.getType().enforceIntType();
+}
+
+unique_ptr<Instr> Memcpy::dup(const string &suffix) const {
+  return make_unique<Memcpy>(dst, src, bytes, align_dst, align_src);
+}
+
 }

--- a/ir/instr.h
+++ b/ir/instr.h
@@ -431,13 +431,15 @@ public:
 
 
 class Memset final : public Instr {
-  Value &ptr, &val, &bytes;
+  Value *ptr, *val, *bytes;
   unsigned align;
 public:
   Memset(Value &ptr, Value &val, Value &bytes, unsigned align)
-    : Instr(Type::voidTy, "memset"), ptr(ptr), val(val), bytes(bytes),
+    : Instr(Type::voidTy, "memset"), ptr(&ptr), val(&val), bytes(&bytes),
             align(align) {}
 
+  std::vector<Value*> operands() const override;
+  void rauw(const Value &what, Value &with) override;
   void print(std::ostream &os) const override;
   StateValue toSMT(State &s) const override;
   smt::expr getTypeConstraints(const Function &f) const override;
@@ -446,14 +448,16 @@ public:
 
 
 class Memcpy final : public Instr {
-  Value &dst, &src, &bytes;
+  Value *dst, *src, *bytes;
   unsigned align_dst, align_src;
 public:
   Memcpy(Value &dst, Value &src, Value &bytes,
         unsigned align_dst, unsigned align_src)
-    : Instr(Type::voidTy, "memcpy"), dst(dst), src(src), bytes(bytes),
+    : Instr(Type::voidTy, "memcpy"), dst(&dst), src(&src), bytes(&bytes),
             align_dst(align_dst), align_src(align_src) {}
 
+  std::vector<Value*> operands() const override;
+  void rauw(const Value &what, Value &with) override;
   void print(std::ostream &os) const override;
   StateValue toSMT(State &s) const override;
   smt::expr getTypeConstraints(const Function &f) const override;

--- a/ir/instr.h
+++ b/ir/instr.h
@@ -429,4 +429,32 @@ public:
   std::unique_ptr<Instr> dup(const std::string &suffix) const override;
 };
 
+
+class Memset final : public Instr {
+  Value &ptr, &val, &bytes;
+  unsigned align;
+public:
+  Memset(Value &ptr, Value &val, Value &bytes, unsigned align)
+    : Instr(Type::voidTy, "memset"), ptr(ptr), val(val), bytes(bytes), align(align) {}
+
+  void print(std::ostream &os) const override;
+  StateValue toSMT(State &s) const override;
+  smt::expr getTypeConstraints(const Function &f) const override;
+  std::unique_ptr<Instr> dup(const std::string &suffix) const override;
+};
+
+
+class Memcpy final : public Instr {
+  Value &dst, &src, &bytes;
+  unsigned align_dst, align_src;
+public:
+  Memcpy(Value &dst, Value &src, Value &bytes, unsigned align_dst, unsigned align_src)
+    : Instr(Type::voidTy, "memcpy"), dst(dst), src(src), bytes(bytes), align_dst(align_dst), align_src(align_src) {}
+
+  void print(std::ostream &os) const override;
+  StateValue toSMT(State &s) const override;
+  smt::expr getTypeConstraints(const Function &f) const override;
+  std::unique_ptr<Instr> dup(const std::string &suffix) const override;
+};
+
 }

--- a/ir/instr.h
+++ b/ir/instr.h
@@ -435,7 +435,8 @@ class Memset final : public Instr {
   unsigned align;
 public:
   Memset(Value &ptr, Value &val, Value &bytes, unsigned align)
-    : Instr(Type::voidTy, "memset"), ptr(ptr), val(val), bytes(bytes), align(align) {}
+    : Instr(Type::voidTy, "memset"), ptr(ptr), val(val), bytes(bytes),
+            align(align) {}
 
   void print(std::ostream &os) const override;
   StateValue toSMT(State &s) const override;
@@ -448,8 +449,10 @@ class Memcpy final : public Instr {
   Value &dst, &src, &bytes;
   unsigned align_dst, align_src;
 public:
-  Memcpy(Value &dst, Value &src, Value &bytes, unsigned align_dst, unsigned align_src)
-    : Instr(Type::voidTy, "memcpy"), dst(dst), src(src), bytes(bytes), align_dst(align_dst), align_src(align_src) {}
+  Memcpy(Value &dst, Value &src, Value &bytes,
+        unsigned align_dst, unsigned align_src)
+    : Instr(Type::voidTy, "memcpy"), dst(dst), src(src), bytes(bytes),
+            align_dst(align_dst), align_src(align_src) {}
 
   void print(std::ostream &os) const override;
   StateValue toSMT(State &s) const override;

--- a/ir/memory.cpp
+++ b/ir/memory.cpp
@@ -149,12 +149,16 @@ void Pointer::is_dereferenceable(unsigned bytes, unsigned align) {
   is_dereferenceable(expr::mkUInt(bytes, m.bits_for_offset), align);
 }
 
-expr disjoint(expr offset1, const expr &len1, expr offset2, const expr &len2) {
-  return ((offset1+len1).ule(offset2) || (offset2+len2).ule(offset1));
+// general disjoint check for unsigned integer
+static expr disjoint(expr begin1, const expr &len1, expr begin2,
+                      const expr &len2) {
+  return begin1.uge(begin2 + len2) || begin2.uge(begin1 + len1);
 }
 
+// offset + len's overflow is checked by 'is_dereferenceable' at line 139.
 void Pointer::is_disjoint(const expr &len1, const Pointer &ptr2, const expr &len2) const {
-  m.state->addUB(get_bid() != ptr2.get_bid() || disjoint(get_offset(), len1, ptr2.get_offset(), len2));
+  m.state->addUB(get_bid() != ptr2.get_bid() ||
+                  disjoint(get_offset(), len1, ptr2.get_offset(), len2));
 }
 
 ostream& operator<<(ostream &os, const Pointer &p) {

--- a/ir/memory.h
+++ b/ir/memory.h
@@ -68,7 +68,8 @@ public:
   smt::expr is_aligned(unsigned align) const;
   void is_dereferenceable(unsigned bytes, unsigned align);
   void is_dereferenceable(const smt::expr &bytes, unsigned align);
-  void is_disjoint(const smt::expr &len1, const Pointer &ptr2, const smt::expr &len2) const;
+  void is_disjoint(const smt::expr &len1, const Pointer &ptr2,
+                   const smt::expr &len2) const;
 
   friend std::ostream& operator<<(std::ostream &os, const Pointer &p);
 };

--- a/ir/memory.h
+++ b/ir/memory.h
@@ -68,6 +68,7 @@ public:
   smt::expr is_aligned(unsigned align) const;
   void is_dereferenceable(unsigned bytes, unsigned align);
   void is_dereferenceable(const smt::expr &bytes, unsigned align);
+  void is_disjoint(const smt::expr &len1, const Pointer &ptr2, const smt::expr &len2) const;
 
   friend std::ostream& operator<<(std::ostream &os, const Pointer &p);
 };

--- a/llvm_util/utils.cpp
+++ b/llvm_util/utils.cpp
@@ -347,6 +347,44 @@ public:
     RETURN_IDENTIFIER(move(call));
   }
 
+  RetTy visitMemSetInst(llvm::MemSetInst &i) {
+    auto fn = i.getCalledFunction();
+    if (!fn) // TODO: check real memset
+      return error(i);
+
+    auto ty = llvm_type2alive(i.getType());
+    if (ty != &Type::voidTy)
+      return error(i);
+
+    auto ptr = get_operand(i.getOperand(0));
+    auto val = get_operand(i.getOperand(1));
+    auto bytes = get_operand(i.getOperand(2));
+    // TODO: add isvolatile, alignment
+    if (!ptr || !val || !bytes)
+      return error(i);
+
+    RETURN_IDENTIFIER(make_unique<Memset>(*ptr, *val, *bytes, 1));
+  }
+
+  RetTy visitMemCpyInst(llvm::MemCpyInst &i) {
+    auto fn = i.getCalledFunction();
+    if (!fn) // TODO: check real memcpy
+      return error(i);
+
+    auto ty = llvm_type2alive(i.getType());
+    if (ty != &Type::voidTy)
+      return error(i);
+
+    auto dst = get_operand(i.getOperand(0));
+    auto src = get_operand(i.getOperand(1));
+    auto bytes = get_operand(i.getOperand(2));
+    // TODO: add isvolatile, alignment
+    if (!dst || !src || !bytes)
+      return error(i);
+
+    RETURN_IDENTIFIER(make_unique<Memcpy>(*dst, *src, *bytes, 1, 1));
+  }
+
   RetTy visitICmpInst(llvm::ICmpInst &i) {
     PARSE_BINOP();
     ICmp::Cond cond;

--- a/llvm_util/utils.cpp
+++ b/llvm_util/utils.cpp
@@ -348,10 +348,6 @@ public:
   }
 
   RetTy visitMemSetInst(llvm::MemSetInst &i) {
-    auto fn = i.getCalledFunction();
-    if (!fn) // TODO: check real memset
-      return error(i);
-
     auto ty = llvm_type2alive(i.getType());
     if (ty != &Type::voidTy)
       return error(i);
@@ -367,10 +363,6 @@ public:
   }
 
   RetTy visitMemCpyInst(llvm::MemCpyInst &i) {
-    auto fn = i.getCalledFunction();
-    if (!fn) // TODO: check real memcpy
-      return error(i);
-
     auto ty = llvm_type2alive(i.getType());
     if (ty != &Type::voidTy)
       return error(i);

--- a/llvm_util/utils.cpp
+++ b/llvm_util/utils.cpp
@@ -348,10 +348,6 @@ public:
   }
 
   RetTy visitMemSetInst(llvm::MemSetInst &i) {
-    auto ty = llvm_type2alive(i.getType());
-    if (ty != &Type::voidTy)
-      return error(i);
-
     auto ptr = get_operand(i.getOperand(0));
     auto val = get_operand(i.getOperand(1));
     auto bytes = get_operand(i.getOperand(2));
@@ -363,10 +359,6 @@ public:
   }
 
   RetTy visitMemCpyInst(llvm::MemCpyInst &i) {
-    auto ty = llvm_type2alive(i.getType());
-    if (ty != &Type::voidTy)
-      return error(i);
-
     auto dst = get_operand(i.getOperand(0));
     auto src = get_operand(i.getOperand(1));
     auto bytes = get_operand(i.getOperand(2));

--- a/tests/memcpy/1-src.ll
+++ b/tests/memcpy/1-src.ll
@@ -1,0 +1,12 @@
+declare void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
+
+define i8 @f() {
+  %p1 = alloca [16 x i8]
+  %p2 = bitcast [16 x i8]* %p1 to i8*
+  %p3 = alloca [16 x i8]
+  %p4 = bitcast [16 x i8]* %p3 to i8*
+  store i8 3, i8* %p2
+  call void @llvm.memcpy.p0i8.p0i8.i32(i8* %p4, i8* %p2, i32 1, i1 0)
+  %v = load i8, i8* %p4
+  ret i8 %v
+}

--- a/tests/memcpy/1-tgt.ll
+++ b/tests/memcpy/1-tgt.ll
@@ -1,0 +1,3 @@
+define i8 @f() {
+  ret i8 1
+}

--- a/tests/memcpy/2-src.ll
+++ b/tests/memcpy/2-src.ll
@@ -1,0 +1,10 @@
+declare void @llvm.memset.p0i8.i8(i8*, i8, i32, i1)
+
+define i8 @f() {
+  %p1 = alloca [16 x i8]
+  %p2 = bitcast [16 x i8]* %p1 to i8*
+  %p3 = getelementptr i8, i8* %p2 , i32 6
+  call void @llvm.memset.p0i8.i8(i8* %p2, i8 3, i32 16, i1 0)
+  %v = load i8, i8* %p3
+  ret i8 %v
+}

--- a/tests/memcpy/2-tgt.ll
+++ b/tests/memcpy/2-tgt.ll
@@ -1,0 +1,3 @@
+define i8 @f() {
+  ret i8 3
+}

--- a/tests/memcpy/3-src.ll
+++ b/tests/memcpy/3-src.ll
@@ -1,0 +1,12 @@
+declare void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
+declare void @llvm.memset.p0i8.i8(i8*, i8, i32, i1)
+
+define i8 @f() {
+  %p1 = alloca [16 x i8]
+  %p2 = bitcast [16 x i8]* %p1 to i8*
+  call void @llvm.memset.p0i8.i8(i8* %p2, i8 3, i32 2, i1 0)
+  %p3 = getelementptr i8, i8* %p2 , i32 2
+  call void @llvm.memcpy.p0i8.p0i8.i32(i8* %p3, i8* %p2, i32 3, i1 0)
+  %v = load i8, i8* %p3
+  ret i8 %v
+}

--- a/tests/memcpy/3-tgt.ll
+++ b/tests/memcpy/3-tgt.ll
@@ -1,0 +1,3 @@
+define i8 @f() {
+  ret i8 1
+}

--- a/tests/memcpy/4-src.ll
+++ b/tests/memcpy/4-src.ll
@@ -1,0 +1,14 @@
+declare void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
+declare void @llvm.memset.p0i8.i8(i8*, i8, i32, i1)
+
+define i8 @f() {
+  %p1 = alloca [16 x i8]
+  %p2 = bitcast [16 x i8]* %p1 to i8*
+  %p3 = alloca [16 x i8]
+  %p4 = bitcast [16 x i8]* %p3 to i8*
+  call void @llvm.memset.p0i8.i8(i8* %p2, i8 3, i32 16, i1 0)
+  call void @llvm.memcpy.p0i8.p0i8.i32(i8* %p4, i8* %p2, i32 16, i1 0)
+  %p5 = getelementptr i8, i8* %p4 , i32 6
+  %v = load i8, i8* %p5
+  ret i8 %v
+}

--- a/tests/memcpy/4-tgt.ll
+++ b/tests/memcpy/4-tgt.ll
@@ -1,0 +1,3 @@
+define i8 @f() {
+  ret i8 3
+}


### PR DESCRIPTION
1) Add memcpy's SMT encoding(in memory.cpp).


2) Make Alive2 interpret memset and memcpy correctly(in instr.cpp, instr.h, utils.cpp).
   
    Previous Alive2 doesn't interpret memset and memcpy, because there is no visit function for them.
    So basic tests in 'test/memcpy/' made 'LLVM error: Unsupported instruction'.
    I fixed it, as a result basic tests which I made are successfully verified by Alive2.