### PR TITLE
Unsupport function argument attributes by default

### DIFF
--- a/llvm_util/llvm2alive.cpp
+++ b/llvm_util/llvm2alive.cpp
@@ -635,8 +635,11 @@ public:
     auto attrs = arg.getParent()->getAttributes()
                  .getParamAttributes(arg.getArgNo());
     for (auto attr : attrs) {
-      *out << "ERROR: Unsupported attribute: " << attr.getAsString() << '\n';
-      return false;
+      switch (attr.getKindAsEnum()) {
+      default:
+        *out << "ERROR: Unsupported attribute: " << attr.getAsString() << '\n';
+        return false;
+      }
     }
     return true;
   }

--- a/llvm_util/llvm2alive.cpp
+++ b/llvm_util/llvm2alive.cpp
@@ -631,6 +631,16 @@ public:
     return true;
   }
 
+  bool handleAttributes(llvm::Argument &arg) {
+    auto attrs = arg.getParent()->getAttributes()
+                 .getParamAttributes(arg.getArgNo());
+    for (auto attr : attrs) {
+      *out << "ERROR: Unsupported attribute: " << attr.getAsString() << '\n';
+      return false;
+    }
+    return true;
+  }
+
   optional<Function> run() {
     auto type = llvm_type2alive(f.getReturnType());
     if (!type)
@@ -646,6 +656,9 @@ public:
       auto val = make_unique<Input>(*ty, value_name(arg));
       add_identifier(arg, *val.get());
       Fn.addInput(move(val));
+
+      if (!handleAttributes(arg))
+        return {};
     }
 
     // create all BBs upfront to keep LLVM's order

--- a/scripts/stats.php
+++ b/scripts/stats.php
@@ -25,7 +25,7 @@ foreach (glob("$logs/*.txt") as $f) {
     @$stats[$stat[1]] += (int)$stat[2];
   }
 
