### PR TITLE
Let local memory blocks' addresses be quantified, run identical inputs for alive-tv

### DIFF
--- a/ir/memory.h
+++ b/ir/memory.h
@@ -107,13 +107,18 @@ class Memory {
   smt::expr blocks_liveness; // array: bid -> bool
   smt::expr blocks_kind; // array: bid -> uint(1bit), 1 if heap, 0 otherwise
   smt::expr blocks_readonly; // array: bid -> bool, true if readonly
+  smt::expr blocks_addr; // array: bid -> uint
+  smt::expr blocks_size_local; // array: local_bid -> uint
 
   std::string mkName(const char *str, bool src) const;
   std::string mkName(const char *str) const;
 
-  smt::expr mk_val_array(const char *name) const;
+  smt::expr mk_val_array() const;
   smt::expr mk_liveness_uf() const;
-  smt::expr mk_readonly_array(const char *name) const;
+  smt::expr mk_readonly_array() const;
+  smt::expr mk_addr_array() const;
+  smt::expr mk_size_array(bool local) const;
+  smt::expr mk_kind_array() const;
 
 public:
   enum BlockKind {

--- a/ir/state.cpp
+++ b/ir/state.cpp
@@ -164,6 +164,11 @@ void State::addReturn(const StateValue &val) {
   domain.first = false;
 }
 
+void State::addPre(smt::expr &&cond, bool quant) {
+  if (quant) precondition_quant &= std::move(cond);
+  else precondition &= std::move(cond);
+}
+
 void State::addUB(expr &&ub) {
   domain.first &= move(ub);
   domain.second.insert(undef_vars.begin(), undef_vars.end());

--- a/ir/state.h
+++ b/ir/state.h
@@ -32,6 +32,7 @@ private:
   bool source;
   bool disable_undef_rewrite = false;
   smt::expr precondition = true;
+  smt::expr precondition_quant = true; // preconditions on quantifiers
   smt::expr axioms = true;
 
   const BasicBlock *current_bb;
@@ -83,7 +84,7 @@ public:
   void addReturn(const StateValue &val);
 
   void addAxiom(smt::expr &&axiom) { axioms &= std::move(axiom); }
-  void addPre(smt::expr &&cond) { precondition &= std::move(cond); }
+  void addPre(smt::expr &&cond, bool quant = false);
   void addUB(smt::expr &&ub);
   void addUB(const smt::expr &ub);
 
@@ -95,6 +96,7 @@ public:
   auto& getMemory() { return memory; }
   auto& getAxioms() const { return axioms; }
   auto& getPre() const { return precondition; }
+  auto& getPreForQuantVars() const { return precondition_quant; }
   const auto& getValues() const { return values; }
   const auto& getQuantVars() const { return quantified_vars; }
 

--- a/tests/alive-tv/memory/alloca-fail.src.ll
+++ b/tests/alive-tv/memory/alloca-fail.src.ll
@@ -1,0 +1,7 @@
+define i8 @f() {
+  %ptr = alloca i8
+  store i8 10, i8* %ptr
+  %v = load i8, i8* %ptr
+  ret i8 %v
+}
+; ERROR: Value mismatch

--- a/tests/alive-tv/memory/alloca-fail.tgt.ll
+++ b/tests/alive-tv/memory/alloca-fail.tgt.ll
@@ -1,0 +1,6 @@
+define i8 @f() {
+  %ptr = alloca i8
+  store i8 20, i8* %ptr
+  %v = load i8, i8* %ptr
+  ret i8 %v
+}

--- a/tests/alive-tv/memory/freshbid-malloc-2.src.ll
+++ b/tests/alive-tv/memory/freshbid-malloc-2.src.ll
@@ -1,4 +1,5 @@
 ; target: 64 bits ptr addr
+; TEST-ARGS: -disable-undef-input
 target datalayout = "e-m:o-i64:64-f80:128-n8:16:32:64-S128"
 
 define i8 @freshbid_malloc(i8** %pptr) {

--- a/tests/alive-tv/memory/storeptr-fail.src.ll
+++ b/tests/alive-tv/memory/storeptr-fail.src.ll
@@ -1,4 +1,5 @@
 target datalayout = "e-m:o-i64:64-f80:128-n8:16:32:64-S128"
+; TEST-ARGS: -disable-undef-input
 
 define i16 @f(i16** %pptr) {
   %ptr0 = call i8* @malloc(i64 2)

--- a/tests/alive-tv/memory/storeptr.src.ll
+++ b/tests/alive-tv/memory/storeptr.src.ll
@@ -1,4 +1,5 @@
 target datalayout = "e-m:o-i64:64-f80:128-n8:16:32:64-S128"
+; TEST-ARGS: -disable-undef-input
 
 define i16 @f(i16** %pptr) {
   %ptr0 = call i8* @malloc(i64 2)

--- a/tests/lit/lit/formats/alive2test.py
+++ b/tests/lit/lit/formats/alive2test.py
@@ -71,6 +71,23 @@ class Alive2Test(TestFormat):
     if m != None:
       cmd += m.group(1).split()
 
+    if alive_tv:
+      # Run identity check first
+      srcpath = test
+      looperr_string = 'Loops are not supported yet! Skipping function'
+      resultchk = lambda msg, exitCode: \
+          (exitCode == 0 and msg.find(ok_string) != -1) or \
+          (exitCode != 0 and msg.find(looperr_string) != -1)
+
+      out, err, exitCode = executeCommand(cmd + [srcpath, srcpath])
+      if not resultchk(out + err, exitCode):
+        return lit.Test.FAIL, 'src identity check fail: ' + out + err
+
+      tgtpath = test.replace('.src.ll', '.tgt.ll')
+      out, err, exitCode = executeCommand(cmd + [tgtpath, tgtpath])
+      if not resultchk(out + err, exitCode):
+        return lit.Test.FAIL, 'tgt identity check fail: ' + out + err
+
     cmd.append(test)
     if alive_tv:
       cmd.append(test.replace('.src.ll', '.tgt.ll'))
@@ -78,10 +95,10 @@ class Alive2Test(TestFormat):
 
     m = self.regex_errs.search(input)
     if m == None:
-      if exitCode == 0 and string.find(out + err, ok_string) != -1:
+      if exitCode == 0 and (out + err).find(ok_string) != -1:
         return lit.Test.PASS, ''
       return lit.Test.FAIL, out + err
 
-    if exitCode != 0 and string.find(err, m.group(1)) != -1:
+    if exitCode != 0 and err.find(m.group(1)) != -1:
       return lit.Test.PASS, ''
     return lit.Test.FAIL, out + err

--- a/tools/alive-tv.cpp
+++ b/tools/alive-tv.cpp
@@ -305,7 +305,7 @@ int main(int argc, char **argv) {
   cerr << "  " << goodCount << " correct transformations\n";
   cerr << "  " << badCount << " incorrect transformations\n";
   cerr << "  " << errorCount << " errors\n";
-  
+
   smt_init.reset();
 
   return result;

--- a/tools/transform.cpp
+++ b/tools/transform.cpp
@@ -266,21 +266,22 @@ static void check_refinement(Errors &errs, Transform &t,
   // so order here matters
   src_state.startParsingPre();
   expr pre = t.precondition ? t.precondition->toSMT(src_state) : true;
-  pre &= src_state.getPre() && tgt_state.getPre();
+  pre &= tgt_state.getPre() && src_state.getPre() && tgt_state.getPreForQuantVars();
+  expr srcpre_quant = src_state.getPreForQuantVars();
 
   auto [poison_cnstr, value_cnstr] = type.refines(a, b);
-  expr pre_dom = pre && (dom_a && dom_b);
+  expr dom_a_b = dom_a && dom_b;
 
   Solver::check({
-    { axioms && preprocess(t, qvars, uvars, pre && dom_a.notImplies(dom_b)),
+    { axioms && preprocess(t, qvars, uvars, pre && (!srcpre_quant || dom_a.notImplies(dom_b))),
       [&](const Result &r) {
         err(r, false, "Source is more defined than target");
       }},
-    { axioms && preprocess(t, qvars, uvars, pre_dom && !poison_cnstr),
+    { axioms && preprocess(t, qvars, uvars, pre && (!srcpre_quant || (dom_a_b && !poison_cnstr))),
       [&](const Result &r) {
         err(r, true, "Target is more poisonous than source");
       }},
-    { axioms && preprocess(t, qvars, uvars, pre_dom && !value_cnstr),
+    { axioms && preprocess(t, qvars, uvars, pre && (!srcpre_quant || (dom_a_b && !value_cnstr))),
       [&](const Result &r) {
         err(r, true, "Value mismatch");
       }}


### PR DESCRIPTION
This patch addresses #120. Addresses of local memory blocks are declared as quantifier through State::addQuant().

I added one more flag to State::addPre which states whether it is a precondition for a quantified variable or not.
This is needed because their representation inside the refinement expression is different from that of preconditions for non-qualifiers. I think preconditions for quantifiers should be represented as follows: 
`forall (quants-for-tgt), precond(quants-for-tgt) -> exists (quants-for-src), precond(quants_for_src) /\ …`

Also, lit test is updated so it runs `alive-tv <input.ll> <input.ll>` (which are identical inputs) for all .ll files.
`-disable-undef-input ` were added to three tests which raised `unknown`.
