### PR TITLE
Implement memcmp / bcmp

### DIFF
--- a/ir/instr.h
+++ b/ir/instr.h
@@ -506,6 +506,22 @@ public:
 };
 
 
+class Memcmp final : public Instr {
+  Value *ptr1, *ptr2, *num;
+  bool equalchk;
+public:
+  Memcmp(Type &type, std::string &&name, Value &ptr1, Value &ptr2, Value &num,
+         bool equalchk): Instr(type, std::move(name)), ptr1(&ptr1), ptr2(&ptr2),
+                         num(&num), equalchk(equalchk) {}
+  std::vector<Value*> operands() const override;
+  void rauw(const Value &what, Value &with) override;
+  void print(std::ostream &os) const override;
+  StateValue toSMT(State &s) const override;
+  smt::expr getTypeConstraints(const Function &f) const override;
+  std::unique_ptr<Instr> dup(const std::string &suffix) const override;
+};
+
+
 class ExtractElement final : public Instr {
   Value *v, *idx;
 public:

--- a/smt/expr.h
+++ b/smt/expr.h
@@ -9,6 +9,7 @@
 #include <string>
 #include <utility>
 #include <vector>
+#include <functional>
 
 typedef struct _Z3_context* Z3_context;
 typedef struct _Z3_func_decl* Z3_decl;
@@ -242,6 +243,7 @@ public:
   expr extract(unsigned high, unsigned low) const;
 
   expr toBVBool() const;
+  expr toBool() const;
   expr float2BV() const;
   expr float2Real() const;
   expr BV2float(const expr &type) const;
@@ -255,6 +257,10 @@ public:
   // of the desired type
   static expr mkUF(const char *name, const std::vector<expr> &args,
                    const expr &range);
+  static expr mkRecFnApp(const char *name, const std::vector<expr> &argdefs,
+                         const expr &range,
+                         std::function<expr(const expr&)> funbody,
+                         const std::vector<expr> &args);
 
   static expr mkArray(const char *name, const expr &domain, const expr &range);
   expr store(const expr &idx, const expr &val) const;
@@ -263,6 +269,8 @@ public:
   static expr mkIf(const expr &cond, const expr &then, const expr &els);
   static expr mkForAll(const std::set<expr> &vars, expr &&val);
   static expr mkLambda(const std::set<expr> &vars, const expr &val);
+
+  expr app(const std::vector<expr> &args) const;
 
   expr simplify() const;
 

--- a/tests/alive-tv/memory/calloc-overflow.src.ll
+++ b/tests/alive-tv/memory/calloc-overflow.src.ll
@@ -1,3 +1,4 @@
+; TEST-ARGS: -smt-to=9000
 target datalayout = "e-m:o-i64:64-f80:128-n8:16:32:64-S128"
 
 define i8 @calloc_overflow(i64 %num) {

--- a/tests/alive-tv/memory/memcmp-basic-fail-1.src.ll
+++ b/tests/alive-tv/memory/memcmp-basic-fail-1.src.ll
@@ -1,0 +1,15 @@
+target datalayout = "e-m:o-i64:64-f80:128-n8:16:32:64-S128"
+
+define i32 @lt() {
+  %p = alloca i8
+  %q = alloca i8
+  store i8 1, i8* %p
+  store i8 2, i8* %q
+  %res = call i32 @memcmp(i8* %p, i8* %q, i64 1)
+  ret i32 %res
+}
+
+; ERROR: Value mismatch
+
+declare i32 @memcmp(i8* nocapture, i8* nocapture, i64)
+

--- a/tests/alive-tv/memory/memcmp-basic-fail-1.tgt.ll
+++ b/tests/alive-tv/memory/memcmp-basic-fail-1.tgt.ll
@@ -1,0 +1,10 @@
+target datalayout = "e-m:o-i64:64-f80:128-n8:16:32:64-S128"
+
+define i32 @lt() {
+  ret i32 0
+}
+
+; ERROR: Value mismatch
+
+declare i32 @memcmp(i8* nocapture, i8* nocapture, i64)
+

--- a/tests/alive-tv/memory/memcmp-basic-fail-2.src.ll
+++ b/tests/alive-tv/memory/memcmp-basic-fail-2.src.ll
@@ -1,0 +1,17 @@
+target datalayout = "e-m:o-i64:64-f80:128-n8:16:32:64-S128"
+
+define i32 @lt() {
+  %p = alloca i32
+  %q = alloca i32
+  store i32 1, i32* %p ; 01 00 00 00
+  store i32 2, i32* %q ; 02 00 00 00
+  %p8 = bitcast i32* %p to i8*
+  %q8 = bitcast i32* %q to i8*
+  %res = call i32 @memcmp(i8* %p8, i8* %q8, i64 4)
+  ret i32 %res
+}
+
+; ERROR: Value mismatch
+
+declare i32 @memcmp(i8* nocapture, i8* nocapture, i64)
+

--- a/tests/alive-tv/memory/memcmp-basic-fail-2.tgt.ll
+++ b/tests/alive-tv/memory/memcmp-basic-fail-2.tgt.ll
@@ -1,0 +1,17 @@
+target datalayout = "e-m:o-i64:64-f80:128-n8:16:32:64-S128"
+
+define i32 @lt() {
+  %p = alloca i32
+  %q = alloca i32
+  store i32 1, i32* %p ; 01 00 00 00
+  store i32 2, i32* %q ; 02 00 00 00
+  %p8 = bitcast i32* %p to i8*
+  %q8 = bitcast i32* %q to i8*
+  %res = call i32 @memcmp(i8* %p8, i8* %q8, i64 4)
+  ret i32 1
+}
+
+; ERROR: Value mismatch
+
+declare i32 @memcmp(i8* nocapture, i8* nocapture, i64)
+

--- a/tests/alive-tv/memory/memcmp-basic-fail-3.src.ll
+++ b/tests/alive-tv/memory/memcmp-basic-fail-3.src.ll
@@ -1,0 +1,17 @@
+target datalayout = "e-m:o-i64:64-f80:128-n8:16:32:64-S128"
+
+define i32 @lt() {
+  %p = alloca i32
+  %q = alloca i32
+  store i32 2, i32* %p ; 02 00 00 00
+  store i32 1, i32* %q ; 01 00 00 00
+  %p8 = bitcast i32* %p to i8*
+  %q8 = bitcast i32* %q to i8*
+  %res = call i32 @memcmp(i8* %p8, i8* %q8, i64 4)
+  ret i32 %res
+}
+
+; ERROR: Value mismatch
+
+declare i32 @memcmp(i8* nocapture, i8* nocapture, i64)
+

--- a/tests/alive-tv/memory/memcmp-basic-fail-3.tgt.ll
+++ b/tests/alive-tv/memory/memcmp-basic-fail-3.tgt.ll
@@ -1,0 +1,17 @@
+target datalayout = "e-m:o-i64:64-f80:128-n8:16:32:64-S128"
+
+define i32 @lt() {
+  %p = alloca i32
+  %q = alloca i32
+  store i32 2, i32* %p ; 02 00 00 00
+  store i32 1, i32* %q ; 01 00 00 00
+  %p8 = bitcast i32* %p to i8*
+  %q8 = bitcast i32* %q to i8*
+  %res = call i32 @memcmp(i8* %p8, i8* %q8, i64 4)
+  ret i32 0
+}
+
+; ERROR: Value mismatch
+
+declare i32 @memcmp(i8* nocapture, i8* nocapture, i64)
+

--- a/tests/alive-tv/memory/memcmp-basic.src.ll
+++ b/tests/alive-tv/memory/memcmp-basic.src.ll
@@ -1,0 +1,81 @@
+target datalayout = "e-p:64:64:64"
+
+define i32 @lt() {
+  %p = alloca i32
+  %q = alloca i32
+  store i32 1, i32* %p ; 01 00 00 00
+  store i32 2, i32* %q ; 02 00 00 00
+  %p8 = bitcast i32* %p to i8*
+  %q8 = bitcast i32* %q to i8*
+  %res = call i32 @memcmp(i8* %p8, i8* %q8, i64 4)
+  ret i32 %res
+}
+
+define i32 @lt2() {
+  %p = alloca i32
+  %q = alloca i32
+  store i32 1, i32* %p   ; 01 00 00 00
+  store i32 513, i32* %q ; 01 02 00 00
+  %p8 = bitcast i32* %p to i8*
+  %q8 = bitcast i32* %q to i8*
+  %res = call i32 @memcmp(i8* %p8, i8* %q8, i64 4)
+  ret i32 %res
+}
+
+define i32 @lt3() {
+  %p = alloca i32
+  %q = alloca i32
+  store i32 513, i32* %p    ; 01 02 00 00
+  store i32 197121, i32* %q ; 01 02 03 00
+  %p8 = bitcast i32* %p to i8*
+  %q8 = bitcast i32* %q to i8*
+  %res = call i32 @memcmp(i8* %p8, i8* %q8, i64 4)
+  ret i32 %res
+}
+
+define i32 @lt4() {
+  %p = alloca i32
+  %q = alloca i32
+  store i32 197121, i32* %p   ; 01 02 03 00
+  store i32 67305985, i32* %q ; 01 02 03 04
+  %p8 = bitcast i32* %p to i8*
+  %q8 = bitcast i32* %q to i8*
+  %res = call i32 @memcmp(i8* %p8, i8* %q8, i64 4)
+  ret i32 %res
+}
+
+define i32 @eq() {
+  %p = alloca i32
+  %q = alloca i32
+  store i32 10, i32* %p
+  store i32 10, i32* %q
+  %p8 = bitcast i32* %p to i8*
+  %q8 = bitcast i32* %q to i8*
+  %res = call i32 @memcmp(i8* %p8, i8* %q8, i64 4)
+  ret i32 %res
+}
+
+define i32 @gt() {
+  %p = alloca i32
+  %q = alloca i32
+  store i32 2, i32* %p ; 02 00 00 00
+  store i32 1, i32* %q ; 01 00 00 00
+  %p8 = bitcast i32* %p to i8*
+  %q8 = bitcast i32* %q to i8*
+  %res = call i32 @memcmp(i8* %p8, i8* %q8, i64 4)
+  ret i32 %res
+}
+
+define i32 @gt2() {
+  %p = alloca i32
+  %q = alloca i32
+  store i32 67305985, i32* %p ; 01 02 03 04
+  store i32 197121, i32* %q   ; 01 02 03 00
+  %p8 = bitcast i32* %p to i8*
+  %q8 = bitcast i32* %q to i8*
+  %res = call i32 @memcmp(i8* %p8, i8* %q8, i64 4)
+  ret i32 %res
+}
+
+declare i32 @memcmp(i8* nocapture, i8* nocapture, i64)
+

--- a/tests/alive-tv/memory/memcmp-basic.tgt.ll
+++ b/tests/alive-tv/memory/memcmp-basic.tgt.ll
@@ -1,0 +1,34 @@
+target datalayout = "e-p:64:64:64"
+
+define i32 @lt() {
+  ret i32 -11 ; any negative number is fine
+}
+
+define i32 @lt2() {
+  ret i32 -99
+}
+
+define i32 @lt3() {
+  ret i32 -2553
+}
+
+define i32 @lt4() {
+  ret i32 -1
+}
+
+define i32 @eq() {
+  ret i32 0
+}
+
+define i32 @gt() {
+  ret i32 101
+}
+
+define i32 @gt2() {
+  ret i32 2147483647
+}
+
+
+
+declare i32 @memcmp(i8* nocapture, i8* nocapture, i64)
+

--- a/tests/alive-tv/memory/memcmp-bcmp.src.ll
+++ b/tests/alive-tv/memory/memcmp-bcmp.src.ll
@@ -1,0 +1,18 @@
+target datalayout = "e-p:64:64:64"
+target triple = "x86_64-unknown-linux-gnu"
+; TEST-ARGS: -smt-to=10000 -disable-undef-input
+; allowing undef as inputs causes timeout, so it is disabled.
+
+define i1 @eq(i64 %x, i64 %y, i64 %n) {
+  %p = alloca i64
+  %q = alloca i64
+  store i64 %x, i64* %p
+  store i64 %y, i64* %q
+  %p8 = bitcast i64* %p to i8*
+  %q8 = bitcast i64* %q to i8*
+  %res = call i32 @memcmp(i8* %p8, i8* %q8, i64 %n)
+  %c = icmp eq i32 %res, 0
+  ret i1 %c
+}
+
+declare i32 @memcmp(i8* nocapture, i8* nocapture, i64)

--- a/tests/alive-tv/memory/memcmp-bcmp.tgt.ll
+++ b/tests/alive-tv/memory/memcmp-bcmp.tgt.ll
@@ -1,0 +1,18 @@
+; TEST-ARGS: -smt-to=5000
+target datalayout = "e-p:64:64:64"
+target triple = "x86_64-unknown-linux-gnu"
+
+define i1 @eq(i64 %x, i64 %y, i64 %n) {
+  %p = alloca i64
+  %q = alloca i64
+  store i64 %x, i64* %p
+  store i64 %y, i64* %q
+  %p8 = bitcast i64* %p to i8*
+  %q8 = bitcast i64* %q to i8*
+  %res = call i32 @bcmp(i8* %p8, i8* %q8, i64 %n)
+  %c = icmp eq i32 %res, 0
+  ret i1 %c
+}
+
+declare i32 @bcmp(i8* nocapture, i8* nocapture, i64)
+

--- a/tests/alive-tv/memory/memcmp-opt-bigendian.src.ll
+++ b/tests/alive-tv/memory/memcmp-opt-bigendian.src.ll
@@ -1,0 +1,17 @@
+target datalayout = "E-p:64:64:64"
+; TEST-ARGS: -disable-undef-input -smt-to=10000
+; allowing undef as inputs causes timeout, so it is disabled.
+
+define i32 @f1(i64 %x, i64 %y) {
+  %p = alloca i64
+  %q = alloca i64
+  store i64 %x, i64* %p, align 1
+  store i64 %y, i64* %q, align 1
+  %p8 = bitcast i64* %p to i8*
+  %q8 = bitcast i64* %q to i8*
+  %res = call i32 @memcmp(i8* %p8, i8* %q8, i64 8)
+  ret i32 %res
+}
+
+declare i32 @memcmp(i8* nocapture, i8* nocapture, i64)
+

--- a/tests/alive-tv/memory/memcmp-opt-bigendian.tgt.ll
+++ b/tests/alive-tv/memory/memcmp-opt-bigendian.tgt.ll
@@ -1,0 +1,12 @@
+target datalayout = "E-p:64:64:64"
+
+define i32 @f1(i64 %x, i64 %y) {
+  %lt = icmp ult i64 %x, %y
+  %eq = icmp eq i64 %x, %y
+  %r = select i1 %eq, i32 0, i32 1
+  %res = select i1 %lt, i32 -1, i32 %r
+  ret i32 %res
+}
+
+declare i32 @memcmp(i8* nocapture, i8* nocapture, i64)
+

--- a/tests/alive-tv/memory/memcmp-opt-littleendian-fail.src.ll
+++ b/tests/alive-tv/memory/memcmp-opt-littleendian-fail.src.ll
@@ -1,0 +1,21 @@
+target datalayout = "e-p:64:64:64"
+; TEST-ARGS: -disable-undef-input -smt-to=9000
+; allowing undef as inputs causes timeout, so it is disabled.
+
+; ex) %x = 0x1020, %y = 0x30
+; Note that %x > %y
+define i32 @f1(i64 %x, i64 %y) {
+  %p = alloca i64
+  %q = alloca i64
+  store i64 %x, i64* %p, align 1 ; 20 10 00 00 ..
+  store i64 %y, i64* %q, align 1 ; 30 00 00 00 ..
+  %p8 = bitcast i64* %p to i8*
+  %q8 = bitcast i64* %q to i8*
+  %res = call i32 @memcmp(i8* %p8, i8* %q8, i64 8) ; %res < 0
+  ret i32 %res
+}
+
+; ERROR: Value mismatch
+
+declare i32 @memcmp(i8* nocapture, i8* nocapture, i64)
+

--- a/tests/alive-tv/memory/memcmp-opt-littleendian-fail.tgt.ll
+++ b/tests/alive-tv/memory/memcmp-opt-littleendian-fail.tgt.ll
@@ -1,0 +1,12 @@
+target datalayout = "e-p:64:64:64"
+
+define i32 @f1(i64 %x, i64 %y) {
+  %lt = icmp ult i64 %x, %y
+  %eq = icmp eq i64 %x, %y
+  %r = select i1 %eq, i32 0, i32 1
+  %res = select i1 %lt, i32 -1, i32 %r
+  ret i32 %res
+}
+
+declare i32 @memcmp(i8* nocapture, i8* nocapture, i64)
+

--- a/tests/alive-tv/memory/memcmp-poison.src.ll
+++ b/tests/alive-tv/memory/memcmp-poison.src.ll
@@ -1,0 +1,83 @@
+target datalayout = "e-p:64:64:64"
+
+define i32 @poison_1() {
+  %p = alloca i32
+  %p8 = bitcast i32* %p to i8*
+  %res = call i32 @memcmp(i8* %p8, i8* %p8, i64 4) ; poison
+  ret i32 %res
+}
+
+define i32 @poison_0() {
+  %p = alloca i32
+  %p8 = bitcast i32* %p to i8*
+  %res = call i32 @memcmp(i8* %p8, i8* %p8, i64 4) ; poison
+  ret i32 %res
+}
+
+define i32 @poison_m1() {
+  %p = alloca i32
+  %p8 = bitcast i32* %p to i8*
+  %res = call i32 @memcmp(i8* %p8, i8* %p8, i64 4) ; poison
+  ret i32 %res
+}
+
+
+define i32 @poison_p() {
+  %p = alloca i32
+  %p8 = bitcast i32* %p to i8*
+  %res = call i32 @memcmp(i8* %p8, i8* %p8, i64 4) ; poison
+  ; To check whether %res is a concrete value or not, this converts 'res + res' to 'res'
+  %res2 = add i32 %res, %res
+  ret i32 %res2
+}
+
+
+define i32 @poison_partial_1() {
+  %p = alloca i32
+  %p8 = bitcast i32* %p to i8*
+  store i8 0, i8* %p8
+  %res = call i32 @memcmp(i8* %p8, i8* %p8, i64 4) ; poison
+  ret i32 %res
+}
+
+define i32 @poison_partial_0() {
+  %p = alloca i32
+  %p8 = bitcast i32* %p to i8*
+  store i8 0, i8* %p8
+  %res = call i32 @memcmp(i8* %p8, i8* %p8, i64 4) ; poison
+  ret i32 %res
+}
+
+define i32 @poison_partial_m1() {
+  %p = alloca i32
+  %p8 = bitcast i32* %p to i8*
+  store i8 0, i8* %p8
+  %res = call i32 @memcmp(i8* %p8, i8* %p8, i64 4) ; poison
+  ret i32 %res
+}
+
+define i32 @poison_partial_p() {
+  %p = alloca i32
+  %p8 = bitcast i32* %p to i8*
+  store i8 0, i8* %p8
+  %res = call i32 @memcmp(i8* %p8, i8* %p8, i64 4) ; poison
+  %res2 = add i32 %res, %res
+  ret i32 %res2
+}
+
+define i32 @poison_diffblocks() {
+  %p = alloca i32
+  %q = alloca i32
+  %p16 = bitcast i32* %p to i16*
+  %q16 = bitcast i32* %q to i16*
+  store i16 257, i16* %p16 ; 01 01 pp pp
+  store i16 257, i16* %q16 ; 01 01 pp pp
+  %p8 = bitcast i32* %p to i8*
+  %q8 = bitcast i32* %q to i8*
+  %res = call i32 @memcmp(i8* %p8, i8* %q8, i64 4)
+  %res2 = add i32 %res, %res
+  ret i32 %res2
+}
+
+declare i32 @memcmp(i8* nocapture, i8* nocapture, i64)
+

--- a/tests/alive-tv/memory/memcmp-poison.tgt.ll
+++ b/tests/alive-tv/memory/memcmp-poison.tgt.ll
@@ -1,0 +1,57 @@
+target datalayout = "e-p:64:64:64"
+
+define i32 @poison_1() {
+  ret i32 1
+}
+
+define i32 @poison_0() {
+  ret i32 0
+}
+
+define i32 @poison_m1() {
+  ret i32 -1
+}
+
+define i32 @poison_p() {
+  %p = alloca i32
+  %p8 = bitcast i32* %p to i8*
+  %res = call i32 @memcmp(i8* %p8, i8* %p8, i64 4) ; poison
+  ret i32 %res
+}
+
+
+define i32 @poison_partial_1() {
+  ret i32 1
+}
+
+define i32 @poison_partial_0() {
+  ret i32 0
+}
+
+define i32 @poison_partial_m1() {
+  ret i32 -1
+}
+
+define i32 @poison_partial_p() {
+  %p = alloca i32
+  %p8 = bitcast i32* %p to i8*
+  store i8 0, i8* %p8
+  %res = call i32 @memcmp(i8* %p8, i8* %p8, i64 4) ; poison
+  ret i32 %res
+}
+
+define i32 @poison_diffblocks() {
+  %p = alloca i32
+  %q = alloca i32
+  %p16 = bitcast i32* %p to i16*
+  %q16 = bitcast i32* %q to i16*
+  store i16 257, i16* %p16 ; 01 01 pp pp
+  store i16 257, i16* %q16 ; 01 01 pp pp
+  %p8 = bitcast i32* %p to i8*
+  %q8 = bitcast i32* %q to i8*
+  %res = call i32 @memcmp(i8* %p8, i8* %q8, i64 4)
+  ret i32 %res
+}
+
+declare i32 @memcmp(i8* nocapture, i8* nocapture, i64)
+

--- a/tests/alive-tv/memory/store-bigendian.src.ll
+++ b/tests/alive-tv/memory/store-bigendian.src.ll
@@ -1,0 +1,11 @@
+target datalayout = "E-p:64:64:64"
+
+define i32 @f1(i32* %p) {
+  store i32 10, i32* %p, align 1
+  %p8 = bitcast i32* %p to i8*
+  %q8 = getelementptr i8, i8* %p8, i64 -1
+  %q = bitcast i8* %q8 to i32*
+  store i32 20, i32* %q, align 1
+  %v = load i32, i32* %p, align 1
+  ret i32 %v
+}

--- a/tests/alive-tv/memory/store-bigendian.tgt.ll
+++ b/tests/alive-tv/memory/store-bigendian.tgt.ll
@@ -1,0 +1,10 @@
+target datalayout = "E-p:64:64:64"
+
+define i32 @f1(i32* %p) {
+  store i32 10, i32* %p, align 1
+  %p8 = bitcast i32* %p to i8*
+  %q8 = getelementptr i8, i8* %p8, i64 -1
+  %q = bitcast i8* %q8 to i32*
+  store i32 20, i32* %q, align 1
+  ret i32 5130 ; 20 * 256 + 10
+}


### PR DESCRIPTION
This PR implements memcmp and bcmp.
Poison-ness of memcmp(p, q, size) is defined as follows:
(1) If all bytes in [p, p+size), [q, q+size) are non-poison, it is not poison.
(2) If there exists `i` s.t. all bytes in [p, p+i], [q, q+i] are non-poison && *(p+i) != *(q+i) && forall j<i, *(p+j) == (q+j).
e.g) `01 02 pp pp` and `01 03 pp pp` (`pp` is a poison byte)

I didn't use a recursive function because it did not work well for unknown reason. It didn't stop even if timeout is given, at least.
This PR includes #157. If #157 is accepted, this PR will be updated to not include it.

memcmp can return an arbitrary positive (and negative) number if the bytes aren't the same (`man memcmp` says the returned value is a subtraction of the different bytes, but it says a well-formed program should not depend on it). To guarantee that it returns non-zero number, #156 is needed I believe, so this PR has dependency on #156. This PR implements the non-zeroness of the result with a simple bit mask (it is not fully general), but the unit tests in this PR still work.