### PR TITLE
Support constexprs in initializers

### DIFF
--- a/ir/function.cpp
+++ b/ir/function.cpp
@@ -73,10 +73,14 @@ void Function::fixupTypes(const Model &m) {
   }
 }
 
-BasicBlock& Function::getBB(string_view name) {
+BasicBlock& Function::getBB(string_view name, bool push_front) {
   auto p = BBs.try_emplace(string(name), name);
-  if (p.second)
-    BB_order.push_back(&p.first->second);
+  if (p.second) {
+    if (push_front)
+      BB_order.insert(BB_order.begin(), &p.first->second);
+    else
+      BB_order.push_back(&p.first->second);
+  }
   return p.first->second;
 }
 
@@ -96,6 +100,14 @@ vector<GlobalVariable *> Function::getGlobalVars() const {
       gvs.push_back(gv);
   }
   return gvs;
+}
+
+vector<string_view> Function::getGlobalVarNames() const {
+  vector<string_view> gvnames;
+  auto gvs = getGlobalVars();
+  transform(gvs.begin(), gvs.end(), back_inserter(gvnames),
+            [](auto itm) { return string_view(itm->getName()).substr(1); });
+  return gvnames;
 }
 
 void Function::addPredicate(unique_ptr<Predicate> &&p) {

--- a/ir/function.h
+++ b/ir/function.h
@@ -78,15 +78,18 @@ public:
   void fixupTypes(const smt::Model &m);
 
   const BasicBlock& getFirstBB() const { return *BB_order[0]; }
-  BasicBlock& getBB(std::string_view name);
+  BasicBlock& getBB(std::string_view name, bool push_front = false);
   const BasicBlock& getBB(std::string_view name) const;
 
   void addConstant(std::unique_ptr<Value> &&c);
   util::const_strip_unique_ptr<decltype(constants)> getConstants() const {
     return constants;
   }
+  unsigned numConstants() const { return constants.size(); }
+  Value &getConstant(int idx) const { return *constants[idx]; }
 
   std::vector<GlobalVariable *> getGlobalVars() const;
+  std::vector<std::string_view> getGlobalVarNames() const;
 
   void addPredicate(std::unique_ptr<Predicate> &&p);
 

--- a/ir/memory.cpp
+++ b/ir/memory.cpp
@@ -711,7 +711,7 @@ void Memory::store(const expr &p, const StateValue &v, const Type &type,
   vector<Byte> bytes = valueToBytes(v, type, *this);
 
   Pointer ptr(*this, p);
-  ptr.is_dereferenceable(bytes.size(), align, true);
+  ptr.is_dereferenceable(bytes.size(), align, !state->isInitializationPhase());
   for (unsigned i = 0, e = bytes.size(); i < e; ++i) {
     auto ptr_i = little_endian ? (ptr + i) : (ptr + (e - i - 1));
     store(ptr_i, bytes[i](), local_block_val, non_local_block_val);

--- a/ir/state.h
+++ b/ir/state.h
@@ -32,6 +32,7 @@ private:
   const Function &f;
   bool source;
   bool disable_undef_rewrite = false;
+  bool is_initialization_phase = true;
   smt::expr precondition = true;
   smt::expr axioms = true;
 
@@ -92,6 +93,9 @@ public:
   void addQuantVar(const smt::expr &var);
   void addUndefVar(smt::expr &&var);
   void resetUndefVars();
+
+  bool isInitializationPhase() const { return is_initialization_phase; }
+  void finishInitializer() { is_initialization_phase = false; }
 
   auto& getFn() const { return f; }
   auto& getMemory() { return memory; }

--- a/llvm_util/llvm2alive.h
+++ b/llvm_util/llvm2alive.h
@@ -6,6 +6,8 @@
 #include "ir/function.h"
 #include <optional>
 #include <ostream>
+#include <string>
+#include <vector>
 
 namespace llvm {
 class DataLayout;
@@ -20,5 +22,6 @@ struct initializer {
 };
 
 std::optional<IR::Function> llvm2alive(llvm::Function &F,
-                                       const llvm::TargetLibraryInfo &TLI);
+    const llvm::TargetLibraryInfo &TLI,
+    std::vector<std::string_view> &&gvnamesInSrc = {});
 }

--- a/llvm_util/utils.cpp
+++ b/llvm_util/utils.cpp
@@ -214,11 +214,10 @@ Value* get_operand(llvm::Value *v,
     }
     Value *initval = nullptr;
     if (gv->hasInitializer() && gv->isConstant()) {
-      if (isa<llvm::ConstantExpr>(gv->getInitializer()))
-        // TODO: not supported
-        return nullptr;
-      else if (!(initval = get_operand(gv->getInitializer(), constexpr_conv)))
-        return nullptr;
+      auto initializer = gv->getInitializer();
+      if (!isa<llvm::ConstantExpr>(initializer))
+        if (!(initval = get_operand(gv->getInitializer(), constexpr_conv)))
+          return nullptr;
     }
     int size = DL->getTypeAllocSize(gv->getValueType());
     int align = gv->getAlignment();

--- a/tests/alive-tv/constexpr/constgep-fail.src.ll
+++ b/tests/alive-tv/constexpr/constgep-fail.src.ll
@@ -1,0 +1,9 @@
+@x = constant i16 0
+@y = constant i8* getelementptr inbounds (i8, i8* bitcast (i16* @x to i8*), i64 0)
+
+define i8* @f() {
+  %p = load i8*, i8** @y
+  ret i8* %p
+}
+
+; ERROR: Value mismatch

--- a/tests/alive-tv/constexpr/constgep-fail.tgt.ll
+++ b/tests/alive-tv/constexpr/constgep-fail.tgt.ll
@@ -1,0 +1,9 @@
+@x = constant i16 0
+@y = constant i8* getelementptr inbounds (i8, i8* bitcast (i16* @x to i8*), i64 0)
+
+define i8* @f() {
+  %p = load i8*, i8** @y ; to relieve mismatch in memory error
+  %a = bitcast i16* @x to i8*
+  %b = getelementptr inbounds i8, i8* %a, i64 1
+  ret i8* %b
+}

--- a/tests/alive-tv/constexpr/constgep.src.ll
+++ b/tests/alive-tv/constexpr/constgep.src.ll
@@ -1,0 +1,7 @@
+@x = constant i16 0
+@y = constant i8* getelementptr inbounds (i8, i8* bitcast (i16* @x to i8*), i64 0)
+
+define i8* @f() {
+  %p = load i8*, i8** @y
+  ret i8* %p
+}

--- a/tests/alive-tv/constexpr/constgep.tgt.ll
+++ b/tests/alive-tv/constexpr/constgep.tgt.ll
@@ -1,0 +1,9 @@
+@x = constant i16 0
+@y = constant i8* getelementptr inbounds (i8, i8* bitcast (i16* @x to i8*), i64 0)
+
+define i8* @f() {
+  %p = load i8*, i8** @y ; to relieve mismatch in memory error
+  %a = bitcast i16* @x to i8*
+  %b = getelementptr inbounds i8, i8* %a, i64 0
+  ret i8* %b
+}

--- a/tests/alive-tv/constexpr/cycle.src.ll
+++ b/tests/alive-tv/constexpr/cycle.src.ll
@@ -1,0 +1,7 @@
+@g1 = constant i8* bitcast (i8** getelementptr inbounds (i8*, i8** @g2, i64 1) to i8*)
+@g2 = constant i8* bitcast (i8** getelementptr inbounds (i8*, i8** @g1, i64 1) to i8*)
+
+define i8* @f() {
+  %x  = load i8*, i8** @g2
+  ret i8* %x
+}

--- a/tests/alive-tv/constexpr/cycle.tgt.ll
+++ b/tests/alive-tv/constexpr/cycle.tgt.ll
@@ -1,0 +1,6 @@
+@g1 = constant i8* bitcast (i8** getelementptr inbounds (i8*, i8** @g2, i64 1) to i8*)
+@g2 = constant i8* bitcast (i8** getelementptr inbounds (i8*, i8** @g1, i64 1) to i8*)
+
+define i8* @f() {
+  ret i8* bitcast (i8** getelementptr inbounds (i8*, i8** @g1, i64 1) to i8*)
+}

--- a/tests/alive-tv/globalopt.src.ll
+++ b/tests/alive-tv/globalopt.src.ll
@@ -1,0 +1,8 @@
+@g = constant i32 0
+
+define i32 @f() {
+  %v = load i32, i32* @g
+  ret i32 %v
+}
+
+; ERROR: Unsupported interprocedural transformation

--- a/tests/alive-tv/globalopt.tgt.ll
+++ b/tests/alive-tv/globalopt.tgt.ll
@@ -1,5 +1,3 @@
-@x = global i32 0, align 4
-
 define i32 @f() {
   ret i32 0
 }

--- a/tests/alive-tv/memory/glb-1.src.ll
+++ b/tests/alive-tv/memory/glb-1.src.ll
@@ -4,5 +4,3 @@ define i32 @f() {
   %v = load i32, i32* @x
   ret i32 %v
 }
-
-; XFAIL: Mismatch in memory

--- a/tests/alive-tv/memory/glb-align-fail.tgt.ll
+++ b/tests/alive-tv/memory/glb-align-fail.tgt.ll
@@ -1,4 +1,4 @@
-@x = constant i32 0, align 4
+@x = global i32 0, align 4
 
 define i32 @f() {
   ret i32 1

--- a/tests/alive-tv/refinement/const-fail.src.ll
+++ b/tests/alive-tv/refinement/const-fail.src.ll
@@ -1,0 +1,10 @@
+@x = internal constant i32 0
+@y = internal constant i32 1
+
+define void @f() {
+  %a = load i32, i32* @x
+  %b = load i32, i32* @y
+  ret void
+}
+
+; ERROR: Mismatch in memory

--- a/tests/alive-tv/refinement/const-fail.tgt.ll
+++ b/tests/alive-tv/refinement/const-fail.tgt.ll
@@ -1,0 +1,8 @@
+@x = internal constant i32 1
+@y = internal constant i32 0
+
+define void @f() {
+  %a = load i32, i32* @x
+  %b = load i32, i32* @y
+  ret void
+}

--- a/tools/alive-tv.cpp
+++ b/tools/alive-tv.cpp
@@ -202,7 +202,7 @@ static bool compareFunctions(llvm::Function &F1, llvm::Function &F2,
   }
 
   auto Func2 = llvm2alive(F2, llvm::TargetLibraryInfoWrapperPass(targetTriple)
-                                    .getTLI(F2));
+                                    .getTLI(F2), Func1->getGlobalVarNames());
   if (!Func2) {
     cerr << "ERROR: Could not translate '" << F2.getName().str()
          << "' to Alive IR\n";

--- a/util/symexec.cpp
+++ b/util/symexec.cpp
@@ -24,6 +24,7 @@ void sym_exec(State &s) {
 
   s.exec(Value::voidVal);
 
+  bool first = true;
   for (auto &bb : f.getBBs()) {
     if (!s.startBB(*bb))
       continue;
@@ -34,6 +35,10 @@ void sym_exec(State &s) {
 
       if (config::symexec_print_each_value && name[0] == '%')
         cout << name << " = " << val << '\n';
+    }
+    if (first) {
+      s.finishInitializer();
+      first = false;
     }
   }
 


### PR DESCRIPTION
This PR creates a standalone basic block which is called "initializer block", and let llvm2alive.cpp add constexprs of initializers to it.

This patch helps LLVM's `Transforms/GlobalOpt/array-elem-refs.ll` pass.

The output of `alive-tv constgep.src.ll constgep.tgt.ll` looks like this:

```
{
__globalvars_init:
  %__constexpr_0 = bitcast * @x to *
  store * %__constexpr_0, * @y, align 1
}
define * @f() {
%0:
  %p = load *, * @y, align 8
  ret * %p
}
=>
{
__globalvars_init:
  %__constexpr_1 = bitcast * @x to *
  store * %__constexpr_1, * @y, align 1
}
define * @f() {
%0:
  %p = load *, * @y, align 8
  %a = bitcast * @x to *
  %b = gep inbounds * %a, 1 x i64 0
  ret * %b
}
Transformation seems to be correct!

```