### PR TITLE
Add Z3_LIBRARIES to alive-tv's dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -142,7 +142,7 @@ add_library(alive2 SHARED ${IR_SRCS} ${SMT_SRCS} ${TOOLS_SRCS} ${UTIL_SRCS} ${LL
 if (BUILD_LLVM_UTILS OR BUILD_TV)
   llvm_map_components_to_libnames(llvm_libs support core irreader)
   target_link_libraries(alive2 PRIVATE ${llvm_libs})
-  target_link_libraries(alive-tv PRIVATE ${ALIVE_LIBS_LLVM} ${llvm_libs})
+  target_link_libraries(alive-tv PRIVATE ${ALIVE_LIBS_LLVM} ${llvm_libs} ${Z3_LIBRARIES})
 endif()
 
 if (CYGWIN)


### PR DESCRIPTION
This resolves linking error when compiling Alive2 at Mac.

Tested at ubuntu 18.04.3 and Mac 10.14.6