-  preg_match_all('/Unsupported (?:instruction|type):\s*(.+)/S', $txt, $m);
+  preg_match_all('/Unsupported (?:instruction|type|attribute):\s*(.+)/S', $txt, $m);
   foreach ($m[1] as $str) {
     if (preg_match('/%\S+ = ([^%[(]+)/S', $str, $m2)) {
       @++$unsupported[trim($m2[1])];

--- a/tests/alive-tv/memory/gep-struct1-fail.src.ll
+++ b/tests/alive-tv/memory/gep-struct1-fail.src.ll
@@ -2,7 +2,7 @@ target datalayout = "e-i32:32-i128:32-i16:16"
 
 %0 = type { i32, i128, i16 }
 
-define i64 @0(%0* nocapture) {
+define i64 @0(%0*) {
   %2 = getelementptr inbounds %0, %0* %0, i32 0, i32 2
   %3 = ptrtoint %0* %0 to i64
   %4 = ptrtoint i16* %2 to i64

--- a/tests/alive-tv/memory/gep-struct1-fail.tgt.ll
+++ b/tests/alive-tv/memory/gep-struct1-fail.tgt.ll
@@ -2,6 +2,6 @@ target datalayout = "e-i32:32-i128:32-i16:16"
 
 %0 = type { i32, i128, i16 }
 
-define i64 @0(%0* nocapture) {
+define i64 @0(%0*) {
   ret i64 24
 }

--- a/tests/alive-tv/memory/gep-struct1.src.ll
+++ b/tests/alive-tv/memory/gep-struct1.src.ll
@@ -2,7 +2,7 @@ target datalayout = "e-i32:32-i128:32-i16:16"
 
 %0 = type { i32, i128, i16 }
 
-define i64 @0(%0* nocapture) {
+define i64 @0(%0*) {
   %2 = getelementptr inbounds %0, %0* %0, i32 0, i32 2
   %3 = ptrtoint %0* %0 to i64
   %4 = ptrtoint i16* %2 to i64

--- a/tests/alive-tv/memory/gep-struct1.tgt.ll
+++ b/tests/alive-tv/memory/gep-struct1.tgt.ll
@@ -2,6 +2,6 @@ target datalayout = "e-i32:32-i128:32-i16:16"
 
 %0 = type { i32, i128, i16 }
 
-define i64 @0(%0* nocapture) {
+define i64 @0(%0*) {
   ret i64 20
 }

--- a/tests/alive-tv/memory/gep-struct2.src.ll
+++ b/tests/alive-tv/memory/gep-struct2.src.ll
@@ -5,7 +5,7 @@ target datalayout = "e-i32:32-i128:32-i8:8"
 ; struct S1 { X(i32); Y(i8); Z(i8); }
 ; struct S2 {A(i32); B(i128); S1[5]; }
 ; %0 = S2[10]
-define i64 @0(%0* nocapture) {
+define i64 @0(%0*) {
 ; %2 points to: S2[2]->S1[3]->Z
   %2 = getelementptr inbounds %0, %0* %0, i32 0, i32 2, i32 2, i32 3, i32 2
   %3 = ptrtoint %0* %0 to i64

--- a/tests/alive-tv/memory/gep-struct2.tgt.ll
+++ b/tests/alive-tv/memory/gep-struct2.tgt.ll
@@ -5,7 +5,7 @@ target datalayout = "e-i32:32-i128:32-i8:8"
 ; struct S1 { X(i32); Y(i8); Z(i8); }
 ; struct S2 {A(i32); B(i128); S1[5]; }
 ; %0 = S2[10]
-define i64 @0(%0* nocapture) {
+define i64 @0(%0*) {
 ; %2 points to: S2[2]->S1[3]->Z
   ret i64 169
 }

--- a/tests/alive-tv/memory/memset-fn.tgt.ll
+++ b/tests/alive-tv/memory/memset-fn.tgt.ll
@@ -1,6 +1,6 @@
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
 
-define i32* @f(i32* returned %ptr, i32 %val, i64 %len) {
+define i32* @f(i32* %ptr, i32 %val, i64 %len) {
   %p = bitcast i32* %ptr to i8*
   %1 = trunc i32 %val to i8
   tail call void @llvm.memset.p0i8.i64(i8* align 1 %p, i8 %1, i64 %len, i1 false)


### PR DESCRIPTION
Function arguments' attributes were being ignored, causing verification failure.

Unit test failures: 242 -> 223.

Unsupported IR features: 
```
Unsupported IR features (Top 20):                                                                                                                                                                                                             
3324  getelementptr inbounds                                                                                                                                                                                                                  
2789  phi i32                                                                                                                                                                                                                                 
>> 2237  nocapture                                                                                                                                                                                                                               
1429  phi i64                                                                                                                                                                                                                                 
>> 1387  noalias                                                                                                                                                                                                                                 
1172  bitcast                                                                                                                                                                                                                                 
635 fpext float                                                                                                                                                                                                                               
407 load i32, i32* getelementptr inbounds                                                                                                                                                                                                     
404 load i64, i64* getelementptr inbounds                                                                                                                                                                                                     
>> 353 zeroext                                                                                                                                                                                                                                   
327 load i16, i16* getelementptr inbounds                                                                                                                                                                                                     
320 load i8, i8* getelementptr inbounds                                                                                                                                                                                                       
290 load float, float* getelementptr inbounds                                                                                                                                                                                                 
265 getelementptr                                                                                                                                                                                                                             
252 load double, double* getelementptr inbounds                                                                                                                                                                                               
207 call i32                                                                                                                                                                                                                                  
192 tail call i8* @llvm.objc.retain                                                                                                                                                                                                           
>> 192 signext                                                                                                                                                                                                                                   
142 call i1 @llvm.type.test                                                                                                                                                                                                                   
125 call i8* @llvm.objc.retain   
```

The semantics of nocapture is needed.