### PR TITLE
Initialize global variables too

### DIFF
--- a/llvm_util/llvm2alive.cpp
+++ b/llvm_util/llvm2alive.cpp
@@ -718,7 +718,7 @@ public:
       if (!GV)
         continue;
       auto gv = M->getGlobalVariable(GV->getName().substr(1), true);
-      if (!gv->isConstant() || !gv->hasInitializer())
+      if (!gv->hasInitializer())
         continue;
 
       auto storedval = get_operand(gv->getInitializer());

--- a/tests/alive-tv/memory/glb-fail-2.src.ll
+++ b/tests/alive-tv/memory/glb-fail-2.src.ll
@@ -4,5 +4,3 @@ define i32 @f() {
   %v = load i32, i32* @x
   ret i32 %v
 }
-
-; ERROR: Value mismatch


### PR DESCRIPTION
I may have missed something but is there any reason we are not initializing the global variables now since we have the support for initializing them?