### PR TITLE
fix alignment check when bytes is 0

### DIFF
--- a/ir/memory.cpp
+++ b/ir/memory.cpp
@@ -143,7 +143,7 @@ void Pointer::is_dereferenceable(const expr &bytes0, unsigned align) {
   cond &= offset.add_no_uoverflow(bytes);
 
   // 2) check block's address is aligned
-  cond &= is_aligned(align);
+  m.state->addUB(is_aligned(align));
 
   // 3) check block is alive
   cond &= is_block_alive();

--- a/llvm_util/llvm2alive.cpp
+++ b/llvm_util/llvm2alive.cpp
@@ -200,11 +200,8 @@ public:
     if (!ptr || !val || !bytes)
       return error(i);
 
-    auto destAlign = i.getDestAlignment();
-    if(destAlign == 0)
-      destAlign = 1;
-
-    RETURN_IDENTIFIER(make_unique<Memset>(*ptr, *val, *bytes, destAlign));
+    RETURN_IDENTIFIER(make_unique<Memset>(*ptr, *val, *bytes,
+                                          min(1, i.getDestAlignment())));
   }
 
   RetTy visitMemTransferInst(llvm::MemTransferInst &i) {
@@ -215,15 +212,9 @@ public:
     if (!dst || !src || !bytes)
       return error(i);
 
-    auto destAlign = i.getDestAlignment();
-    if(destAlign == 0)
-      destAlign = 1;
-    auto sourceAlign = i.getSourceAlignment();
-    if(sourceAlign == 0)
-      sourceAlign = 1;
-
-    RETURN_IDENTIFIER(make_unique<Memcpy>(*dst, *src, *bytes, destAlign,
-                                          sourceAlign,
+    RETURN_IDENTIFIER(make_unique<Memcpy>(*dst, *src, *bytes,
+                                          min(1, i.getDestAlignment()),
+                                          min(1, i.getSourceAlignment()),
                                           isa<llvm::MemMoveInst>(&i)));
   }
 

--- a/llvm_util/llvm2alive.cpp
+++ b/llvm_util/llvm2alive.cpp
@@ -200,8 +200,11 @@ public:
     if (!ptr || !val || !bytes)
       return error(i);
 
-    RETURN_IDENTIFIER(make_unique<Memset>(*ptr, *val, *bytes,
-                                          i.getDestAlignment()));
+    auto destAlign = i.getDestAlignment();
+    if(destAlign == 0)
+      destAlign = 1;
+
+    RETURN_IDENTIFIER(make_unique<Memset>(*ptr, *val, *bytes, destAlign));
   }
 
   RetTy visitMemTransferInst(llvm::MemTransferInst &i) {
@@ -212,9 +215,15 @@ public:
     if (!dst || !src || !bytes)
       return error(i);
 
-    RETURN_IDENTIFIER(make_unique<Memcpy>(*dst, *src, *bytes,
-                                          i.getDestAlignment(),
-                                          i.getSourceAlignment(),
+    auto destAlign = i.getDestAlignment();
+    if(destAlign == 0)
+      destAlign = 1;
+    auto sourceAlign = i.getSourceAlignment();
+    if(sourceAlign == 0)
+      sourceAlign = 1;
+
+    RETURN_IDENTIFIER(make_unique<Memcpy>(*dst, *src, *bytes, destAlign,
+                                          sourceAlign,
                                           isa<llvm::MemMoveInst>(&i)));
   }
 


### PR DESCRIPTION
I did two minor fix.

1) Pointer must be aligned when bytes in memset (memcpy) is 0.

2) When alignments in memset (memcpy) is zero, make them 1.