### PR TITLE
Let refinement correctly encode precondition on source's quantifier

### DIFF
--- a/ir/state.cpp
+++ b/ir/state.cpp
@@ -165,6 +165,11 @@ void State::addReturn(const StateValue &val) {
   domain.first = false;
 }
 
+void State::addPre(smt::expr &&cond, bool pre_on_quantifier) {
+  if (pre_on_quantifier) precondition_quant &= std::move(cond);
+  else precondition &= std::move(cond);
+}
+
 void State::addUB(expr &&ub) {
   domain.first &= move(ub);
   domain.second.insert(undef_vars.begin(), undef_vars.end());

--- a/ir/state.h
+++ b/ir/state.h
@@ -32,6 +32,7 @@ private:
   bool source;
   bool disable_undef_rewrite = false;
   smt::expr precondition = true;
+  smt::expr precondition_quant = true; // preconditions on quantifiers
   smt::expr axioms = true;
 
   const BasicBlock *current_bb;
@@ -83,7 +84,7 @@ public:
   void addReturn(const StateValue &val);
 
   void addAxiom(smt::expr &&axiom) { axioms &= std::move(axiom); }
-  void addPre(smt::expr &&cond) { precondition &= std::move(cond); }
+  void addPre(smt::expr &&cond, bool pre_on_quantifier = false);
   void addUB(smt::expr &&ub);
   void addUB(const smt::expr &ub);
 
@@ -95,6 +96,7 @@ public:
   auto& getMemory() { return memory; }
   auto& getAxioms() const { return axioms; }
   auto& getPre() const { return precondition; }
+  auto& getPreOnQuantifiers() const { return precondition_quant; }
   const auto& getValues() const { return values; }
   const auto& getQuantVars() const { return quantified_vars; }
 

--- a/tools/transform.cpp
+++ b/tools/transform.cpp
@@ -271,7 +271,6 @@ static void check_refinement(Errors &errs, Transform &t,
   expr srcpre_quant = src_state.getPreOnQuantifiers();
 
   auto [poison_cnstr, value_cnstr] = type.refines(a, b);
-  expr pre_dom = pre && (dom_a && dom_b);
   expr dom_a_b = dom_a && dom_b;
 
   Solver::check({
@@ -292,7 +291,7 @@ static void check_refinement(Errors &errs, Transform &t,
       }}
   });
 
-  if (check_expr(axioms && preprocess(t, qvars, uvars, pre && srcpre_quant))
+  if (check_expr(axioms && preprocess(t, {}, {}, pre && srcpre_quant))
       .isUnsat()) {
     errs.add("Precondition is always false", false);
   }


### PR DESCRIPTION
This is the second PR that splits #144. This is orthogonal with other opened PRs.

This patch let preconditions for source quantifiers be in the existential predicate inside the refinement.
```
forall (quants-for-tgt), precond(quants-for-tgt) -> exists (quants-for-src), precond(quants_for_src) /\ refines(src_output, tgt_output)
```

This hasn't been problematic till now, because there was no case where precondition on quantifiers was added, IIUC.

But this patch is needed for the next splitted PR, which is to set the address of a memory block as a quantifier (as the result of `freeze` does) to resolve issue #120.
Unlike `freeze`'s result, blocks' addresses need preconditions (blocks' disjointness, non-zero-ness). This PR helps them to be correctly encoded.

Note that this is not related with malloc's null semantics, because this is talking about preconditions of addresses of successfully allocated blocks.