### PR TITLE
Let alive2test.py run same input check as well

### DIFF
--- a/tests/lit/lit/formats/alive2test.py
+++ b/tests/lit/lit/formats/alive2test.py
@@ -72,6 +72,24 @@ class Alive2Test(TestFormat):
     if m != None:
       cmd += m.group(1).split()
 
+    if alive_tv:
+       # Run identity check first
+       srcpath = test
+       looperr_string = 'Loops are not supported yet! Skipping function'
+       resultchk = lambda msg, exitCode: \
+           (exitCode == 0 and msg.find(ok_string) != -1) or \
+           (exitCode != 0 and msg.find(looperr_string) != -1)
+
+       out, err, exitCode = executeCommand(cmd + [srcpath, srcpath])
+       if not resultchk(out + err, exitCode):
+         return lit.Test.FAIL, 'src identity check fail: ' + out + err
+
+       tgtpath = test.replace('.src.ll', '.tgt.ll')
+       out, err, exitCode = executeCommand(cmd + [tgtpath, tgtpath])
+       if not resultchk(out + err, exitCode):
+         return lit.Test.FAIL, 'tgt identity check fail: ' + out + err
+
+
     cmd.append(test)
     if alive_tv:
       cmd.append(test.replace('.src.ll', '.tgt.ll'))


### PR DESCRIPTION
This PR updates alive2test.py so identical input tests (`alive-tv <input.ll> <input.ll>`) are run.