### PR TITLE
Let storing to const globals UB, support extern const globals

### DIFF
--- a/ir/memory.h
+++ b/ir/memory.h
@@ -73,12 +73,13 @@ public:
 
   smt::expr inbounds() const;
   smt::expr is_aligned(unsigned align) const;
-  void is_dereferenceable(unsigned bytes, unsigned align);
-  void is_dereferenceable(const smt::expr &bytes, unsigned align);
+  void is_dereferenceable(unsigned bytes, unsigned align, bool iswrite);
+  void is_dereferenceable(const smt::expr &bytes, unsigned align, bool iswrite);
   void is_disjoint(const smt::expr &len1, const Pointer &ptr2,
                    const smt::expr &len2) const;
   smt::expr is_block_alive() const;
   smt::expr is_at_heap() const;
+  smt::expr is_readonly() const;
 
   const Memory& getMemory() const { return m; }
 
@@ -103,18 +104,20 @@ class Memory {
   unsigned bits_size_t = 64;
 
   smt::expr blocks_val; // array: (bid, offset) -> Byte
-  smt::expr blocks_liveness; // array: bid -> uint(1bit), 1 if alive, 0 if freed
+  smt::expr blocks_liveness; // array: bid -> bool
   smt::expr blocks_kind; // array: bid -> uint(1bit), 1 if heap, 0 otherwise
+  smt::expr blocks_readonly; // array: bid -> bool, true if readonly
 
   std::string mkName(const char *str, bool src) const;
   std::string mkName(const char *str) const;
 
   smt::expr mk_val_array(const char *name) const;
   smt::expr mk_liveness_uf() const;
+  smt::expr mk_readonly_array(const char *name) const;
 
 public:
   enum BlockKind {
-    HEAP, STACK, GLOBAL
+    HEAP, STACK, GLOBAL, CONSTGLOBAL
   };
 
   Memory(State &state);

--- a/ir/value.cpp
+++ b/ir/value.cpp
@@ -96,16 +96,19 @@ StateValue GlobalVariable::toSMT(State &s) const {
   auto sizeexpr = expr::mkInt(allocsize, 64);
   expr ptrval;
   unsigned glbvar_bid;
+  auto blkkind = isconst ? Memory::CONSTGLOBAL : Memory::GLOBAL;
+
   if (s.hasGlobalVarBid(getName(), glbvar_bid)) {
     // Use the same block id that is used by src
     assert(!s.isSource());
-    ptrval = s.getMemory().alloc(sizeexpr, align, Memory::GLOBAL, glbvar_bid);
+    ptrval = s.getMemory().alloc(sizeexpr, align, blkkind, glbvar_bid);
   } else {
-    ptrval = s.getMemory().alloc(sizeexpr, align, Memory::GLOBAL, nullopt,
+    ptrval = s.getMemory().alloc(sizeexpr, align, blkkind, nullopt,
                                  &glbvar_bid);
     s.addGlobalVarBid(getName(), glbvar_bid);
   }
   if (initval) {
+    assert(isconst);
     s.getMemory().store(ptrval, s[*initval], initval->getType(), align);
   }
   return { move(ptrval), true };

--- a/ir/value.h
+++ b/ir/value.h
@@ -91,11 +91,14 @@ class GlobalVariable final : public Value {
   // This is initialized only if the global is constant.
   // If it has no initial value, this is nullptr.
   Value *initval;
+  // Is this global variable constant?
+  // initval can be null even if isconst is true if this is an external const.
+  bool isconst;
 public:
   GlobalVariable(Type &type, std::string &&name, int allocsize, int align,
-                 Value *initval) :
+                 Value *initval, bool isconst) :
     Value(type, std::move(name)), allocsize(allocsize), align(align),
-    initval(initval) {}
+    initval(initval), isconst(isconst) {}
   void print(std::ostream &os) const override;
   StateValue toSMT(State &s) const override;
 };

--- a/llvm_util/utils.cpp
+++ b/llvm_util/utils.cpp
@@ -191,7 +191,7 @@ Value* get_operand(llvm::Value *v) {
     int align = gv->getAlignment();
     auto name = "@" + gv->getName().str();
     auto val = make_unique<GlobalVariable>(*ty, move(name), size, align,
-                                           initval);
+                                           initval, gv->isConstant());
     auto ret = val.get();
     gvar = ret;
     current_fn->addConstant(move(val));

--- a/tests/alive-tv/memory/alloca-malloc-fail.src.ll
+++ b/tests/alive-tv/memory/alloca-malloc-fail.src.ll
@@ -1,0 +1,21 @@
+; target: 64 bits ptr addr
+target datalayout = "e-m:o-i64:64-f80:128-n8:16:32:64-S128"
+
+define i8 @alloca_malloc(i8* %ptr0) {
+  %ptr = call noalias i8* @malloc(i64 1)
+  %i = ptrtoint i8* %ptr to i64
+  %cmp = icmp eq i64 %i, 0
+  br i1 %cmp, label %BB1, label %BB2
+BB1:
+  ret i8 0
+BB2:
+  store i8 10, i8* %ptr
+  %v = load i8, i8* %ptr
+  call void @free(i8* %ptr)
+  ret i8 %v
+}
+
+declare noalias i8* @malloc(i64)
+declare void @free(i8*)
+
+; ERROR: Value mismatch

--- a/tests/alive-tv/memory/alloca-malloc-fail.tgt.ll
+++ b/tests/alive-tv/memory/alloca-malloc-fail.tgt.ll
@@ -1,0 +1,9 @@
+; target: 64 bits ptr addr
+target datalayout = "e-m:o-i64:64-f80:128-n8:16:32:64-S128"
+
+define i8 @alloca_malloc(i8* %ptr0) {
+  %ptr = alloca i8
+  store i8 20, i8* %ptr
+  %v = load i8, i8* %ptr
+  ret i8 %v
+}

--- a/tests/alive-tv/memory/alloca-malloc.src.ll
+++ b/tests/alive-tv/memory/alloca-malloc.src.ll
@@ -1,0 +1,19 @@
+; target: 64 bits ptr addr
+target datalayout = "e-m:o-i64:64-f80:128-n8:16:32:64-S128"
+
+define i8 @alloca_malloc(i8* %ptr0) {
+  %ptr = call noalias i8* @malloc(i64 1)
+  %i = ptrtoint i8* %ptr to i64
+  %cmp = icmp eq i64 %i, 0
+  br i1 %cmp, label %BB1, label %BB2
+BB1:
+  ret i8 0
+BB2:
+  store i8 20, i8* %ptr
+  %v = load i8, i8* %ptr
+  call void @free(i8* %ptr)
+  ret i8 %v
+}
+
+declare noalias i8* @malloc(i64)
+declare void @free(i8*)

--- a/tests/alive-tv/memory/alloca-malloc.tgt.ll
+++ b/tests/alive-tv/memory/alloca-malloc.tgt.ll
@@ -1,0 +1,9 @@
+; target: 64 bits ptr addr
+target datalayout = "e-m:o-i64:64-f80:128-n8:16:32:64-S128"
+
+define i8 @alloca_malloc(i8* %ptr0) {
+  %ptr = alloca i8
+  store i8 20, i8* %ptr
+  %v = load i8, i8* %ptr
+  ret i8 %v
+}

--- a/tests/alive-tv/memory/glb-5.src.ll
+++ b/tests/alive-tv/memory/glb-5.src.ll
@@ -1,0 +1,6 @@
+@x = constant i8 0
+
+define i8 @f() {
+  store i8 1, i8* @x
+  ret i8 0
+}

--- a/tests/alive-tv/memory/glb-5.tgt.ll
+++ b/tests/alive-tv/memory/glb-5.tgt.ll
@@ -1,0 +1,6 @@
+@x = constant i8 0
+
+define i8 @f() {
+  store i8 1, i8* @x
+  unreachable
+}

--- a/tests/alive-tv/memory/glb-externconst.src.ll
+++ b/tests/alive-tv/memory/glb-externconst.src.ll
@@ -1,0 +1,6 @@
+@x = external constant i8, align 4
+
+define i8 @f() {
+  store i8 1, i8* @x
+  ret i8 0
+}

--- a/tests/alive-tv/memory/glb-externconst.tgt.ll
+++ b/tests/alive-tv/memory/glb-externconst.tgt.ll
@@ -1,0 +1,6 @@
+@x = external constant i8, align 4
+
+define i8 @f() {
+  store i8 1, i8* @x
+  unreachable
+}

--- a/tests/alive-tv/memory/memset-store-fail.src.ll
+++ b/tests/alive-tv/memory/memset-store-fail.src.ll
@@ -1,0 +1,12 @@
+declare void @llvm.memset.p0i8.i8(i8*, i8, i32, i1)
+
+@x = global i32 0
+
+define i32 @f() {
+  %p = bitcast i32* @x to i8*
+  call void @llvm.memset.p0i8.i8(i8* %p, i8 1, i32 4, i1 0)
+  %v = load i32, i32* @x
+  ret i32 %v
+}
+
+; ERROR: Value mismatch

--- a/tests/alive-tv/memory/memset-store-fail.tgt.ll
+++ b/tests/alive-tv/memory/memset-store-fail.tgt.ll
@@ -1,0 +1,9 @@
+declare void @llvm.memset.p0i8.i8(i8*, i8, i32, i1)
+
+@x = global i32 0
+
+define i32 @f() {
+  store i32 0, i32* @x
+  %v = load i32, i32* @x
+  ret i32 %v
+}

--- a/tests/alive-tv/memory/memset-store.src.ll
+++ b/tests/alive-tv/memory/memset-store.src.ll
@@ -1,0 +1,10 @@
+declare void @llvm.memset.p0i8.i8(i8*, i8, i32, i1)
+
+@x = global i32 0
+
+define i32 @f() {
+  %p = bitcast i32* @x to i8*
+  call void @llvm.memset.p0i8.i8(i8* %p, i8 1, i32 4, i1 0)
+  %v = load i32, i32* @x
+  ret i32 %v
+}

--- a/tests/alive-tv/memory/memset-store.tgt.ll
+++ b/tests/alive-tv/memory/memset-store.tgt.ll
@@ -1,0 +1,9 @@
+declare void @llvm.memset.p0i8.i8(i8*, i8, i32, i1)
+
+@x = global i32 0
+
+define i32 @f() {
+  store i32 16843009, i32* @x ; 0x01010101
+  %v = load i32, i32* @x
+  ret i32 %v
+}


### PR DESCRIPTION
This PR
- Makes storing to const global UB (by adding `blocks_readonly` array)
- Supports extern const globals (which do not have initial values)
- Adds a few more tests.

Unit tests: 152 -> 153 fails; the failure is llvm-test/Transforms/GlobalOpt/invariant.ll .
What it does is pretty interesting:
```
@object1 = global i32 0
define void @ctor1() {
  store i32 -1, i32* @object1
  %A = bitcast i32* @object1 to i8*
  call void @test1(i8* %A)
  ret void
}
```
=>
```
@object1 = constant i32 -1
define void @ctor1() local_unnamed_addr {
  store i32 -1, i32* @object1
  %A = bitcast i32* @object1 to i8*
  call void @test1(i8* %A)
  ret void
}
```

But I think this is wrong, because LLVM LangRef states that const global var can be placed at read-only section of an executable:
```
A variable may be defined as a global constant, which indicates that the contents of the variable will never be modified (enabling better optimization, allowing the global data to be placed in the read-only section of an executable, etc).
```