### PR TITLE
disambiguate an alive problem (timeout, OOM, etc.) from an incorrect

### DIFF
--- a/tools/alive-tv.cpp
+++ b/tools/alive-tv.cpp
@@ -223,8 +223,13 @@ static bool compareFunctions(llvm::Function &F1, llvm::Function &F2,
   Errors errs = verifier.verify();
   bool result(errs);
   if (result) {
-    cerr << "Transformation doesn't verify!\n" << errs << endl;
-    ++badCount;
+    if (errs.isUnsound()) {
+      cerr << errs << endl;
+      ++errorCount;
+    } else {
+      cerr << "Transformation doesn't verify!\n" << errs << endl;
+      ++badCount;
+    }
   } else {
     cerr << "Transformation seems to be correct!\n\n";
     ++goodCount;

--- a/tools/transform.cpp
+++ b/tools/transform.cpp
@@ -111,7 +111,7 @@ static void error(Errors &errs, State &src_state, State &tgt_state,
   }
 
   if (r.isUnknown()) {
-    errs.add("Timeout", false);
+    errs.add("Timeout", true);
     return;
   }
 


### PR DESCRIPTION
transformation in the alive-tv summary output