### PR TITLE
Add tests for reordering between ptrtoint & free

### DIFF
--- a/tests/alive-tv/memory/ptrtoint-free-reorder-fail.src.ll
+++ b/tests/alive-tv/memory/ptrtoint-free-reorder-fail.src.ll
@@ -1,0 +1,16 @@
+target datalayout = "e-p:64:64"
+define i64 @f() {
+  %p = call noalias i8* @malloc(i64 10)
+  %c = icmp eq i8* %p, null
+  br i1 %c, label %EXIT, label %BB
+EXIT:
+  ret i64 1
+BB:
+  call void @free(i8* %p)
+  %i = ptrtoint i8* %p to i64
+  ret i64 %i
+}
+
+; ERROR: Value mismatch
+declare void @free(i8*)
+declare noalias i8* @malloc(i64)

--- a/tests/alive-tv/memory/ptrtoint-free-reorder-fail.tgt.ll
+++ b/tests/alive-tv/memory/ptrtoint-free-reorder-fail.tgt.ll
@@ -1,0 +1,11 @@
+target datalayout = "e-p:64:64"
+define i64 @f() {
+  %p = call noalias i8* @malloc(i64 10)
+  %i0 = ptrtoint i8* %p to i64
+  %i = add i64 %i0, 1
+  call void @free(i8* %p)
+  ret i64 %i
+}
+
+declare void @free(i8*)
+declare noalias i8* @malloc(i64)

--- a/tests/alive-tv/memory/ptrtoint-free-reorder.src.ll
+++ b/tests/alive-tv/memory/ptrtoint-free-reorder.src.ll
@@ -1,0 +1,10 @@
+target datalayout = "e-p:64:64"
+define i64 @f() {
+  %p = call noalias i8* @malloc(i64 10)
+  call void @free(i8* %p)
+  %i = ptrtoint i8* %p to i64
+  ret i64 %i
+}
+
+declare void @free(i8*)
+declare noalias i8* @malloc(i64)

--- a/tests/alive-tv/memory/ptrtoint-free-reorder.tgt.ll
+++ b/tests/alive-tv/memory/ptrtoint-free-reorder.tgt.ll
@@ -1,0 +1,10 @@
+target datalayout = "e-p:64:64"
+define i64 @f() {
+  %p = call noalias i8* @malloc(i64 10)
+  %i = ptrtoint i8* %p to i64
+  call void @free(i8* %p)
+  ret i64 %i
+}
+
+declare void @free(i8*)
+declare noalias i8* @malloc(i64)


### PR DESCRIPTION
This adds sanity checks for #171 .

Right now the `local_blk_addr.del` at Memory::free never happens unless the program has UB (malloc.is_local() is never true, and freeing alloca is UB), so just adding tests seems enough.

