### PR TITLE
Support gep with vector operands, let num_ptrinputs count ptr elems in aggregates

### DIFF
--- a/ir/instr.cpp
+++ b/ir/instr.cpp
@@ -1826,39 +1826,65 @@ void GEP::print(std::ostream &os) const {
 }
 
 StateValue GEP::toSMT(State &s) const {
-  auto [val, non_poison] = s[*ptr];
-
-  Pointer ptr(s.getMemory(), move(val));
-  if (inbounds)
-    non_poison &= ptr.inbounds();
-
-  for (auto &[sz, idx] : idxs) {
-    auto &[v, np] = s[*idx];
-    auto multiplier = expr::mkUInt(sz, bits_for_offset);
-    auto val = v.sextOrTrunc(bits_for_offset);
-    auto inc = multiplier * val;
-
-    if (inbounds) {
-      non_poison &= multiplier.mul_no_soverflow(val);
-      non_poison &= ptr.add_no_overflow(inc);
-    }
-
-    ptr += inc;
-    non_poison &= np;
+  auto scalar = [&](const StateValue &ptrval,
+                    vector<pair<unsigned, StateValue>> &offsets)
+      -> StateValue {
+    auto non_poison = ptrval.non_poison;
+    Pointer ptr(s.getMemory(), ptrval.value);
 
     if (inbounds)
       non_poison &= ptr.inbounds();
+
+    for (auto &[sz, idx] : offsets) {
+      auto &[v, np] = idx;
+      auto multiplier = expr::mkUInt(sz, bits_for_offset);
+      auto val = v.sextOrTrunc(bits_for_offset);
+      auto inc = multiplier * val;
+
+      if (inbounds) {
+        non_poison &= multiplier.mul_no_soverflow(val);
+        non_poison &= ptr.add_no_overflow(inc);
+      }
+
+      ptr += inc;
+      non_poison &= np;
+
+      if (inbounds)
+        non_poison &= ptr.inbounds();
+    }
+    return { ptr.release(), expr(non_poison) };
+  };
+
+  if (auto ptr_aty = ptr->getType().getAsAggregateType()) {
+    vector<StateValue> vals;
+    auto &ptrval = s[*ptr];
+    for (unsigned i = 0, e = ptr_aty->numElementsConst(); i != e; ++i) {
+      vector<pair<unsigned, StateValue>> offsets;
+      for (auto &[sz, idx] : idxs) {
+        if (auto idx_aty = idx->getType().getAsAggregateType())
+          offsets.emplace_back(sz, idx_aty->extract(s[*idx], i));
+        else
+          offsets.emplace_back(sz, s[*idx]);
+      }
+      vals.emplace_back(scalar(ptr_aty->extract(ptrval, i), offsets));
+    }
+    return getType().getAsAggregateType()->aggregateVals(vals);
   }
-  return { ptr.release(), move(non_poison) };
+  vector<pair<unsigned, StateValue>> offsets;
+  for (auto &[sz, idx] : idxs)
+    offsets.emplace_back(sz, s[*idx]);
+  return scalar(s[*ptr], offsets);
 }
 
 expr GEP::getTypeConstraints(const Function &f) const {
   auto c = Value::getTypeConstraints() &&
            getType() == ptr->getType() &&
-           getType().enforcePtrType();
+           getType().enforcePtrOrVectorType();
   for (auto &[sz, idx] : idxs) {
     (void)sz;
-    c &= idx->getType().enforceIntType();
+    // It is allowed to have non-vector idx with vector pointer operand
+    c &= idx->getType().enforceIntOrVectorType() &&
+          getType().enforceVectorTypeIff(idx->getType());
   }
   return c;
 }

--- a/ir/instr.cpp
+++ b/ir/instr.cpp
@@ -1852,7 +1852,7 @@ StateValue GEP::toSMT(State &s) const {
       if (inbounds)
         non_poison &= ptr.inbounds();
     }
-    return { ptr.release(), expr(non_poison) };
+    return { ptr.release(), move(non_poison) };
   };
 
   if (auto ptr_aty = ptr->getType().getAsAggregateType()) {

--- a/ir/type.cpp
+++ b/ir/type.cpp
@@ -826,6 +826,17 @@ pair<expr, vector<expr>> AggregateType::mkUndefInput(State &s) const {
   return { move(val), move(vars) };
 }
 
+unsigned AggregateType::numPointerElements() const {
+  unsigned count = 0;
+  for (unsigned i = 0; i < elements; ++i) {
+    if (children[i]->isPtrType())
+      count++;
+    else if (auto aty = children[i]->getAsAggregateType())
+      count += aty->numPointerElements();
+  }
+  return count;
+}
+
 void AggregateType::printVal(ostream &os, State &s, const expr &e) const {
   UNREACHABLE();
 }

--- a/ir/type.h
+++ b/ir/type.h
@@ -282,6 +282,7 @@ public:
   smt::expr mkInput(State &s, const char *name) const override;
   std::pair<smt::expr, std::vector<smt::expr>>
     mkUndefInput(State &s) const override;
+  unsigned numPointerElements() const;
   void printVal(std::ostream &os, State &s, const smt::expr &e) const override;
   const AggregateType* getAsAggregateType() const override;
 };

