### PR TITLE
Deal with the case when either src or tgt has unreachable

### DIFF
--- a/ir/state.h
+++ b/ir/state.h
@@ -27,6 +27,7 @@ class Function;
 class State {
 public:
   using ValTy = std::pair<StateValue, std::set<smt::expr>>;
+  // DomainTy: (reachability from entry to this basic block, undef vars)
   using DomainTy = std::pair<smt::expr, std::set<smt::expr>>;
 
 private:
@@ -57,10 +58,10 @@ private:
   std::array<StateValue, 32> tmp_values;
   unsigned i_tmp_values = 0; // next available position in tmp_values
 
+  // return_domain: a boolean expression describing return condition
   smt::expr return_domain;
   // FIXME: replace with disjoint expr builder
   ValTy return_val;
-  bool returned = false;
 
 public:
   State(const Function &f, bool source);
@@ -95,7 +96,6 @@ public:
   const auto& getValues() const { return values; }
   const auto& getQuantVars() const { return quantified_vars; }
 
-  bool fnReturned() const { return returned; }
   auto& returnDomain() const { return return_domain; }
   auto& returnVal() const { return return_val; }
 

--- a/ir/type.cpp
+++ b/ir/type.cpp
@@ -208,7 +208,7 @@ unsigned VoidType::bits() const {
 }
 
 StateValue VoidType::getDummyValue(bool non_poison) const {
-  UNREACHABLE();
+  return { false, non_poison };
 }
 
 expr VoidType::getTypeConstraints() const {

--- a/llvm_util/llvm2alive.cpp
+++ b/llvm_util/llvm2alive.cpp
@@ -596,13 +596,6 @@ public:
       }
     }
 
-    // infinite void functions may not have a return stmt in LLVM
-    if (!Fn.hasReturn()) {
-      assert(f.getReturnType()->isVoidTy());
-      Fn.getBBs().back()->addInstr(
-        make_unique<Return>(Type::voidTy, Value::voidVal));
-    }
-
     return move(Fn);
   }
 };

--- a/tests/alive-tv/infinite-loop.src.ll
+++ b/tests/alive-tv/infinite-loop.src.ll
@@ -1,0 +1,15 @@
+define void @f() {
+  br label %loop
+loop:
+  ; It is UB to have infinite loop without side effect in C, but
+  ; it is not clear it also applies to LLVM.
+  ; Here is an unknown function call g() inside this loop, so it doesn't apply
+  ; here.
+  call void @g()
+  br label %loop
+}
+
+declare void @g()
+
+; Currently loops are not supported, so following error appears.
+; ERROR: Loops are not supported yet! Skipping function.

--- a/tests/alive-tv/infinite-loop.tgt.ll
+++ b/tests/alive-tv/infinite-loop.tgt.ll
@@ -1,0 +1,3 @@
+define void @f() {
+  ret void
+}

--- a/tests/alive-tv/unreachable-1.src.ll
+++ b/tests/alive-tv/unreachable-1.src.ll
@@ -1,0 +1,3 @@
+define i32 @f() {
+  unreachable
+}

--- a/tests/alive-tv/unreachable-1.tgt.ll
+++ b/tests/alive-tv/unreachable-1.tgt.ll
@@ -1,0 +1,3 @@
+define i32 @f() {
+  ret i32 0
+}

--- a/tests/alive-tv/unreachable-2.src.ll
+++ b/tests/alive-tv/unreachable-2.src.ll
@@ -1,0 +1,7 @@
+define i32 @f() {
+  br label %bb
+bb:
+  unreachable
+exit:
+  ret i32 1
+}

--- a/tests/alive-tv/unreachable-2.tgt.ll
+++ b/tests/alive-tv/unreachable-2.tgt.ll
@@ -1,0 +1,3 @@
+define i32 @f() {
+  ret i32 2
+}

--- a/tests/alive-tv/unreachable-fail.src.ll
+++ b/tests/alive-tv/unreachable-fail.src.ll
@@ -1,0 +1,5 @@
+define i32 @f() {
+  ret i32 0
+}
+
+; ERROR: Source is more defined than target

--- a/tests/alive-tv/unreachable-fail.tgt.ll
+++ b/tests/alive-tv/unreachable-fail.tgt.ll
@@ -1,0 +1,3 @@
+define i32 @f() {
+  unreachable
+}

--- a/tests/alive-tv/unreachable-void-1.src.ll
+++ b/tests/alive-tv/unreachable-void-1.src.ll
@@ -1,0 +1,3 @@
+define void @f() {
+  unreachable
+}

--- a/tests/alive-tv/unreachable-void-1.tgt.ll
+++ b/tests/alive-tv/unreachable-void-1.tgt.ll
@@ -1,0 +1,3 @@
+define void @f() {
+  ret void
+}

--- a/tests/alive-tv/unreachable-void-2.src.ll
+++ b/tests/alive-tv/unreachable-void-2.src.ll
@@ -1,0 +1,7 @@
+define void @f() {
+  br label %bb
+bb:
+  unreachable
+exit:
+  unreachable
+}

--- a/tests/alive-tv/unreachable-void-2.tgt.ll
+++ b/tests/alive-tv/unreachable-void-2.tgt.ll
@@ -1,0 +1,3 @@
+define void @f() {
+  ret void
+}

--- a/tools/transform.cpp
+++ b/tools/transform.cpp
@@ -297,11 +297,6 @@ TransformVerify::TransformVerify(Transform &t, bool check_each_var) :
       tgt_instrs.emplace(i.getName(), &i);
     }
   }
-
-  if (!check_each_var) {
-    assert(t.src.hasReturn());
-    assert(t.tgt.hasReturn());
-  }
 }
 
 Errors TransformVerify::verify() const {
@@ -335,18 +330,10 @@ Errors TransformVerify::verify() const {
     }
   }
 
-  if (src_state.fnReturned() != tgt_state.fnReturned()) {
-    if (src_state.fnReturned())
-      errs.add("Source returns but target doesn't");
-    else
-      errs.add("Target returns but source doesn't");
-
-  } else if (src_state.fnReturned()) {
-    check_refinement(errs, t, src_state, tgt_state, nullptr, t.src.getType(),
-                     src_state.returnDomain(), src_state.returnVal(),
-                     tgt_state.returnDomain(), tgt_state.returnVal(),
-                     check_each_var);
-  }
+  check_refinement(errs, t, src_state, tgt_state, nullptr, t.src.getType(),
+                   src_state.returnDomain(), src_state.returnVal(),
+                   tgt_state.returnDomain(), tgt_state.returnVal(),
+                   check_each_var);
 
   return errs;
 }


### PR DESCRIPTION
This patch addresses the case when source ends with unreachable but target does (and vice versa):

```
define i32 @f() {
  unreachable
}
=>
define i32 @f() {
  ret i32 0
}
```

The solution this PR suggests is to lower `unreachable` into `assume 0` followed by `ret poison`.

Adding `ret poison` at the last block doesn’t work in the following case:

```
define i32 @f() {
  unreachable
bb: ; unreachable block
  ret i32 0
}
```

llvm unit tests (compared with master + #106 + #107): 1197 sec -> 1193sec , 133 fails -> 109 fails