### PR TITLE
add support for struct indexing

### DIFF
--- a/llvm_util/llvm2alive.cpp
+++ b/llvm_util/llvm2alive.cpp
@@ -337,9 +337,14 @@ public:
       if (!op)
         return error(i);
 
-      // TODO: support for struct indexing
-      if (I.getStructTypeOrNull())
-        return error(i);
+      if (auto structTy = I.getStructTypeOrNull()) {
+        llvm::Value *vals[] = { llvm::ConstantInt::getFalse(i.getContext()),
+                                I.getOperand() };
+        auto offset = DL().getIndexedOffsetInType(structTy,
+                llvm::makeArrayRef(vals, 2));
+        gep->addIdx(offset, *make_intconst(1, 64));
+        continue;
+      }
 
       gep->addIdx(DL().getTypeAllocSize(I.getIndexedType()), *op);
     }

--- a/tests/alive-tv/memory/gep-struct1-fail.src.ll
+++ b/tests/alive-tv/memory/gep-struct1-fail.src.ll
@@ -1,0 +1,13 @@
+target datalayout = "e-i32:32-i128:32-i16:16"
+
+%0 = type { i32, i128, i16 }
+
+define i64 @0(%0* nocapture) {
+  %2 = getelementptr inbounds %0, %0* %0, i32 0, i32 2
+  %3 = ptrtoint %0* %0 to i64
+  %4 = ptrtoint i16* %2 to i64
+  %5 = sub i64 %4, %3
+  ret i64 %5
+}
+
+; ERROR: Value mismatch

--- a/tests/alive-tv/memory/gep-struct1-fail.tgt.ll
+++ b/tests/alive-tv/memory/gep-struct1-fail.tgt.ll
@@ -1,0 +1,7 @@
+target datalayout = "e-i32:32-i128:32-i16:16"
+
+%0 = type { i32, i128, i16 }
+
+define i64 @0(%0* nocapture) {
+  ret i64 24
+}

--- a/tests/alive-tv/memory/gep-struct1.src.ll
+++ b/tests/alive-tv/memory/gep-struct1.src.ll
@@ -1,0 +1,11 @@
+target datalayout = "e-i32:32-i128:32-i16:16"
+
+%0 = type { i32, i128, i16 }
+
+define i64 @0(%0* nocapture) {
+  %2 = getelementptr inbounds %0, %0* %0, i32 0, i32 2
+  %3 = ptrtoint %0* %0 to i64
+  %4 = ptrtoint i16* %2 to i64
+  %5 = sub i64 %4, %3
+  ret i64 %5
+}

--- a/tests/alive-tv/memory/gep-struct1.tgt.ll
+++ b/tests/alive-tv/memory/gep-struct1.tgt.ll
@@ -1,0 +1,7 @@
+target datalayout = "e-i32:32-i128:32-i16:16"
+
+%0 = type { i32, i128, i16 }
+
+define i64 @0(%0* nocapture) {
+  ret i64 20
+}

--- a/tests/alive-tv/memory/gep-struct2.src.ll
+++ b/tests/alive-tv/memory/gep-struct2.src.ll
@@ -1,0 +1,15 @@
+target datalayout = "e-i32:32-i128:32-i8:8"
+
+%0 = type [10 x { i32, i128, [5 x { i32, i8, i8 }] }]
+; C representation:
+; struct S1 { X(i32); Y(i8); Z(i8); }
+; struct S2 {A(i32); B(i128); S1[5]; }
+; %0 = S2[10]
+define i64 @0(%0* nocapture) {
+; %2 points to: S2[2]->S1[3]->Z
+  %2 = getelementptr inbounds %0, %0* %0, i32 0, i32 2, i32 2, i32 3, i32 2
+  %3 = ptrtoint %0* %0 to i64
+  %4 = ptrtoint i8* %2 to i64
+  %5 = sub i64 %4, %3
+  ret i64 %5
+}

--- a/tests/alive-tv/memory/gep-struct2.tgt.ll
+++ b/tests/alive-tv/memory/gep-struct2.tgt.ll
@@ -1,0 +1,11 @@
+target datalayout = "e-i32:32-i128:32-i8:8"
+
+%0 = type [10 x { i32, i128, [5 x { i32, i8, i8 }] }]
+; C representation:
+; struct S1 { X(i32); Y(i8); Z(i8); }
+; struct S2 {A(i32); B(i128); S1[5]; }
+; %0 = S2[10]
+define i64 @0(%0* nocapture) {
+; %2 points to: S2[2]->S1[3]->Z
+  ret i64 169
+}


### PR DESCRIPTION
it's possible that i am overlooking something and there's more to it but following the code around, struct indexing should already work with following change. Can you point to any other issues, if any, that needs to be addressed for this?