### PR TITLE
disambiguate an alive problem (timeout, OOM, etc.) from an incorrect

### DIFF
--- a/tools/alive-tv.cpp
+++ b/tools/alive-tv.cpp
@@ -223,8 +223,13 @@ static bool compareFunctions(llvm::Function &F1, llvm::Function &F2,
   Errors errs = verifier.verify();
   bool result(errs);
   if (result) {
-    cerr << "Transformation doesn't verify!\n" << errs << endl;
-    ++badCount;
+    if (errs.isUnsound()) {
+      cerr << "Transformation doesn't verify!\n" << errs << endl;
+      ++badCount;
+    } else {
+      cerr << errs << endl;
+      ++errorCount;
+    }
   } else {
     cerr << "Transformation seems to be correct!\n\n";
     ++goodCount;


### PR DESCRIPTION
transformation in the alive-tv summary output