### PR TITLE
Add disjointness of block addresses, blockaddr+size never overflows

### DIFF
--- a/ir/memory.cpp
+++ b/ir/memory.cpp
@@ -517,8 +517,6 @@ Memory::Memory(State &state, bool little_endian)
       }
       // Non-local blocks' addr + size does not overflow.
       state.addAxiom(p1.get_address().add_no_uoverflow(p1.block_size()));
-      // Size is less than half of memory
-      state.addAxiom(p1.block_size().extract(bits_size_t-1, bits_size_t-1) == 0);
     }
   }
 
@@ -592,8 +590,8 @@ expr Memory::alloc(const expr &size, unsigned align, BlockKind blockKind,
     allocated &= size_upperbound.ule(avail_space);
 
     // Disjointness of block's address range with other local blocks
+    auto zero = expr::mkUInt(0, bitsOffset());
     for (auto &itm : local_blk_addr) {
-      auto zero = expr::mkUInt(0, bitsOffset());
       // itm.first is short bid, so concat prefix 1.
       Pointer p2(*this, expr::mkUInt(1, 1).concat(itm.first), zero);
       state->addPre((allocated && p2.is_block_alive())

--- a/ir/memory.cpp
+++ b/ir/memory.cpp
@@ -466,37 +466,15 @@ Memory::Memory(State &state, bool little_endian)
   local_block_liveness
     = expr::mkLambda({ expr::mkVar("#bid0", bitsBid() - 1) }, false);
 
-  // The first byte of the memory cannot be allocated because it is for a null
-  // pointer.
+  // A memory space is separated into non-local area / local area.
+  // Non-local area is the lower half of memory (to include null pointer),
+  // local area is the upper half.
+  // This helps efficient encoding of disjointness between local and nonlocal
+  // blocks.
   // The last byte of the memory cannot be allocated because ptr + size
   // (where size is the size of the block and ptr is the beginning address of
   // the block) should not overflow.
-  avail_space = expr::mkVar("avail_space", bitsPtrSize());
-  if (state.isSource()) {
-    state.addAxiom(avail_space.ult(expr::mkInt(-2 * max_align, bitsPtrSize())));
-  }
-
-  // TODO: replace the magic number 2 with the result of analysis.
-  // This is just set as 2 to make existing unit tests run without timeout.
-  unsigned non_local_bid_upperbound = 2;
-
-  // Omit null pointer
-  for (unsigned bid = 1; bid <= non_local_bid_upperbound; ++bid) {
-    Pointer p(*this, bid, false);
-
-    // The required space size should consider alignment
-    auto size_upperbound = p.block_size() + expr::mkUInt(max_align - 1,
-                                                         bitsPtrSize());
-
-    if (state.isSource()) {
-      state.addAxiom(p.is_block_alive().implies(
-          size_upperbound.ule(avail_space)));
-    }
-    // size_upperbound should be subtracted here (not size_zext0) because we
-    // need to simulate fragmentation from blocks' alignment.
-    avail_space = expr::mkIf(p.is_block_alive(), avail_space - size_upperbound,
-                             avail_space);
-  }
+  local_avail_space = expr::mkUInt((1ull << 63) - 1, bitsPtrSize());
 
   if (state.isSource()) {
     // Initialize a memory block for null pointer.
@@ -505,8 +483,12 @@ Memory::Memory(State &state, bool little_endian)
     state.addAxiom(nullPtr.get_address(false) == 0);
     state.addAxiom(nullPtr.block_size(false) == 0);
 
+    // TODO: replace the magic number 2 with the result of analysis.
+    // This is just set as 2 to make existing unit tests run without timeout.
+    unsigned non_local_bid_upperbound = 2;
     // Non-local blocks are disjoint.
     // Ignore null pointer block
+    auto memsz_half = expr::mkUInt((1ull << 63), bitsPtrSize());
     for (unsigned bid = 1; bid <= non_local_bid_upperbound; ++bid) {
       Pointer p1(*this, bid, false);
       for (unsigned bid2 = bid + 1; bid2 <= non_local_bid_upperbound; ++bid2) {
@@ -515,8 +497,10 @@ Memory::Memory(State &state, bool little_endian)
             .implies(disjoint(p1.get_address(), p1.block_size(),
                               p2.get_address(), p2.block_size())));
       }
-      // Non-local blocks' addr + size does not overflow.
-      state.addAxiom(p1.get_address().add_no_uoverflow(p1.block_size()));
+      // Non-local blocks' addr, addr + size is not greater than a half of
+      // memory.
+      state.addAxiom(p1.get_address().ule(memsz_half));
+      state.addAxiom(memsz_half.uge(p1.get_address() + p1.block_size()));
     }
   }
 
@@ -587,7 +571,7 @@ expr Memory::alloc(const expr &size, unsigned align, BlockKind blockKind,
                                : addr_var;
 
     auto size_upperbound = size_zext0 + expr::mkUInt(align - 1, bitsPtrSize());
-    allocated &= size_upperbound.ule(avail_space);
+    allocated &= size_upperbound.ule(local_avail_space);
 
     // Disjointness of block's address range with other local blocks
     auto zero = expr::mkUInt(0, bitsOffset());
@@ -606,26 +590,20 @@ expr Memory::alloc(const expr &size, unsigned align, BlockKind blockKind,
     local_block_liveness = local_block_liveness.store(short_bid, allocated);
 
     // size_upperbound should be subtracted here (not size_zext0) because we
-    // need to simulate fragmentation from blocks' alignment.
-    avail_space = expr::mkIf(allocated, avail_space - size_upperbound,
-                             avail_space);
+    // need to consider blocks' alignment.
+    local_avail_space = expr::mkIf(allocated,
+                                   local_avail_space - size_upperbound,
+                                   local_avail_space);
 
-    state->addPre(allocated.implies(p.get_address() != 0));
+    // Local block area is at the top half of the memory.
+    // This also encodes the non-zero-ness of the address
+    state->addPre(allocated.implies(p.get_address()
+        .extract(bitsPtrSize() - 1, bitsPtrSize() - 1) == 1));
 
     // addr + size does not overflow.
     // C std states that one byte past the block boundary does not overflow
     state->addPre(p.get_address().add_no_uoverflow(p.block_size()));
 
-    // Disjointness of block's address range with nonlocal blocks
-    unsigned non_local_bid_upperbound = 2; // TODO: replace this magic number with
-                                           // something else from analysis
-    // Ignore null block.
-    for (unsigned bid2 = 1; bid2 <= non_local_bid_upperbound; ++bid2) {
-      Pointer p2(*this, bid2, false);
-      state->addPre((p.is_block_alive() && p2.is_block_alive())
-          .implies(disjoint(p.get_address(), p.block_size(),
-                            p2.get_address(), p2.block_size())));
-    }
   } else {
     state->addAxiom(blockKind == CONSTGLOBAL ? p.is_readonly()
                                              : !p.is_readonly());
@@ -766,11 +744,11 @@ bool Memory::operator<(const Memory &rhs) const {
   return
     tie(non_local_block_val, local_block_val, non_local_block_liveness,
         local_block_liveness, local_blk_addr, local_blk_size, local_blk_kind,
-        avail_space) <
+        local_avail_space) <
     tie(rhs.non_local_block_val, rhs.local_block_val,
         rhs.non_local_block_liveness, rhs.local_block_liveness,
         rhs.local_blk_addr, rhs.local_blk_size, rhs.local_blk_kind,
-        rhs.avail_space);
+        rhs.local_avail_space);
 }
 
 }

--- a/ir/memory.h
+++ b/ir/memory.h
@@ -113,9 +113,6 @@ class Memory {
   unsigned bits_for_bid = 12;
   // bits_size_t is equivalent to the size of a pointer.
   unsigned bits_size_t = 64;
-  // maximum alignment of memory blocks
-  // TODO: fill this from target data
-  unsigned max_align = 8;
 
   bool little_endian;
 
@@ -125,7 +122,7 @@ class Memory {
   smt::expr non_local_block_liveness; // array: bid -> bool
   smt::expr local_block_liveness;
 
-  smt::expr avail_space; // The size of available space in memory.
+  smt::expr local_avail_space; // available space in local block area.
 
   smt::FunctionExpr local_blk_addr;
   smt::FunctionExpr local_blk_size;

--- a/ir/memory.h
+++ b/ir/memory.h
@@ -124,7 +124,7 @@ class Memory {
 
   smt::expr local_avail_space; // available space in local block area.
 
-  smt::FunctionExpr local_blk_addr;
+  smt::FunctionExpr local_blk_addr; // bid -> (bits_size_t - 1)
   smt::FunctionExpr local_blk_size;
   smt::FunctionExpr local_blk_kind;
 

--- a/smt/exprs.h
+++ b/smt/exprs.h
@@ -57,6 +57,8 @@ public:
   void add(const FunctionExpr &other);
   void del(const expr &key);
   expr operator()(expr &key) const;
+  const decltype(fn)::const_iterator begin() const { return fn.begin(); }
+  const decltype(fn)::const_iterator end() const { return fn.end(); }
 
   // for container use only
   bool operator<(const FunctionExpr &rhs) const;

--- a/smt/exprs.h
+++ b/smt/exprs.h
@@ -57,8 +57,8 @@ public:
   void add(const FunctionExpr &other);
   void del(const expr &key);
   expr operator()(expr &key) const;
-  const decltype(fn)::const_iterator begin() const { return fn.begin(); }
-  const decltype(fn)::const_iterator end() const { return fn.end(); }
+  auto begin() const { return fn.begin(); }
+  auto end() const { return fn.end(); }
 
   // for container use only
   bool operator<(const FunctionExpr &rhs) const;

--- a/tests/alive-tv/memory/alloca-address-nonnull.src.ll
+++ b/tests/alive-tv/memory/alloca-address-nonnull.src.ll
@@ -1,3 +1,4 @@
+; TEST-ARGS: -smt-to=9000
 target datalayout = "e-m:o-i64:64-f80:128-n8:16:32:64-S128"
 
 define i1 @f() {

--- a/tests/alive-tv/memory/alloca-calloc.src.ll
+++ b/tests/alive-tv/memory/alloca-calloc.src.ll
@@ -1,3 +1,4 @@
+; TEST-ARGS: -smt-to=9000
 ; target: 64 bits ptr addr
 target datalayout = "e-m:o-i64:64-f80:128-n8:16:32:64-S128"
 

--- a/tests/alive-tv/memory/alloca-calloc.tgt.ll
+++ b/tests/alive-tv/memory/alloca-calloc.tgt.ll
@@ -1,3 +1,4 @@
+; TEST-ARGS: -smt-to=9000
 ; target: 64 bits ptr addr
 target datalayout = "e-m:o-i64:64-f80:128-n8:16:32:64-S128"
 

--- a/tests/alive-tv/memory/alloca-disjoint-fail.src.ll
+++ b/tests/alive-tv/memory/alloca-disjoint-fail.src.ll
@@ -1,0 +1,17 @@
+; TEST-ARGS: -smt-to=15000
+; target: 64 bits ptr addr
+target datalayout = "p:64:64:64"
+
+define i1 @disj() {
+  %x = alloca i32
+  %y = alloca i64
+  %ix = ptrtoint i32* %x to i64
+  %iy = ptrtoint i64* %y to i64
+  %yx = sub i64 %iy, %ix ; %yx <= -8 \/ 4 <= %yx
+  %left = icmp sle i64 %yx, -8
+  %right = icmp sle i64 4, %yx
+  %or = or i1 %left, %right
+  ret i1 %or
+}
+
+; ERROR: Value mismatch

--- a/tests/alive-tv/memory/alloca-disjoint-fail.tgt.ll
+++ b/tests/alive-tv/memory/alloca-disjoint-fail.tgt.ll
@@ -1,0 +1,6 @@
+; target: 64 bits ptr addr
+target datalayout = "p:64:64:64"
+
+define i1 @disj() {
+  ret i1 false
+}

--- a/tests/alive-tv/memory/alloca-disjoint.src.ll
+++ b/tests/alive-tv/memory/alloca-disjoint.src.ll
@@ -1,0 +1,27 @@
+; TEST-ARGS: -smt-to=15000
+; target: 64 bits ptr addr
+target datalayout = "p:64:64:64"
+
+define i1 @disj() {
+  %x = alloca i32
+  %y = alloca i64
+  %ix = ptrtoint i32* %x to i64
+  %iy = ptrtoint i64* %y to i64
+  %yx = sub i64 %iy, %ix ; %yx <= -8 \/ 4 <= %yx
+  %left = icmp sle i64 %yx, -8
+  %right = icmp sle i64 4, %yx
+  %or = or i1 %left, %right
+  ret i1 %or
+}
+
+define i1 @disj_false() {
+  %x = alloca i32
+  %y = alloca i64
+  %ix = ptrtoint i32* %x to i64
+  %iy = ptrtoint i64* %y to i64
+  %yx = sub i64 %iy, %ix ; %yx <= -8 \/ 4 <= %yx
+  %left = icmp slt i64 -8, %yx
+  %right = icmp slt i64 %yx, 4
+  %and = and i1 %left, %right
+  ret i1 %and
+}

--- a/tests/alive-tv/memory/alloca-disjoint.tgt.ll
+++ b/tests/alive-tv/memory/alloca-disjoint.tgt.ll
@@ -1,0 +1,11 @@
+; target: 64 bits ptr addr
+target datalayout = "p:64:64:64"
+@x = global i32 0
+
+define i1 @disj() {
+  ret i1 true
+}
+
+define i1 @disj_false() {
+  ret i1 false
+}

--- a/tests/alive-tv/memory/alloca-malloc-fail.src.ll
+++ b/tests/alive-tv/memory/alloca-malloc-fail.src.ll
@@ -1,3 +1,4 @@
+; TEST-ARGS: -smt-to=9000
 ; target: 64 bits ptr addr
 target datalayout = "e-m:o-i64:64-f80:128-n8:16:32:64-S128"
 

--- a/tests/alive-tv/memory/alloca-malloc-fail.tgt.ll
+++ b/tests/alive-tv/memory/alloca-malloc-fail.tgt.ll
@@ -1,3 +1,4 @@
+; TEST-ARGS: -smt-to=9000
 ; target: 64 bits ptr addr
 target datalayout = "e-m:o-i64:64-f80:128-n8:16:32:64-S128"
 

--- a/tests/alive-tv/memory/alloca-malloc.src.ll
+++ b/tests/alive-tv/memory/alloca-malloc.src.ll
@@ -1,3 +1,4 @@
+; TEST-ARGS: -smt-to=9000
 ; target: 64 bits ptr addr
 target datalayout = "e-m:o-i64:64-f80:128-n8:16:32:64-S128"
 

--- a/tests/alive-tv/memory/alloca-malloc.tgt.ll
+++ b/tests/alive-tv/memory/alloca-malloc.tgt.ll
@@ -1,3 +1,4 @@
+; TEST-ARGS: -smt-to=9000
 ; target: 64 bits ptr addr
 target datalayout = "e-m:o-i64:64-f80:128-n8:16:32:64-S128"
 

--- a/tests/alive-tv/memory/alloca-uninit.src.ll
+++ b/tests/alive-tv/memory/alloca-uninit.src.ll
@@ -1,3 +1,5 @@
+; TEST-ARGS: -smt-to=9000
+
 define i32 @f() {
   %p = alloca i32
   %v = load i32, i32* %p

--- a/tests/alive-tv/memory/alloca-uninit.tgt.ll
+++ b/tests/alive-tv/memory/alloca-uninit.tgt.ll
@@ -1,3 +1,5 @@
+; TEST-ARGS: -smt-to=9000
+
 define i32 @f() {
   %p = alloca i32
   %v = load i32, i32* %p

--- a/tests/alive-tv/memory/free-ub-alloca.src.ll
+++ b/tests/alive-tv/memory/free-ub-alloca.src.ll
@@ -1,3 +1,5 @@
+; TEST-ARGS: -smt-to=9000
+
 define i32 @free_ub_alloca() {
   %1 = alloca i32
   %2 = bitcast i32* %1 to i8*

--- a/tests/alive-tv/memory/freshbid-alloca-1.src.ll
+++ b/tests/alive-tv/memory/freshbid-alloca-1.src.ll
@@ -1,3 +1,5 @@
+; TEST-ARGS: -smt-to=9000
+
 define i8 @freshbid_alloca(i8* %ptr0) {
   %ptr = alloca i8
   store i8 10, i8* %ptr

--- a/tests/alive-tv/memory/freshbid-alloca-2.src.ll
+++ b/tests/alive-tv/memory/freshbid-alloca-2.src.ll
@@ -1,4 +1,4 @@
-; TEST-ARGS: -smt-to=15000 -disable-undef-input
+; TEST-ARGS: -smt-to=9000 -disable-undef-input
 ; To resolve timeout error, it is assumed that input %pptr is never an undef pointer
 
 define i8 @freshbid_alloca(i8** %pptr) {
@@ -9,7 +9,3 @@ define i8 @freshbid_alloca(i8** %pptr) {
   %v = load i8, i8* %ptr
   ret i8 %v
 }
-
-; Couldn't figure out how to make this test work
-; Leave it as XFAIL.
-; XFAIL: Timeout

--- a/tests/alive-tv/memory/freshbid-alloca-2.src.ll
+++ b/tests/alive-tv/memory/freshbid-alloca-2.src.ll
@@ -1,4 +1,4 @@
-; TEST-ARGS: -smt-to=9000 -disable-undef-input
+; TEST-ARGS: -smt-to=15000 -disable-undef-input
 ; To resolve timeout error, it is assumed that input %pptr is never an undef pointer
 
 define i8 @freshbid_alloca(i8** %pptr) {
@@ -9,3 +9,7 @@ define i8 @freshbid_alloca(i8** %pptr) {
   %v = load i8, i8* %ptr
   ret i8 %v
 }
+
+; Couldn't figure out how to make this test work
+; Leave it as XFAIL.
+; XFAIL: Timeout

--- a/tests/alive-tv/memory/freshbid-alloca-2.tgt.ll
+++ b/tests/alive-tv/memory/freshbid-alloca-2.tgt.ll
@@ -1,4 +1,5 @@
-; TEST-ARGS: -smt-to=9000
+; TEST-ARGS: -smt-to=15000 -disable-undef-input
+; To resolve timeout error, it is assumed that input %pptr is never an undef pointer
 
 define i8 @freshbid_alloca(i8** %pptr) {
   %ptr = alloca i8

--- a/tests/alive-tv/memory/freshbid-malloc-1.src.ll
+++ b/tests/alive-tv/memory/freshbid-malloc-1.src.ll
@@ -1,3 +1,4 @@
+; TEST-ARGS: -smt-to=9000
 ; target: 64 bits ptr addr
 target datalayout = "e-m:o-i64:64-f80:128-n8:16:32:64-S128"
 

--- a/tests/alive-tv/memory/glb-1.tgt.ll
+++ b/tests/alive-tv/memory/glb-1.tgt.ll
@@ -1,5 +1,6 @@
 @x = constant i32 5, align 4
 
 define i32 @f() {
+  %v = load i32, i32* @x ; relieves memory mismatch check
   ret i32 5
 }

--- a/tests/alive-tv/memory/glb-2.tgt.ll
+++ b/tests/alive-tv/memory/glb-2.tgt.ll
@@ -3,5 +3,9 @@ target datalayout = "e-m:o-i64:64-f80:128-n8:16:32:64-S128" ; has little endian
 @y = constant i32 258, align 4
 
 define i8 @f() {
+  %x8 = bitcast i32* @x to i8*
+  %y8 = bitcast i32* @y to i8*
+  %v = load i8, i8* %x8
+  %w = load i8, i8* %y8
   ret i8 3
 }

--- a/tests/alive-tv/memory/glb-alloca-disjoint-fail.src.ll
+++ b/tests/alive-tv/memory/glb-alloca-disjoint-fail.src.ll
@@ -1,0 +1,17 @@
+; TEST-ARGS: -smt-to=9000
+; target: 64 bits ptr addr
+target datalayout = "p:64:64:64"
+@x = global i32 0
+
+define i1 @disj() {
+  %y = alloca i64
+  %ix = ptrtoint i32* @x to i64
+  %iy = ptrtoint i64* %y to i64
+  %yx = sub i64 %iy, %ix ; %yx <= -8 \/ 4 <= %yx
+  %left = icmp sle i64 %yx, -8
+  %right = icmp sle i64 4, %yx
+  %or = or i1 %left, %right
+  ret i1 %or
+}
+
+; ERROR: Value mismatch

--- a/tests/alive-tv/memory/glb-alloca-disjoint-fail.tgt.ll
+++ b/tests/alive-tv/memory/glb-alloca-disjoint-fail.tgt.ll
@@ -1,0 +1,8 @@
+; target: 64 bits ptr addr
+target datalayout = "p:64:64:64"
+@x = global i32 0
+
+define i1 @disj() {
+  ret i1 false
+}
+

--- a/tests/alive-tv/memory/glb-alloca-disjoint.src.ll
+++ b/tests/alive-tv/memory/glb-alloca-disjoint.src.ll
@@ -1,0 +1,26 @@
+; target: 64 bits ptr addr
+; TEST-ARGS: -smt-to=5000
+target datalayout = "p:64:64:64"
+@x = global i32 0
+
+define i1 @disj() {
+  %y = alloca i64
+  %ix = ptrtoint i32* @x to i64
+  %iy = ptrtoint i64* %y to i64
+  %yx = sub i64 %iy, %ix ; %yx <= -8 \/ 4 <= %yx
+  %left = icmp sle i64 %yx, -8
+  %right = icmp sle i64 4, %yx
+  %or = or i1 %left, %right
+  ret i1 %or
+}
+
+define i1 @disj_false() {
+  %y = alloca i64
+  %ix = ptrtoint i32* @x to i64
+  %iy = ptrtoint i64* %y to i64
+  %yx = sub i64 %iy, %ix ; %yx <= -8 \/ 4 <= %yx
+  %left = icmp slt i64 -8, %yx
+  %right = icmp slt i64 %yx, 4
+  %and = and i1 %left, %right
+  ret i1 %and
+}

--- a/tests/alive-tv/memory/glb-alloca-disjoint.tgt.ll
+++ b/tests/alive-tv/memory/glb-alloca-disjoint.tgt.ll
@@ -1,0 +1,11 @@
+; target: 64 bits ptr addr
+target datalayout = "p:64:64:64"
+@x = global i32 0
+
+define i1 @disj() {
+  ret i1 true
+}
+
+define i1 @disj_false() {
+  ret i1 false
+}

--- a/tests/alive-tv/memory/glb-disjoint-fail.src.ll
+++ b/tests/alive-tv/memory/glb-disjoint-fail.src.ll
@@ -1,0 +1,16 @@
+; target: 64 bits ptr addr
+target datalayout = "p:64:64:64"
+@x = global i32 0
+@y = global i64 0
+
+define i1 @disj() {
+  %ix = ptrtoint i32* @x to i64
+  %iy = ptrtoint i64* @y to i64
+  %yx = sub i64 %iy, %ix ; %yx <= -8 \/ 4 <= %yx
+  %left = icmp sle i64 %yx, -8
+  %right = icmp sle i64 4, %yx
+  %or = or i1 %left, %right
+  ret i1 %or
+}
+
+; ERROR: Value mismatch

--- a/tests/alive-tv/memory/glb-disjoint-fail.tgt.ll
+++ b/tests/alive-tv/memory/glb-disjoint-fail.tgt.ll
@@ -1,0 +1,8 @@
+; target: 64 bits ptr addr
+target datalayout = "p:64:64:64"
+@x = global i32 0
+@y = global i64 0
+
+define i1 @disj() {
+  ret i1 false
+}

--- a/tests/alive-tv/memory/glb-disjoint.src.ll
+++ b/tests/alive-tv/memory/glb-disjoint.src.ll
@@ -1,3 +1,4 @@
+; TEST-ARGS: -smt-to=9000
 ; target: 64 bits ptr addr
 target datalayout = "p:64:64:64"
 @x = global i32 0

--- a/tests/alive-tv/memory/glb-disjoint.src.ll
+++ b/tests/alive-tv/memory/glb-disjoint.src.ll
@@ -1,0 +1,24 @@
+; target: 64 bits ptr addr
+target datalayout = "p:64:64:64"
+@x = global i32 0
+@y = global i64 0
+
+define i1 @disj() {
+  %ix = ptrtoint i32* @x to i64
+  %iy = ptrtoint i64* @y to i64
+  %yx = sub i64 %iy, %ix ; %yx <= -8 \/ 4 <= %yx
+  %left = icmp sle i64 %yx, -8
+  %right = icmp sle i64 4, %yx
+  %or = or i1 %left, %right
+  ret i1 %or
+}
+
+define i1 @disj_false() {
+  %ix = ptrtoint i32* @x to i64
+  %iy = ptrtoint i64* @y to i64
+  %yx = sub i64 %iy, %ix ; %yx <= -8 \/ 4 <= %yx
+  %left = icmp slt i64 -8, %yx
+  %right = icmp slt i64 %yx, 4
+  %and = and i1 %left, %right
+  ret i1 %and
+}

--- a/tests/alive-tv/memory/glb-disjoint.tgt.ll
+++ b/tests/alive-tv/memory/glb-disjoint.tgt.ll
@@ -1,0 +1,12 @@
+; target: 64 bits ptr addr
+target datalayout = "p:64:64:64"
+@x = global i32 0
+@y = global i64 0
+
+define i1 @disj() {
+  ret i1 true
+}
+
+define i1 @disj_false() {
+  ret i1 false
+}

--- a/tests/alive-tv/memory/malloc-oom.src.ll
+++ b/tests/alive-tv/memory/malloc-oom.src.ll
@@ -1,0 +1,17 @@
+; target: 64 bits ptr addr
+target datalayout = "e-p:64:64"
+
+define i1 @malloc_oom() {
+  %ptr1 = call noalias i8* @malloc(i64 9223372036854775552) ; 7FFF FFFF FFFF FF00
+  %ptr2 = call noalias i8* @malloc(i64 9223372036854775552) ; 7FFF FFFF FFFF FF00
+  %i1 = ptrtoint i8* %ptr1 to i64
+  %i2 = ptrtoint i8* %ptr2 to i64
+  %eq1 = icmp ne i64 %i1, 0
+  %eq2 = icmp ne i64 %i2, 0
+  %res = and i1 %eq1, %eq2
+  ret i1 %res
+}
+
+; ERROR: Value mismatch
+
+declare noalias i8* @malloc(i64)

--- a/tests/alive-tv/memory/malloc-oom.tgt.ll
+++ b/tests/alive-tv/memory/malloc-oom.tgt.ll
@@ -1,0 +1,10 @@
+; target: 64 bits ptr addr
+target datalayout = "e-p:64:64"
+
+define i1 @malloc_oom() {
+  %ptr1 = call noalias i8* @malloc(i64 9223372036854775552) ; 7FFF FFFF FFFF FF00
+  %ptr2 = call noalias i8* @malloc(i64 9223372036854775552) ; 7FFF FFFF FFFF FF00
+  ret i1 true
+}
+
+declare noalias i8* @malloc(i64)

--- a/tests/alive-tv/memory/malloc-undef.src.ll
+++ b/tests/alive-tv/memory/malloc-undef.src.ll
@@ -1,4 +1,4 @@
-; TEST-ARGS: -smt-to=9000
+; TEST-ARGS: -smt-to=30000
 ; ERROR: Value mismatch
 
 define i8 @malloc_undef() {

--- a/tests/alive-tv/memory/malloc-undef.tgt.ll
+++ b/tests/alive-tv/memory/malloc-undef.tgt.ll
@@ -1,4 +1,4 @@
-; TEST-ARGS: -smt-to=9000
+; TEST-ARGS: -smt-to=30000
 
 define i8 @malloc_undef() {
   %ptr = call i8* @malloc(i64 undef)

--- a/tests/alive-tv/memory/memcpy-1.src.ll
+++ b/tests/alive-tv/memory/memcpy-1.src.ll
@@ -1,3 +1,4 @@
+; TEST-ARGS: -smt-to=5000
 declare void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
 
 define i8 @f() {

--- a/tests/alive-tv/memory/memcpy-memset-1.src.ll
+++ b/tests/alive-tv/memory/memcpy-memset-1.src.ll
@@ -1,3 +1,5 @@
+; TEST-ARGS: -smt-to=9000
+
 declare void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
 declare void @llvm.memset.p0i8.i8(i8*, i8, i32, i1)
 

--- a/tests/alive-tv/memory/memcpy-memset-2.src.ll
+++ b/tests/alive-tv/memory/memcpy-memset-2.src.ll
@@ -1,3 +1,4 @@
+; TEST-ARGS: -smt-to=9000
 declare void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
 declare void @llvm.memset.p0i8.i8(i8*, i8, i32, i1)
 

--- a/tests/alive-tv/memory/memset-1.src.ll
+++ b/tests/alive-tv/memory/memset-1.src.ll
@@ -1,3 +1,4 @@
+; TEST-ARGS: -smt-to=9000
 declare void @llvm.memset.p0i8.i8(i8*, i8, i32, i1)
 
 define i8 @f() {

--- a/tests/alive-tv/memory/punning-ptrint.src.ll
+++ b/tests/alive-tv/memory/punning-ptrint.src.ll
@@ -1,3 +1,5 @@
+; TEST-ARGS: -smt-to=10000 -disable-undef-input
+; -disable-undef-input is given to resolve timeout error
 target datalayout = "e-m:o-i64:64-f80:128-n8:16:32:64-S128"
 
 define i8 @ptr_int_punning(i8** %pptr, i64 %n) {

--- a/tests/alive-tv/memory/punning-ptrint.tgt.ll
+++ b/tests/alive-tv/memory/punning-ptrint.tgt.ll
@@ -1,3 +1,5 @@
+; TEST-ARGS: -smt-to=10000 -disable-undef-input
+; -disable-undef-input is given to resolve timeout error
 target datalayout = "e-m:o-i64:64-f80:128-n8:16:32:64-S128"
 
 define i8 @ptr_int_punning(i8** %pptr, i64 %n) {

--- a/tests/alive-tv/memory/storeptr-fail.src.ll
+++ b/tests/alive-tv/memory/storeptr-fail.src.ll
@@ -1,3 +1,4 @@
+; TEST-ARGS: -smt-to=15000
 target datalayout = "e-m:o-i64:64-f80:128-n8:16:32:64-S128"
 
 define i16 @f(i16** %pptr) {

--- a/tests/alive-tv/memory/storeptr-fail.tgt.ll
+++ b/tests/alive-tv/memory/storeptr-fail.tgt.ll
@@ -1,3 +1,4 @@
+; TEST-ARGS: -smt-to=15000
 target datalayout = "e-m:o-i64:64-f80:128-n8:16:32:64-S128"
 
 define i16 @f(i16** %pptr) {

--- a/tests/alive-tv/memory/storeptr.src.ll
+++ b/tests/alive-tv/memory/storeptr.src.ll
@@ -1,3 +1,4 @@
+; TEST-ARGS: -smt-to=15000
 target datalayout = "e-m:o-i64:64-f80:128-n8:16:32:64-S128"
 
 define i16 @f(i16** %pptr) {

--- a/tests/alive-tv/memory/storeptr.tgt.ll
+++ b/tests/alive-tv/memory/storeptr.tgt.ll
@@ -1,3 +1,4 @@
+; TEST-ARGS: -smt-to=15000
 target datalayout = "e-m:o-i64:64-f80:128-n8:16:32:64-S128"
 
 define i16 @f(i16** %pptr) {

--- a/tests/unit/fshl/folds32.opt
+++ b/tests/unit/fshl/folds32.opt
@@ -1,4 +1,4 @@
-; TEST-ARGS: -root-only
+; TEST-ARGS: -root-only -smt-to:15000
 
 Name: single shift by masked value
 %c_mod_width = urem i32 %c, i32 32

--- a/tests/unit/fshl/folds32.opt
+++ b/tests/unit/fshl/folds32.opt
@@ -1,4 +1,4 @@
-; TEST-ARGS: -root-only -smt-to:15000
+; TEST-ARGS: -root-only -smt-to:30000
 
 Name: single shift by masked value
 %c_mod_width = urem i32 %c, i32 32


### PR DESCRIPTION
This PR adds disjointness of block addresses as well as precondition stating that blockaddr+size never overflows.

Disjointness between a block and another non-local block that is never explicitly allocated is not enforced because I guess there is no reasonable code that can observe the size of such blocks (at least in standard library functions).

Tests for disjointness of mallocs is not added here, I'll add those after updating malloc's null-ness semantics.