### PR TITLE
Support clang plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,20 +91,10 @@ Running Alive2 as a Clang plugin:
 
 ```
 $ clang -O3 <src.c> -S -emit-llvm \
-  -fpass-plugin=$HOME/alive2/build/tv/tv.dylib -fexperimental-new-pass-manager \
-  -Xclang -load -Xclang $HOME/alive2/build/tv/tv.dylib \
-  -mllvm -tv-report-dir="build/logs" \
-  -mllvm -tv-exit-on-error
+  -fpass-plugin=$HOME/alive2/build/tv/tv.so -fexperimental-new-pass-manager \
+  -Xclang -load -Xclang $HOME/alive2/build/tv/tv.so
 ```
 
-If Alive2 finds an incorrect transformation, it will print a message like
-following:
-
-```
-$ clang -O3 ...<omitted>
-Report written to build/logs/a_2495581251.txt
-fatal error: error in backend: Alive2: Transform doesn't verify; aborting!
-```
 
 Running Standalone Translation Validation Tool (alive-tv)
 --------

--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ the ``-DZ3_INCLUDE_DIR=/path/to/z3/include`` argument to CMake
 Building and Running Translation Validation
 --------
 
-Alive2's `opt` translation validation requires a build of LLVM with RTTI and
-exceptions turned on.
+Alive2's `opt` and `clang` translation validation requires a build of LLVM with
+RTTI and exceptions turned on.
 LLVM can be built in the following way:
 ```
 cd llvm
@@ -63,6 +63,9 @@ Alive2 should then be configured as follows:
 ```
 cmake -GNinja -DLLVM_DIR=~/llvm/build/lib/cmake/llvm -DBUILD_TV=1 -DCMAKE_BUILD_TYPE=Release ..
 ```
+
+If you want to use Alive2 as a clang plugin, add `-DCLANG_PLUGIN=1` to the
+cmake command.
 
 
 Translation validation of a single test case:
@@ -84,6 +87,24 @@ Translation validation of the LLVM unit tests:
 ~/llvm/build/bin/llvm-lit -vv -Dopt=/home/user/alive2/scripts/opt-alive.sh ~/llvm/llvm/test/Transforms
 ```
 
+Running Alive2 as a Clang plugin:
+
+```
+$ clang -O3 <src.c> -S -emit-llvm \
+  -fpass-plugin=$HOME/alive2/build/tv/tv.dylib -fexperimental-new-pass-manager \
+  -Xclang -load -Xclang $HOME/alive2/build/tv/tv.dylib \
+  -mllvm -tv-report-dir="build/logs" \
+  -mllvm -tv-exit-on-error
+```
+
+If Alive2 finds an incorrect transformation, it will print a message like
+following:
+
+```
+$ clang -O3 ...<omitted>
+Report written to build/logs/a_2495581251.txt
+fatal error: error in backend: Alive2: Transform doesn't verify; aborting!
+```
 
 Running Standalone Translation Validation Tool (alive-tv)
 --------

--- a/tv/CMakeLists.txt
+++ b/tv/CMakeLists.txt
@@ -5,6 +5,13 @@ else()
   add_llvm_library(tv MODULE tv.cpp)
 endif()
 
+if (CLANG_PLUGIN)
+  message(STATUS "Clang plugin support enabled")
+  set_target_properties(tv PROPERTIES
+      COMPILE_FLAGS "-DCLANG_PLUGIN"
+  )
+endif()
+
 target_link_libraries(tv PRIVATE ${ALIVE_LIBS_LLVM} ${Z3_LIBRARIES}
   $<$<AND:$<CXX_COMPILER_ID:GNU>,$<VERSION_LESS:$<CXX_COMPILER_VERSION>,9.0>>:stdc++fs>)
 


### PR DESCRIPTION
This is a patch that let alive2 run as a clang plugin.
It uses the new pass manager to get callback after each pass. It seems the new pass manager is working pretty well.
To make this PR work, https://reviews.llvm.org/D71086 needs to be reviewed. It is adding just a couple of lines to LLVM's header.

```
clang -fpass-plugin=build/tv/tv.dylib -fexperimental-new-pass-manager -O3 a.c -S -emit-llvm \
  -Xclang -load -Xclang tv/tv.dylib
```
You can give additional arguments with -mllvm (e.g. -mllvm -tv-smt-to=2000)
