### PR TITLE
Resolve segmentation fault when aborting 

### DIFF
--- a/tv/tv.cpp
+++ b/tv/tv.cpp
@@ -129,8 +129,10 @@ struct TVPass : public llvm::FunctionPass {
           !errs.isTimeout() &&
           !errs.isInvalidExpr() &&
           !errs.isOOM() &&
-          !errs.isLoopyCFG())
+          !errs.isLoopyCFG()) {
+        llvm_util_init.reset();
         llvm::report_fatal_error("Alive2: Transform doesn't verify; aborting!");
+      }
     } else {
       *out << "Transformation seems to be correct!\n\n";
     }


### PR DESCRIPTION
This is a small patch that resolves segmentation fault that happened due to double-free.

For example, `./alive2/scripts/opt-alive.sh ./llvm/test/Transforms/InstSimplify/gep.ll -instsimplify`
raises assertion failure, but this patch resolves it.