### PR TITLE
nullptr_is_used should consider undef pointer too

### DIFF
--- a/tests/alive-tv/memory/undefptr.src.ll
+++ b/tests/alive-tv/memory/undefptr.src.ll
@@ -1,0 +1,6 @@
+define void @f() {
+  %a = bitcast i8* undef to i32*
+  %b = getelementptr i32, i32* %a, i32 1
+  store i32 undef, i32* %b
+  ret void
+}

--- a/tests/alive-tv/memory/undefptr.tgt.ll
+++ b/tests/alive-tv/memory/undefptr.tgt.ll
@@ -1,0 +1,6 @@
+define void @f() {
+  %a = bitcast i8* undef to i32*
+  %b = getelementptr i32, i32* %a, i32 1
+  store i32 undef, i32* %b
+  unreachable
+}

--- a/tools/transform.cpp
+++ b/tools/transform.cpp
@@ -320,7 +320,9 @@ static void check_refinement(Errors &errs, Transform &t,
 }
 
 static bool has_nullptr(const Value *v) {
-  if (dynamic_cast<const NullPointerValue*>(v))
+  if (dynamic_cast<const NullPointerValue*>(v) ||
+      (dynamic_cast<const UndefValue*>(v) && v->getType().isPtrType()))
+      // undef pointer points to the nullblk
     return true;
 
   if (auto agg = dynamic_cast<const AggregateConst*>(v)) {


### PR DESCRIPTION
This PR addresses about 20 "Assertion `!memory_unused()' failed." error from LLVM unit tests.

nullptr_is_used should consider undef pointer because undef pointer is pointing to a null block.