### PR TITLE
try to more consistently include the string ERROR in errors

### DIFF
--- a/ir/function.cpp
+++ b/ir/function.cpp
@@ -119,11 +119,11 @@ void Function::syncDataWithSrc(const Function &src) {
       in_tgt->copySMTName(*dynamic_cast<Input*>(IS->get()));
 
     if (!(IS->get()->getType() == IT->get()->getType()).isTrue())
-      throw AliveException("Source and target args have different type", false);
+      throw AliveException("ERROR: Source and target args have different type", false);
   }
 
   if (IS != ES || IT != ET)
-    throw AliveException("Source and target have different number of args",
+    throw AliveException("ERROR: Source and target have different number of args",
                          false);
 }
 

--- a/ir/state.cpp
+++ b/ir/state.cpp
@@ -55,7 +55,7 @@ const StateValue& State::operator[](const Value &val) {
   }
 
   if (hit_half_memory_limit())
-    throw AliveException("Out of memory; skipping function.", false);
+    throw AliveException("ERROR: Out of memory; skipping function.", false);
 
   auto sval_new = sval.subst(repls);
   if (sval_new.eq(sval)) {
@@ -117,7 +117,7 @@ bool State::startBB(const BasicBlock &bb) {
 
 void State::addJump(const BasicBlock &dst, expr &&cond) {
   if (seen_bbs.count(&dst))
-    throw AliveException("Loops are not supported yet! Skipping function.",
+    throw AliveException("ERROR: Loops are not supported yet! Skipping function.",
                          false);
 
   cond &= domain.first;

--- a/llvm_util/llvm2alive.cpp
+++ b/llvm_util/llvm2alive.cpp
@@ -502,7 +502,7 @@ public:
   RetTy visitInstruction(llvm::Instruction &i) { return error(i); }
 
   RetTy error(llvm::Instruction &i) {
-    *out << "Unsupported instruction: " << i << '\n';
+    *out << "ERROR: Unsupported instruction: " << i << '\n';
     return {};
   }
 
@@ -556,7 +556,7 @@ public:
         break;
       }
       default:
-        *out << "Unsupported metadata: " << ID << '\n';
+        *out << "ERROR: Unsupported metadata: " << ID << '\n';
         return false;
       }
     }

--- a/llvm_util/utils.cpp
+++ b/llvm_util/utils.cpp
@@ -123,7 +123,7 @@ Type* llvm_type2alive(const llvm::Type *ty) {
   }
   default:
 err:
-    *out << "Unsupported type: " << *ty << '\n';
+    *out << "ERROR: Unsupported type: " << *ty << '\n';
     return nullptr;
   }
 }


### PR DESCRIPTION
make sure this string appears in the output when something goes wrong, so that bulk alive2 runs can be quickly scanned for problems