### PR TITLE
Let lit print expected fail

### DIFF
--- a/tests/lit/lit/formats/alive2test.py
+++ b/tests/lit/lit/formats/alive2test.py
@@ -83,5 +83,5 @@ class Alive2Test(TestFormat):
       return lit.Test.FAIL, out + err
 
     if exitCode != 0 and string.find(err, m.group(1)) != -1:
-      return lit.Test.PASS, ''
-    return lit.Test.FAIL, out + err
+      return lit.Test.XFAIL, ''
+    return lit.Test.XPASS, out + err


### PR DESCRIPTION
This is a very small patch that helps lit test print the number of expected fails:
```
$ ninja check
Testing Time: 8.74s
  Expected Passes    : 59
  Expected Failures  : 22
```