### PR TITLE
Fix assertion failure at expr::load when optimizing lambda

### DIFF
--- a/smt/expr.cpp
+++ b/smt/expr.cpp
@@ -1288,9 +1288,10 @@ expr expr::load(const expr &idx) const {
 
     auto extract_load = [&idx](expr &e, const expr &var) {
       if (auto app = e.isAppOf(Z3_OP_SELECT)) { // load(array, idx)
-        assert(expr(Z3_get_app_arg(ctx(), app, 1)).eq(var));
-        e = expr(Z3_get_app_arg(ctx(), app, 0)).load(idx);
-        return true;
+        if (expr(Z3_get_app_arg(ctx(), app, 1)).eq(var)) {
+          e = expr(Z3_get_app_arg(ctx(), app, 0)).load(idx);
+          return true;
+        }
       }
       return false;
     };


### PR DESCRIPTION
At some point, the second argument of app can also have form `((_ extract 66 0) (concat #x2 ((_ extract 63 0) (:var 0)))))`.
Test case: Transforms/GVN/pr17732.ll