### PR TITLE
Implement array (no padding)

### DIFF
--- a/ir/type.cpp
+++ b/ir/type.cpp
@@ -805,7 +805,6 @@ const AggregateType* AggregateType::getAsAggregateType() const {
 
 ArrayType::ArrayType(string &&name, unsigned elements, Type &elementTy)
   : AggregateType(move(name), false) {
-  assert(elements != 0);
   this->elements = elements;
   defined = true;
   children.resize(elements, &elementTy);

--- a/ir/type.cpp
+++ b/ir/type.cpp
@@ -816,8 +816,7 @@ bool ArrayType::isArrayType() const {
 }
 
 void ArrayType::print(ostream &os) const {
-  if (elements)
-    os << '[' << elements << " x " << *children[0] << ']';
+  os << '[' << elements << " x " << *children[0] << ']';
 }
 
 

--- a/ir/type.cpp
+++ b/ir/type.cpp
@@ -803,9 +803,13 @@ const AggregateType* AggregateType::getAsAggregateType() const {
 }
 
 
-expr ArrayType::getTypeConstraints() const {
-  // TODO
-  return false;
+ArrayType::ArrayType(string &&name, unsigned elements, Type &elementTy)
+  : AggregateType(move(name), false) {
+  assert(elements != 0);
+  this->elements = elements;
+  defined = true;
+  children.resize(elements, &elementTy);
+  is_padding.resize(elements, false);
 }
 
 bool ArrayType::isArrayType() const {
@@ -813,7 +817,8 @@ bool ArrayType::isArrayType() const {
 }
 
 void ArrayType::print(ostream &os) const {
-  os << "TODO";
+  if (elements)
+    os << '[' << elements << " x " << *children[0] << ']';
 }
 
 

--- a/ir/type.h
+++ b/ir/type.h
@@ -281,7 +281,8 @@ public:
 class ArrayType final : public AggregateType {
 public:
   ArrayType(std::string &&name) : AggregateType(std::move(name)) {}
-  smt::expr getTypeConstraints() const override;
+  ArrayType(std::string &&name, unsigned elements, Type &elementTy);
+
   bool isArrayType() const override;
   void print(std::ostream &os) const override;
 };

--- a/tests/alive-tv/constexpr/string.src.ll
+++ b/tests/alive-tv/constexpr/string.src.ll
@@ -1,0 +1,48 @@
+;target datalayout = "e-m:o-i64:64-f80:128-n8:16:32:64-S128"
+;target triple = "x86_64-apple-macosx10.15.0"
+
+@.str = constant [6 x i8] c"hello\00", align 1
+@aa = constant i8* getelementptr inbounds ([6 x i8], [6 x i8]* @.str, i32 0, i32 0)
+
+define i8 @h() {
+  %aa = load i8*, i8** @aa
+  %c = load i8, i8* %aa
+  ret i8 %c
+}
+
+define i8 @e() {
+  %aa = load i8*, i8** @aa
+  %p = getelementptr i8, i8* %aa, i32 1
+  %c = load i8, i8* %p
+  ret i8 %c
+}
+
+define i8 @l() {
+  %aa = load i8*, i8** @aa
+  %p = getelementptr i8, i8* %aa, i32 2
+  %c = load i8, i8* %p
+  ret i8 %c
+}
+
+define i8 @l2() {
+  %aa = load i8*, i8** @aa
+  %p = getelementptr i8, i8* %aa, i32 3
+  %c = load i8, i8* %p
+  ret i8 %c
+}
+
+define i8 @o() {
+  %aa = load i8*, i8** @aa
+  %p = getelementptr i8, i8* %aa, i32 4
+  %c = load i8, i8* %p
+  ret i8 %c
+}
+
+define i8 @zero() {
+  %aa = load i8*, i8** @aa
+  %p = getelementptr i8, i8* %aa, i32 5
+  %c = load i8, i8* %p
+  ret i8 %c
+}
+
+

--- a/tests/alive-tv/constexpr/string.tgt.ll
+++ b/tests/alive-tv/constexpr/string.tgt.ll
@@ -1,0 +1,31 @@
+;target datalayout = "e-m:o-i64:64-f80:128-n8:16:32:64-S128"
+;target triple = "x86_64-apple-macosx10.15.0"
+
+@.str = constant [6 x i8] c"hello\00", align 1
+@aa = constant i8* getelementptr inbounds ([6 x i8], [6 x i8]* @.str, i32 0, i32 0)
+
+define i8 @h() {
+  ret i8 104
+}
+
+define i8 @e() {
+  ret i8 101
+}
+
+define i8 @l() {
+  ret i8 108
+}
+
+define i8 @l2() {
+  ret i8 108
+}
+
+define i8 @o() {
+  ret i8 111
+}
+
+define i8 @zero() {
+  ret i8 0
+}
+
+


### PR DESCRIPTION
This implements array type without paddings.
Unlike vector, array only has static number of elements.
Next I'll be working on array paddings. For example, [2 x i24] has paddings between elements.
Also I'll find fix for random failures in LLVM unit tests too.