### PR TITLE
Fix assertion failure when GlobalVariable::toSMT is called twice in src

### DIFF
--- a/ir/state.cpp
+++ b/ir/state.cpp
@@ -207,6 +207,8 @@ void State::copyGlobalVarBidsFromSrc(const State &src) {
   assert(glbvar_bids.empty());
   assert(src.isSource());
   glbvar_bids = src.glbvar_bids;
+  for (auto &itm : glbvar_bids)
+    itm.second.second = false;
 
   Memory::resetLocalBids();
 }

--- a/ir/state.cpp
+++ b/ir/state.cpp
@@ -183,16 +183,24 @@ void State::resetUndefVars() {
 }
 
 void State::addGlobalVarBid(const string &glbvar, unsigned bid) {
-  ENSURE(glbvar_bids.emplace(glbvar, bid).second);
+  ENSURE(glbvar_bids.emplace(glbvar, make_pair(bid, true)).second);
 }
 
-bool State::hasGlobalVarBid(const string &glbvar, unsigned &bid) const {
+bool State::hasGlobalVarBid(const string &glbvar, unsigned &bid,
+                            bool &allocated) const {
   auto itr = glbvar_bids.find(glbvar);
   bool found = itr != glbvar_bids.end();
   if (found) {
-    bid = itr->second;
+    bid = itr->second.first;
+    allocated = itr->second.second;
   }
   return found;
+}
+
+void State::markGlobalAsAllocated(const string &glbvar) {
+  auto itr = glbvar_bids.find(glbvar);
+  assert(itr != glbvar_bids.end());
+  itr->second.second = true;
 }
 
 void State::copyGlobalVarBidsFromSrc(const State &src) {

--- a/ir/state.h
+++ b/ir/state.h
@@ -50,8 +50,8 @@ private:
     predecessor_data;
   std::unordered_set<const BasicBlock*> seen_bbs;
 
-  // Global variables' memory block ids
-  std::unordered_map<std::string, unsigned> glbvar_bids;
+  // Global variables' memory block ids & Memory::alloc has been called?
+  std::unordered_map<std::string, std::pair<unsigned, bool> > glbvar_bids;
 
   // temp state
   DomainTy domain;
@@ -118,8 +118,10 @@ public:
 
   void addGlobalVarBid(const std::string &glbvar, unsigned bid);
   // Checks whether glbvar has block id assigned.
-  // If it has, bid is updated with the block id.
-  bool hasGlobalVarBid(const std::string &glbvar, unsigned &bid) const;
+  // If it has, bid is updated with the block id, and allocated is updated too.
+  bool hasGlobalVarBid(const std::string &glbvar, unsigned &bid,
+                       bool &allocated) const;
+  void markGlobalAsAllocated(const std::string &glbvar);
   void copyGlobalVarBidsFromSrc(const State &src);
 
 private:

--- a/tests/alive-tv/constexpr/aggregate2.src.ll
+++ b/tests/alive-tv/constexpr/aggregate2.src.ll
@@ -1,0 +1,8 @@
+@a = constant i8 0
+@x = constant { i8*, i8* } { i8* @a, i8* @a }
+
+define i8* @f() {
+  %a = load { i8*, i8* }, { i8*, i8* }* @x
+  %b = extractvalue {i8*, i8*} %a, 0
+  ret i8* %b
+}

--- a/tests/alive-tv/constexpr/aggregate2.tgt.ll
+++ b/tests/alive-tv/constexpr/aggregate2.tgt.ll
@@ -1,0 +1,6 @@
+@a = constant i8 0
+@x = constant { i8*, i8* } { i8* @a, i8* @a }
+
+define i8* @f() {
+  ret i8* @a
+}


### PR DESCRIPTION
This resolves issue #205.

GlobalVariable::toSMT() checks whether it is being called twice, and if it does, calls Memory::alloc() only once.