--- a/llvm_util/llvm2alive.cpp
+++ b/llvm_util/llvm2alive.cpp
@@ -10,7 +10,7 @@
 #include "llvm/IR/Operator.h"
 #include <utility>
 #include <vector>
-#include <iostream>
+
 using namespace llvm_util;
 using namespace IR;
 using namespace std;

--- a/tests/alive-tv/memory/gep-vector.src.ll
+++ b/tests/alive-tv/memory/gep-vector.src.ll
@@ -1,0 +1,19 @@
+; TEST-ARGS: -disable-undef-input
+target datalayout = "e-m:m-p:40:64:64:32-i32:32-i16:16-i8:8-n32"
+
+define <2 x i8*> @f(<2 x i8*> %x) {
+  %y = getelementptr i8, <2 x i8*> %x, <2 x i64> <i64 0, i64 1>
+  %z = getelementptr i8, <2 x i8*> %y, <2 x i64> <i64 1, i64 0>
+  ret <2 x i8*> %z
+}
+
+; from Transforms/InstCombine/gep-custom-dl.ll
+%S = type { i32, [ 100 x i32] }
+
+define <2 x i1> @test6b(<2 x i32> %X, <2 x %S*> %P) {
+  %A = getelementptr inbounds %S, <2 x %S*> %P, i32 0, i32 1, <2 x i32> %X
+  %B = getelementptr inbounds %S, <2 x %S*> %P, i32 0, i32 0
+  %C = icmp eq <2 x i32*> %A, %B
+  ret <2 x i1> %C
+}
+

--- a/tests/alive-tv/memory/gep-vector.tgt.ll
+++ b/tests/alive-tv/memory/gep-vector.tgt.ll
@@ -1,0 +1,14 @@
+target datalayout = "e-m:m-p:40:64:64:32-i32:32-i16:16-i8:8-n32"
+
+define <2 x i8*> @f(<2 x i8*> %x) {
+  %y = getelementptr i8, <2 x i8*> %x, <2 x i64> <i64 1, i64 1>
+  ret <2 x i8*> %y
+}
+
+%S = type { i32, [ 100 x i32] }
+
+define <2 x i1> @test6b(<2 x i32> %X, <2 x %S*> %P) {
+  %a = icmp eq <2 x i32> %X, <i32 -1, i32 -1>
+  ret <2 x i1> %a
+}
+

--- a/tools/transform.cpp
+++ b/tools/transform.cpp
@@ -370,11 +370,11 @@ static void calculateAndInitConstants(Transform &t) {
   unsigned num_ptrinputs = 0;
   const auto &inputs = t.src.getInputs();
   for (auto &arg : inputs) {
-    // An argument with aggregate type with pointer member isn't regarded
-    // as a source of non-local pointer, because its member should be extracted
-    // with extractelement / extractvalue instructions, which are also counted
-    // as source of non-local blocks.
+    // An argument with aggregate type with pointer member is dealt separately
     num_ptrinputs += arg.getType().isPtrType();
+
+    if (auto aty = arg.getType().getAsAggregateType())
+      num_ptrinputs += aty->numPointerElements();
   }
 
   auto returns_local = [](const Instr &inst) {


### PR DESCRIPTION
This PR adds supports for gep with vector operands, and lets num_ptrinputs  include ptr elems in aggregates too. The reason is as follows:
```
define <2 x i8*> @f(<2 x i8*> %a) {
  ret <2 x i8*> %a
}
=>
define <2 x i8*> @f(<2 x i8*> %a) {
  ret <2 x i8*> %a
}
```
In this program, %a was not being counted into num_ptrinputs because it was aggregate, but there should have been at least one used memory block when getting formula for refinement of pointer.
To be conservative, I counted all pointer elements in aggregate operands' types as num_ptrinputs.