### PR TITLE
Let llvm2alive_::run convert constexprs to instructions

### DIFF
--- a/ir/function.cpp
+++ b/ir/function.cpp
@@ -11,6 +11,21 @@ using namespace std;
 
 namespace IR {
 
+ostream& operator<<(ostream &os, const Initializers &inits) {
+  os << "<init> {\n";
+  for (auto &init : inits.instrs) {
+    os << "  ; @" << init.first << "\n";
+    for (auto &inst : init.second) {
+      os << "  ";
+      inst->print(os);
+      os << "\n";
+    }
+  }
+  os << "}\n";
+  return os;
+}
+
+
 expr BasicBlock::getTypeConstraints(const Function &f) const {
   expr t(true);
   for (auto &i : instrs()) {

--- a/ir/function.h
+++ b/ir/function.h
@@ -8,6 +8,7 @@
 #include "ir/value.h"
 #include "smt/expr.h"
 #include "util/compiler.h"
+#include <map>
 #include <memory>
 #include <ostream>
 #include <string>
@@ -21,6 +22,24 @@ namespace smt { class Model; }
 namespace IR {
 
 class Function;
+
+// A list of instructions for initializing global variables
+class Initializers final {
+  // (global var name, instruction list) list
+  std::map<std::string, std::vector<std::unique_ptr<Instr>>> instrs;
+
+public:
+  Initializers() {}
+
+  void addInstr(const std::string &glb_name, std::unique_ptr<Instr> &&inst)
+  { instrs[glb_name].push_back(move(inst)); }
+
+  bool empty() const { return instrs.empty(); }
+  auto begin() const { return instrs.begin(); }
+  auto end() const { return instrs.end(); }
+
+  friend std::ostream& operator<<(std::ostream &os, const Initializers &inits);
+};
 
 class BasicBlock final {
   std::string name;

--- a/ir/memory.cpp
+++ b/ir/memory.cpp
@@ -293,8 +293,10 @@ void Pointer::is_dereferenceable(const expr &bytes0, unsigned align,
 
   cond &= is_block_alive();
 
-  if (iswrite)
+  if (iswrite && !m.state->isInitializationPhase()) {
+    // In initialization phase, read-only blocks' values are being updated.
     cond &= !is_readonly();
+  }
 
   m.state->addUB(bytes.uge(1).implies(cond));
 

--- a/ir/state.cpp
+++ b/ir/state.cpp
@@ -13,8 +13,8 @@ using namespace std;
 
 namespace IR {
 
-State::State(const Function &f, bool source)
-  : f(f), source(source), memory(*this, f.isLittleEndian()),
+State::State(const Initializers &inits, const Function &f, bool source)
+  : inits(inits), f(f), source(source), memory(*this, f.isLittleEndian()),
     return_domain(false), return_val(f.getType().getDummyValue(false)),
     return_memory(memory) {}
 

--- a/ir/state.h
+++ b/ir/state.h
@@ -21,6 +21,7 @@ namespace IR {
 class Value;
 class BasicBlock;
 class Function;
+class Initializers;
 
 class State {
 public:
@@ -29,6 +30,7 @@ public:
   using DomainTy = std::pair<smt::expr, std::set<smt::expr>>;
 
 private:
+  const Initializers &inits;
   const Function &f;
   bool source;
   bool disable_undef_rewrite = false;
@@ -58,6 +60,7 @@ private:
   std::set<smt::expr> undef_vars;
   std::array<StateValue, 32> tmp_values;
   unsigned i_tmp_values = 0; // next available position in tmp_values
+  bool is_initialization_phase = true; // Is initializer running?
 
   // return_domain: a boolean expression describing return condition
   smt::expr return_domain;
@@ -66,7 +69,7 @@ private:
   std::set<smt::expr> return_undef_vars;
 
 public:
-  State(const Function &f, bool source);
+  State(const Initializers &inits, const Function &f, bool source);
 
   static void resetGlobals();
 
@@ -92,6 +95,10 @@ public:
   void addQuantVar(const smt::expr &var);
   void addUndefVar(smt::expr &&var);
   void resetUndefVars();
+
+  auto &getInitializers() const { return inits; }
+  bool isInitializationPhase() const { return is_initialization_phase; }
+  void finishInitializer() { is_initialization_phase = false; }
 
   auto& getFn() const { return f; }
   auto& getMemory() { return memory; }

--- a/llvm_util/llvm2alive.h
+++ b/llvm_util/llvm2alive.h
@@ -19,6 +19,6 @@ struct initializer {
   initializer(std::ostream &os, const llvm::DataLayout &DL);
 };
 
-std::optional<IR::Function> llvm2alive(llvm::Function &F,
-                                       const llvm::TargetLibraryInfo &TLI);
+std::optional<std::pair<IR::Initializers, IR::Function>>
+llvm2alive(llvm::Function &F, const llvm::TargetLibraryInfo &TLI);
 }

--- a/llvm_util/utils.cpp
+++ b/llvm_util/utils.cpp
@@ -12,7 +12,6 @@
 #include "llvm/IR/GlobalVariable.h"
 #include <unordered_map>
 #include <utility>
-#include <vector>
 
 using namespace IR;
 using namespace std;

--- a/llvm_util/utils.h
+++ b/llvm_util/utils.h
@@ -11,6 +11,9 @@ class BasicBlock;
 class DataLayout;
 class Type;
 class Value;
+class GlobalVariable;
+class Function;
+
 }
 
 namespace IR {
@@ -21,6 +24,9 @@ class Value;
 }
 
 namespace llvm_util {
+
+std::vector<llvm::GlobalVariable *> getUsedGlobalVariables(llvm::Function &F);
+
 
 IR::BasicBlock& getBB(const llvm::BasicBlock *bb);
 

--- a/llvm_util/utils.h
+++ b/llvm_util/utils.h
@@ -5,6 +5,7 @@
 
 #include <ostream>
 #include <string>
+#include <vector>
 
 namespace llvm {
 class BasicBlock;

--- a/tests/alive-tv/constexpr/constgep-fail.src.ll
+++ b/tests/alive-tv/constexpr/constgep-fail.src.ll
@@ -1,0 +1,14 @@
+@x = constant i16 0
+@y = constant i8* getelementptr inbounds (i8, i8* bitcast (i16* @x to i8*), i64 0)
+
+define i8* @f() {
+; <init> {
+;  ; @y
+;  %__constexpr_0 = bitcast * @x to *
+;  store * %__constexpr_0, * @y, align 8
+; }
+  %p = load i8*, i8** @y
+  ret i8* %p
+}
+
+; ERROR: Value mismatch

--- a/tests/alive-tv/constexpr/constgep-fail.tgt.ll
+++ b/tests/alive-tv/constexpr/constgep-fail.tgt.ll
@@ -1,0 +1,9 @@
+@x = constant i16 0
+@y = constant i8* getelementptr inbounds (i8, i8* bitcast (i16* @x to i8*), i64 0)
+
+define i8* @f() {
+  %p = load i8*, i8** @y ; to relieve mismatch in memory error
+  %a = bitcast i16* @x to i8*
+  %b = getelementptr inbounds i8, i8* %a, i64 1
+  ret i8* %b
+}

--- a/tests/alive-tv/constexpr/constgep.src.ll
+++ b/tests/alive-tv/constexpr/constgep.src.ll
@@ -1,0 +1,12 @@
+@x = constant i16 0
+@y = constant i8* getelementptr inbounds (i8, i8* bitcast (i16* @x to i8*), i64 0)
+
+define i8* @f() {
+; <init> {
+;  ; @y
+;  %__constexpr_0 = bitcast * @x to *
+;  store * %__constexpr_0, * @y, align 8
+; }
+  %p = load i8*, i8** @y
+  ret i8* %p
+}

--- a/tests/alive-tv/constexpr/constgep.tgt.ll
+++ b/tests/alive-tv/constexpr/constgep.tgt.ll
@@ -1,0 +1,9 @@
+@x = constant i16 0
+@y = constant i8* getelementptr inbounds (i8, i8* bitcast (i16* @x to i8*), i64 0)
+
+define i8* @f() {
+  %p = load i8*, i8** @y ; to relieve mismatch in memory error
+  %a = bitcast i16* @x to i8*
+  %b = getelementptr inbounds i8, i8* %a, i64 0
+  ret i8* %b
+}

--- a/tests/alive-tv/constexpr/loadgep-fail.src.ll
+++ b/tests/alive-tv/constexpr/loadgep-fail.src.ll
@@ -1,0 +1,12 @@
+@g = constant i16 1
+
+define i8 @f() {
+  %x  = load i8, i8* getelementptr inbounds (i8, i8* bitcast (i16* @g to i8*), i64 1)
+  ; After conversion, it becomes
+  ;   %1 = bitcast * @g to *
+  ;   %2 = gep inbounds * %1, 1 x i64 1
+  ;   %x = load i8, * %2, align 1
+  ret i8 %x
+}
+
+; ERROR: Value mismatch

--- a/tests/alive-tv/constexpr/loadgep-fail.tgt.ll
+++ b/tests/alive-tv/constexpr/loadgep-fail.tgt.ll
@@ -1,0 +1,8 @@
+@g = constant i16 1
+
+define i8 @f() {
+  %1 = bitcast i16* @g to i8*
+  %2 = getelementptr inbounds i8, i8* %1, i64 0
+  %x = load i8, i8* %2, align 1
+  ret i8 %x
+}

--- a/tests/alive-tv/constexpr/loadgep.src.ll
+++ b/tests/alive-tv/constexpr/loadgep.src.ll
@@ -1,0 +1,6 @@
+@g = constant i16 0
+
+define i8 @f() {
+  %x  = load i8, i8* getelementptr inbounds (i8, i8* bitcast (i16* @g to i8*), i64 1)
+  ret i8 %x
+}

--- a/tests/alive-tv/constexpr/loadgep.tgt.ll
+++ b/tests/alive-tv/constexpr/loadgep.tgt.ll
@@ -1,0 +1,8 @@
+@g = constant i16 0
+
+define i8 @f() {
+  %1 = bitcast i16* @g to i8*
+  %2 = getelementptr inbounds i8, i8* %1, i64 1
+  %x = load i8, i8* %2, align 1
+  ret i8 0
+}

--- a/tests/alive-tv/constexpr/phigep-fail.src.ll
+++ b/tests/alive-tv/constexpr/phigep-fail.src.ll
@@ -1,0 +1,16 @@
+@g = constant i16 1
+
+define i8 @f(i1 %cond) {
+  br i1 %cond, label %A, label %B
+A:
+  br label %EXIT
+B:
+  br label %EXIT
+EXIT:
+  %addr = phi i8* [getelementptr inbounds (i8, i8* bitcast (i16* @g to i8*), i64 0), %A],
+                  [getelementptr inbounds (i8, i8* bitcast (i16* @g to i8*), i64 1), %B]
+  %x  = load i8, i8* %addr
+  ret i8 %x
+}
+
+; ERROR: Value mismatch

--- a/tests/alive-tv/constexpr/phigep-fail.tgt.ll
+++ b/tests/alive-tv/constexpr/phigep-fail.tgt.ll
@@ -1,0 +1,17 @@
+@g = constant i16 1
+
+define i8 @f(i1 %cond) {
+  br i1 %cond, label %A, label %B
+A:
+  %g1 = bitcast i16* @g to i8*
+  %a1 = getelementptr inbounds i8, i8* %g1, i64 1
+  br label %EXIT
+B:
+  %g2 = bitcast i16* @g to i8*
+  %a2 = getelementptr inbounds i8, i8* %g2, i64 0
+  br label %EXIT
+EXIT:
+  %addr = phi i8* [%a1, %A], [%a2, %B]
+  %x  = load i8, i8* %addr
+  ret i8 %x
+}

--- a/tests/alive-tv/constexpr/phigep.src.ll
+++ b/tests/alive-tv/constexpr/phigep.src.ll
@@ -1,0 +1,18 @@
+@g = constant i16 0
+
+define i8 @f(i1 %cond) {
+  br i1 %cond, label %A, label %B
+A:
+  br label %EXIT
+B:
+  br label %EXIT
+EXIT:
+; %__constexpr_0 = bitcast * @g to *
+; %__constexpr_1 = bitcast * @g to *
+; %__constexpr_2 = gep inbounds * %__constexpr_1, 1 x i64 1
+; %addr = phi * [ %__constexpr_0, %A ], [ %__constexpr_2, %B ]
+  %addr = phi i8* [getelementptr inbounds (i8, i8* bitcast (i16* @g to i8*), i64 0), %A],
+                  [getelementptr inbounds (i8, i8* bitcast (i16* @g to i8*), i64 1), %B]
+  %x  = load i8, i8* %addr
+  ret i8 %x
+}

--- a/tests/alive-tv/constexpr/phigep.tgt.ll
+++ b/tests/alive-tv/constexpr/phigep.tgt.ll
@@ -1,0 +1,17 @@
+@g = constant i16 0
+
+define i8 @f(i1 %cond) {
+  br i1 %cond, label %A, label %B
+A:
+  %g1 = bitcast i16* @g to i8*
+  %a1 = getelementptr inbounds i8, i8* %g1, i64 0
+  br label %EXIT
+B:
+  %g2 = bitcast i16* @g to i8*
+  %a2 = getelementptr inbounds i8, i8* %g2, i64 1
+  br label %EXIT
+EXIT:
+  %addr = phi i8* [%a1, %A], [%a2, %B]
+  %x  = load i8, i8* %addr
+  ret i8 %x
+}

--- a/tools/transform.cpp
+++ b/tools/transform.cpp
@@ -356,7 +356,8 @@ Errors TransformVerify::verify() const {
   }
 
   State::resetGlobals();
-  State src_state(t.src, true), tgt_state(t.tgt, false);
+  State src_state(t.src_inits, t.src, true),
+        tgt_state(t.tgt_inits, t.tgt, false);
 
   try {
     sym_exec(src_state);
@@ -454,8 +455,14 @@ void Transform::print(ostream &os, const TransformPrintOpts &opt) const {
     precondition->print(os << "Pre: ");
     os << '\n';
   }
+  if (!src_inits.empty()) {
+    os << src_inits;
+  }
   src.print(os, opt.print_fn_header);
   os << "=>\n";
+  if (!tgt_inits.empty()) {
+    os << tgt_inits;
+  }
   tgt.print(os, opt.print_fn_header);
 }
 

--- a/tools/transform.h
+++ b/tools/transform.h
@@ -7,6 +7,7 @@
 #include "smt/solver.h"
 #include "util/errors.h"
 #include <string>
+#include <optional>
 #include <ostream>
 #include <unordered_map>
 
@@ -19,6 +20,7 @@ struct TransformPrintOpts {
 
 struct Transform {
   std::string name;
+  IR::Initializers src_inits, tgt_inits;
   IR::Function src, tgt;
   IR::Predicate *precondition = nullptr;
 

--- a/util/symexec.cpp
+++ b/util/symexec.cpp
@@ -13,6 +13,7 @@ using namespace std;
 namespace util {
 
 void sym_exec(State &s) {
+  Initializers &inits = const_cast<Initializers&>(s.getInitializers());
   Function &f = const_cast<Function&>(s.getFn());
 
   // add constants & inputs to State table first of all
@@ -24,6 +25,19 @@ void sym_exec(State &s) {
 
   s.exec(Value::voidVal);
 
+  // Run initializers
+  for (auto &glbinits : inits) {
+    for (auto &i : glbinits.second) {
+      auto val = s.exec(*i);
+      auto &name = i->getName();
+
+      if (config::symexec_print_each_value && name[0] == '%')
+        cout << name << " = " << val << '\n';
+    }
+  }
+  s.finishInitializer();
+
+  // Run the function.
   for (auto &bb : f.getBBs()) {
     if (!s.startBB(*bb))
       continue;


### PR DESCRIPTION
This PR converts constexprs to instructions (#176).

constexprs inside global vars are converted into corresponding instructions in Initializer block.

constexprs inside phis are placed just before phis.