### PR TITLE
Support global variables, alloca/glbvar's address should be non-zero

### DIFF
--- a/ir/instr.cpp
+++ b/ir/instr.cpp
@@ -1349,7 +1349,7 @@ void Alloc::print(std::ostream &os) const {
 StateValue Alloc::toSMT(State &s) const {
   auto &[sz, np] = s[*size];
   s.addUB(np);
-  return { s.getMemory().alloc(sz, align, false), true };
+  return { s.getMemory().alloc(sz, align, Memory::STACK), true };
 }
 
 expr Alloc::getTypeConstraints(const Function &f) const {
@@ -1379,7 +1379,7 @@ StateValue Malloc::toSMT(State &s) const {
   auto &[sz, np] = s[*size];
   s.addUB(np);
   // TODO: malloc's alignment is implementation defined.
-  return { s.getMemory().alloc(sz, 8, true), true };
+  return { s.getMemory().alloc(sz, 8, Memory::HEAP), true };
 }
 
 expr Malloc::getTypeConstraints(const Function &f) const {

--- a/ir/state.h
+++ b/ir/state.h
@@ -51,6 +51,9 @@ private:
     predecessor_data;
   std::unordered_set<const BasicBlock*> seen_bbs;
 
+  // Global variables' memory block ids
+  std::unordered_map<std::string, unsigned> glbvar_bids;
+
   // temp state
   DomainTy domain;
   Memory memory;
@@ -103,6 +106,12 @@ public:
 
   // whether this is source or target program
   bool isSource() const { return source; }
+
+  void addGlobalVarBid(const std::string &glbvar, unsigned bid);
+  // Checks whether glbvar has block id assigned.
+  // If it has, bid is updated with the block id.
+  bool hasGlobalVarBid(const std::string &glbvar, unsigned &bid) const;
+  void copyGlobalVarBidsFromSrc(const State &src);
 
 private:
   void addJump(const BasicBlock &dst, smt::expr &&domain);

--- a/ir/value.cpp
+++ b/ir/value.cpp
@@ -88,7 +88,31 @@ StateValue NullPointerValue::toSMT(State &s) const {
 }
 
 
-void Input::print(std::ostream &os) const {
+void GlobalVariable::print(ostream &os) const {
+  UNREACHABLE();
+}
+
+StateValue GlobalVariable::toSMT(State &s) const {
+  auto sizeexpr = expr::mkInt(allocsize, 64);
+  expr ptrval;
+  unsigned glbvar_bid;
+  if (s.hasGlobalVarBid(getName(), glbvar_bid)) {
+    // Use the same block id that is used by src
+    assert(!s.isSource());
+    ptrval = s.getMemory().alloc(sizeexpr, align, Memory::GLOBAL, glbvar_bid);
+  } else {
+    ptrval = s.getMemory().alloc(sizeexpr, align, Memory::GLOBAL, nullopt,
+                                 &glbvar_bid);
+    s.addGlobalVarBid(getName(), glbvar_bid);
+  }
+  if (initval) {
+    s.getMemory().store(ptrval, s[*initval], getType(), align);
+  }
+  return { move(ptrval), true };
+}
+
+
+void Input::print(ostream &os) const {
   UNREACHABLE();
 }
 

--- a/ir/value.h
+++ b/ir/value.h
@@ -82,6 +82,25 @@ public:
 };
 
 
+class GlobalVariable final : public Value {
+  // The size of this global variable (in bytes)
+  int allocsize;
+  // Alignment of this global variable
+  int align;
+  // Initial value stored at this global variable.
+  // This is initialized only if the global is constant.
+  // If it has no initial value, this is nullptr.
+  Value *initval;
+public:
+  GlobalVariable(Type &type, std::string &&name, int allocsize, int align,
+                 Value *initval) :
+    Value(type, std::move(name)), allocsize(allocsize), align(align),
+    initval(initval) {}
+  void print(std::ostream &os) const override;
+  StateValue toSMT(State &s) const override;
+};
+
+
 class Input final : public Value {
 public:
   Input(Type &type, std::string &&name) :

--- a/llvm_util/llvm2alive.cpp
+++ b/llvm_util/llvm2alive.cpp
@@ -607,9 +607,9 @@ public:
 
 namespace llvm_util {
 
-initializer::initializer(ostream &os) {
+initializer::initializer(ostream &os, const llvm::DataLayout &DL) {
   out = &os;
-  init_llvm_utils(os);
+  init_llvm_utils(os, DL);
 }
 
 optional<IR::Function> llvm2alive(llvm::Function &F,

--- a/llvm_util/llvm2alive.h
+++ b/llvm_util/llvm2alive.h
@@ -8,6 +8,7 @@
 #include <ostream>
 
 namespace llvm {
+class DataLayout;
 class Function;
 class TargetLibraryInfo;
 }
@@ -15,7 +16,7 @@ class TargetLibraryInfo;
 namespace llvm_util {
 
 struct initializer {
-  initializer(std::ostream &os);
+  initializer(std::ostream &os, const llvm::DataLayout &DL);
 };
 
 std::optional<IR::Function> llvm2alive(llvm::Function &F,

--- a/llvm_util/utils.h
+++ b/llvm_util/utils.h
@@ -8,6 +8,7 @@
 
 namespace llvm {
 class BasicBlock;
+class DataLayout;
 class Type;
 class Value;
 }
@@ -38,6 +39,6 @@ PRINT(llvm::Type)
 PRINT(llvm::Value)
 #undef PRINT
 
-void init_llvm_utils(std::ostream &os);
+void init_llvm_utils(std::ostream &os, const llvm::DataLayout &DL);
 void reset_state(IR::Function &f);
 }

--- a/tests/alive-tv/memory/alloca-address-nonnull.src.ll
+++ b/tests/alive-tv/memory/alloca-address-nonnull.src.ll
@@ -1,0 +1,8 @@
+target datalayout = "e-m:o-i64:64-f80:128-n8:16:32:64-S128"
+
+define i1 @f() {
+  %ptr = alloca i8
+  %i = ptrtoint i8* %ptr to i64
+  %x = icmp eq i64 %i, 0
+  ret i1 %x
+}

--- a/tests/alive-tv/memory/alloca-address-nonnull.tgt.ll
+++ b/tests/alive-tv/memory/alloca-address-nonnull.tgt.ll
@@ -1,0 +1,5 @@
+target datalayout = "e-m:o-i64:64-f80:128-n8:16:32:64-S128"
+
+define i1 @f() {
+  ret i1 0
+}

--- a/tests/alive-tv/memory/free-ub-glb.src.ll
+++ b/tests/alive-tv/memory/free-ub-glb.src.ll
@@ -1,0 +1,8 @@
+@x = global i8 0
+
+define i8 @free_ub_glb() {
+  call void @free(i8* @x)
+  ret i8 0
+}
+
+declare void @free(i8*)

--- a/tests/alive-tv/memory/free-ub-glb.tgt.ll
+++ b/tests/alive-tv/memory/free-ub-glb.tgt.ll
@@ -1,0 +1,8 @@
+@x = global i8 0
+
+define i8 @free_ub_glb() {
+  call void @free(i8* @x)
+  ret i8 1
+}
+
+declare void @free(i8*)

--- a/tests/alive-tv/memory/glb-1.src.ll
+++ b/tests/alive-tv/memory/glb-1.src.ll
@@ -1,0 +1,6 @@
+@x = constant i32 5, align 4
+
+define i32 @f() {
+  %v = load i32, i32* @x
+  ret i32 %v
+}

--- a/tests/alive-tv/memory/glb-1.tgt.ll
+++ b/tests/alive-tv/memory/glb-1.tgt.ll
@@ -1,0 +1,5 @@
+@x = constant i32 5, align 4
+
+define i32 @f() {
+  ret i32 5
+}

--- a/tests/alive-tv/memory/glb-2.src.ll
+++ b/tests/alive-tv/memory/glb-2.src.ll
@@ -1,0 +1,12 @@
+target datalayout = "e-m:o-i64:64-f80:128-n8:16:32:64-S128" ; has little endian
+@x = constant i32 257, align 4
+@y = constant i32 258, align 4
+
+define i8 @f() {
+  %x8 = bitcast i32* @x to i8*
+  %y8 = bitcast i32* @y to i8*
+  %v = load i8, i8* %x8
+  %w = load i8, i8* %y8
+  %z = add i8 %v, %w
+  ret i8 %z
+}

--- a/tests/alive-tv/memory/glb-2.tgt.ll
+++ b/tests/alive-tv/memory/glb-2.tgt.ll
@@ -1,0 +1,7 @@
+target datalayout = "e-m:o-i64:64-f80:128-n8:16:32:64-S128" ; has little endian
+@x = constant i32 257, align 4
+@y = constant i32 258, align 4
+
+define i8 @f() {
+  ret i8 3
+}

--- a/tests/alive-tv/memory/glb-3.src.ll
+++ b/tests/alive-tv/memory/glb-3.src.ll
@@ -1,0 +1,7 @@
+@x = global i8 0
+
+define i8 @f() {
+  %v = load i8, i8* @x
+  %w = load i8, i8* @x
+  ret i8 %v
+}

--- a/tests/alive-tv/memory/glb-3.tgt.ll
+++ b/tests/alive-tv/memory/glb-3.tgt.ll
@@ -1,0 +1,7 @@
+@x = global i8 0
+
+define i8 @f() {
+  %v = load i8, i8* @x
+  %w = load i8, i8* @x
+  ret i8 %w
+}

--- a/tests/alive-tv/memory/glb-4.src.ll
+++ b/tests/alive-tv/memory/glb-4.src.ll
@@ -1,0 +1,7 @@
+@x = global i8 0
+@y = global i8 0
+
+define i8 @f() {
+  %v = load i8, i8* @x
+  ret i8 %v
+}

--- a/tests/alive-tv/memory/glb-4.tgt.ll
+++ b/tests/alive-tv/memory/glb-4.tgt.ll
@@ -1,0 +1,8 @@
+@x = global i8 0
+@y = global i8 0
+
+define i8 @f() {
+  %w = load i8, i8* @y
+  %v = load i8, i8* @x
+  ret i8 %v
+}

--- a/tests/alive-tv/memory/glb-address-nonnull.src.ll
+++ b/tests/alive-tv/memory/glb-address-nonnull.src.ll
@@ -1,0 +1,8 @@
+target datalayout = "e-m:o-i64:64-f80:128-n8:16:32:64-S128"
+@x = global i32 0, align 4
+
+define i1 @f() {
+  %i = ptrtoint i32* @x to i64
+  %x = icmp eq i64 %i, 0
+  ret i1 %x
+}

--- a/tests/alive-tv/memory/glb-address-nonnull.tgt.ll
+++ b/tests/alive-tv/memory/glb-address-nonnull.tgt.ll
@@ -1,0 +1,6 @@
+target datalayout = "e-m:o-i64:64-f80:128-n8:16:32:64-S128"
+@x = global i32 0, align 4
+
+define i1 @f() {
+  ret i1 0
+}

--- a/tests/alive-tv/memory/glb-align-fail.src.ll
+++ b/tests/alive-tv/memory/glb-align-fail.src.ll
@@ -1,0 +1,9 @@
+@x = global i32 0, align 4
+
+define i32 @f() {
+  %i = ptrtoint i32* @x to i32
+  %x = urem i32 %i, 4
+  ret i32 %x
+}
+
+; ERROR: Value mismatch

--- a/tests/alive-tv/memory/glb-align-fail.tgt.ll
+++ b/tests/alive-tv/memory/glb-align-fail.tgt.ll
@@ -1,0 +1,5 @@
+@x = constant i32 0, align 4
+
+define i32 @f() {
+  ret i32 1
+}

--- a/tests/alive-tv/memory/glb-align.src.ll
+++ b/tests/alive-tv/memory/glb-align.src.ll
@@ -1,0 +1,7 @@
+@x = global i32 0, align 4
+
+define i32 @f() {
+  %i = ptrtoint i32* @x to i32
+  %x = urem i32 %i, 4
+  ret i32 %x
+}

--- a/tests/alive-tv/memory/glb-align.tgt.ll
+++ b/tests/alive-tv/memory/glb-align.tgt.ll
@@ -1,0 +1,5 @@
+@x = constant i32 0, align 4
+
+define i32 @f() {
+  ret i32 0
+}

--- a/tests/alive-tv/memory/glb-alloca-noalias.src.ll
+++ b/tests/alive-tv/memory/glb-alloca-noalias.src.ll
@@ -1,0 +1,9 @@
+@glb = global i8 0
+
+define i8 @glb_alloca_noalias() {
+  %ptr = alloca i8
+  store i8 10, i8* %ptr
+  store i8 20, i8* @glb
+  %v = load i8, i8* %ptr
+  ret i8 %v
+}

--- a/tests/alive-tv/memory/glb-alloca-noalias.tgt.ll
+++ b/tests/alive-tv/memory/glb-alloca-noalias.tgt.ll
@@ -1,0 +1,9 @@
+@glb = global i8 0
+
+define i8 @glb_alloca_noalias() {
+  %ptr = alloca i8
+  store i8 10, i8* %ptr
+  store i8 20, i8* @glb
+  %v = load i8, i8* %ptr
+  ret i8 10
+}

--- a/tests/alive-tv/memory/glb-arg-noalias-fail.src.ll
+++ b/tests/alive-tv/memory/glb-arg-noalias-fail.src.ll
@@ -1,0 +1,10 @@
+@glb = global i8 0
+
+define i8 @glb_arg_noalias(i8* %ptr) {
+  store i8 10, i8* %ptr
+  store i8 20, i8* @glb
+  %v = load i8, i8* %ptr
+  ret i8 %v
+}
+
+; ERROR: Value mismatch

--- a/tests/alive-tv/memory/glb-arg-noalias-fail.tgt.ll
+++ b/tests/alive-tv/memory/glb-arg-noalias-fail.tgt.ll
@@ -1,0 +1,8 @@
+@glb = global i8 0
+
+define i8 @glb_arg_noalias(i8* %ptr) {
+  store i8 10, i8* %ptr
+  store i8 20, i8* @glb
+  %v = load i8, i8* %ptr
+  ret i8 10
+}

--- a/tests/alive-tv/memory/glb-fail-1.src.ll
+++ b/tests/alive-tv/memory/glb-fail-1.src.ll
@@ -1,0 +1,8 @@
+@x = constant i32 5, align 4
+
+define i32 @f() {
+  %v = load i32, i32* @x
+  ret i32 %v
+}
+
+; ERROR: Value mismatch

--- a/tests/alive-tv/memory/glb-fail-1.tgt.ll
+++ b/tests/alive-tv/memory/glb-fail-1.tgt.ll
@@ -1,0 +1,5 @@
+@x = constant i32 5, align 4
+
+define i32 @f() {
+  ret i32 1
+}

--- a/tests/alive-tv/memory/glb-fail-2.src.ll
+++ b/tests/alive-tv/memory/glb-fail-2.src.ll
@@ -1,0 +1,8 @@
+@x = global i32 3, align 4
+
+define i32 @f() {
+  %v = load i32, i32* @x
+  ret i32 %v
+}
+
+; ERROR: Value mismatch

--- a/tests/alive-tv/memory/glb-fail-2.tgt.ll
+++ b/tests/alive-tv/memory/glb-fail-2.tgt.ll
@@ -1,0 +1,5 @@
+@x = global i32 3, align 4
+
+define i32 @f() {
+  ret i32 3
+}

--- a/tests/alive-tv/memory/glb-malloc-noalias.src.ll
+++ b/tests/alive-tv/memory/glb-malloc-noalias.src.ll
@@ -1,0 +1,11 @@
+@glb = global i8 0
+
+define i8 @glb_malloc_noalias() {
+  %ptr = call noalias i8* @malloc(i64 1)
+  store i8 10, i8* %ptr
+  store i8 20, i8* @glb
+  %v = load i8, i8* %ptr
+  ret i8 %v
+}
+
+declare noalias i8* @malloc(i64)

--- a/tests/alive-tv/memory/glb-malloc-noalias.tgt.ll
+++ b/tests/alive-tv/memory/glb-malloc-noalias.tgt.ll
@@ -1,0 +1,11 @@
+@glb = global i8 0
+
+define i8 @glb_malloc_noalias() {
+  %ptr = call noalias i8* @malloc(i64 1)
+  store i8 10, i8* %ptr
+  store i8 20, i8* @glb
+  %v = load i8, i8* %ptr
+  ret i8 10
+}
+
+declare noalias i8* @malloc(i64)

--- a/tests/alive-tv/memory/glb-reorder.src.ll
+++ b/tests/alive-tv/memory/glb-reorder.src.ll
@@ -1,0 +1,9 @@
+@A = global i32 0
+@B = global i32 0
+
+define i32 @foo() {
+  %l = load i32, i32* @A
+  store i32 1, i32* @B
+  ret i32 %l
+}
+

--- a/tests/alive-tv/memory/glb-reorder.tgt.ll
+++ b/tests/alive-tv/memory/glb-reorder.tgt.ll
@@ -1,0 +1,9 @@
+@A = global i32 0
+@B = global i32 0
+
+define i32 @foo() {
+  store i32 1, i32* @B
+  %l = load i32, i32* @A
+  ret i32 %l
+}
+

--- a/tools/alive-tv.cpp
+++ b/tools/alive-tv.cpp
@@ -199,7 +199,6 @@ int main(int argc, char **argv) {
   llvm::cl::ParseCommandLineOptions(argc, argv,
                                   "Alive2 stand-alone translation validator\n");
 
-  llvm_util::initializer llvm_util_init(cerr);
   smt::smt_initializer smt_init;
   TransformPrintOpts print_opts;
 
@@ -232,6 +231,9 @@ int main(int argc, char **argv) {
 
   auto targetTriple = llvm::Triple(M1.get()->getTargetTriple());
   auto TLI = llvm::TargetLibraryInfoWrapperPass(targetTriple).getTLI(*F1);
+  auto &DL = M1->getDataLayout();
+
+  llvm_util::initializer llvm_util_init(cerr, DL);
 
   auto Func1 = llvm2alive(*F1, TLI);
   if (!Func1)

--- a/tools/transform.cpp
+++ b/tools/transform.cpp
@@ -305,6 +305,7 @@ Errors TransformVerify::verify() const {
 
   try {
     sym_exec(src_state);
+    tgt_state.copyGlobalVarBidsFromSrc(src_state);
     sym_exec(tgt_state);
   } catch (LoopInCFGDetected&) {
     return "Loops are not supported yet! Skipping function.";

--- a/tv/tv.cpp
+++ b/tv/tv.cpp
@@ -186,7 +186,7 @@ struct TVPass : public llvm::FunctionPass {
     config::disable_undef_input = opt_disable_undef_input;
     config::disable_poison_input = opt_disable_poison_input;
 
-    llvm_util_init.emplace(*out);
+    llvm_util_init.emplace(*out, module.getDataLayout());
     smt_init.emplace();
     return false;
   }


### PR DESCRIPTION
This patch adds support for global variables, and makes alloca/glbvar's address never be zero.
malloc's address is not addressed here, as malloc() can return null in runtime. (#110 )

Global variable support is done as follows:
- A global variable in src and tgt are given the same block id , and this information is passed as
```
    sym_exec(src_state);
    tgt_state.setGlobalVarBidsFrom(src_state);
    sym_exec(tgt_state);
```
at TransformVerify::verify().
- To give the block id precisely, `Memory::alloc` now can take an optional argument that specifies which bid to use. It is caller's responsibility to give a unique bid.


LLVM unit tests result:
- Failures: 133 -> 173 (+40), around +30 tests are global (test/Transforms/SafeStack , test/Transforms/GlobalOpt). For other tests, investigation is needed.
- Running time: 1197 -> 296 secs; speedup exists, which is a bit weird :/