### PR TITLE
CMake: bump required version of Z3 to 4.8.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ if (CYGWIN)
   set(CMAKE_FIND_LIBRARY_SUFFIXES ".dll")
 endif()
 
-find_package(Z3 4.8.4 REQUIRED)
+find_package(Z3 4.8.5 REQUIRED)
 include_directories(${Z3_INCLUDE_DIR})
 
 find_program(RE2C re2c)


### PR DESCRIPTION
Fixes https://github.com/AliveToolkit/alive2/issues/122
References https://github.com/AliveToolkit/alive2/issues/123