### PR TITLE
Check that xfail is not none

### DIFF
--- a/tests/lit/lit/formats/alive2test.py
+++ b/tests/lit/lit/formats/alive2test.py
@@ -106,6 +106,6 @@ class Alive2Test(TestFormat):
     if exitCode != 0:
       if expect_err != None and string.find(err, expect_err.group(1)) != -1:
         return lit.Test.PASS, ''
-      if string.find(err, xfail.group(1)) != -1:
+      if xfail != None and string.find(err, xfail.group(1)) != -1:
         return lit.Test.XFAIL, ''
     return lit.Test.FAIL, out + err


### PR DESCRIPTION
This resolves following Python error when running particular tests that are not pushed yet:
```
  File "/Users/juneyounglee/alive2/tests/lit/lit/formats/alive2test.py", line 109, in execute
    if string.find(err, xfail.group(1)) != -1:
AttributeError: 'NoneType' object has no attribute 'group'
```