### PR TITLE
Support llvm.lifetime.start/end for local blocks

### DIFF
--- a/ir/memory.h
+++ b/ir/memory.h
@@ -200,19 +200,19 @@ public:
   smt::expr mkInput(const char *name) const;
   std::pair<smt::expr, smt::expr> mkUndefInput() const;
 
-  // Allocates a new memory block.
+  // Allocates a new memory block, and returns (pointer expr, allocated).
   // If bid is not specified, it creates a fresh block id by increasing
   // last_bid.
   // If bid is specified, the bid is used, and last_bid is not increased.
-  // In this case, it is caller's responsibility to give a unique bid, and
-  // bumpLastBid() should be called in advance to correctly do this.
+  // In this case, it is caller's responsibility to give a unique bid.
   // The newly assigned bid is stored to bid_out if bid_out != nullptr.
-  smt::expr alloc(const smt::expr &size, unsigned align, BlockKind blockKind,
-                  std::optional<unsigned> bid = std::nullopt,
-                  unsigned *bid_out = nullptr,
-                  const smt::expr &precond = true);
+  std::pair<smt::expr, smt::expr> alloc(const smt::expr &size, unsigned align,
+      BlockKind blockKind, std::optional<unsigned> bid = std::nullopt,
+      unsigned *bid_out = nullptr, const smt::expr &precond = true);
 
-  void free(const smt::expr &ptr);
+  // Start lifetime of a local block.
+  void start_lifetime(const smt::expr &ptr_local);
+  void free(const smt::expr &ptr, bool unconstrained);
 
   void store(const smt::expr &ptr, const StateValue &val, const Type &type,
              unsigned align, bool deref_check = true);

--- a/ir/value.cpp
+++ b/ir/value.cpp
@@ -94,14 +94,14 @@ StateValue GlobalVariable::toSMT(State &s) const {
     if (!allocated) {
       // Use the same block id that is used by src
       assert(!s.isSource());
-      ptrval = s.getMemory().alloc(sizeexpr, align, blkkind, glbvar_bid);
+      ptrval = s.getMemory().alloc(sizeexpr, align, blkkind, glbvar_bid).first;
       s.markGlobalAsAllocated(getName());
     } else {
       ptrval = Pointer(s.getMemory(), glbvar_bid, false).release();
     }
   } else {
     ptrval = s.getMemory().alloc(sizeexpr, align, blkkind, nullopt,
-                                 &glbvar_bid);
+                                 &glbvar_bid).first;
     s.addGlobalVarBid(getName(), glbvar_bid);
   }
   return { move(ptrval), true };

--- a/tests/alive-tv/memory/lifetime-1.src.ll
+++ b/tests/alive-tv/memory/lifetime-1.src.ll
@@ -1,0 +1,12 @@
+define void @f1() {
+  %p = alloca i32
+  ret void
+}
+
+define i32 @f2() {
+  %p = alloca i32
+  store i32 10, i32* %p
+  %v = load i32, i32* %p
+  ret i32 %v
+}
+

--- a/tests/alive-tv/memory/lifetime-1.tgt.ll
+++ b/tests/alive-tv/memory/lifetime-1.tgt.ll
@@ -1,0 +1,21 @@
+declare void @llvm.lifetime.start.p0i8(i64, i8*)
+declare void @llvm.lifetime.end.p0i8(i64, i8*)
+
+define void @f1() {
+  %p = alloca i32
+  %p0 = bitcast i32* %p to i8*
+  call void @llvm.lifetime.start.p0i8(i64 4, i8* %p0)
+  call void @llvm.lifetime.end.p0i8(i64 4, i8* %p0)
+  ret void
+}
+
+define i32 @f2() {
+  %p = alloca i32
+  %p0 = bitcast i32* %p to i8*
+  call void @llvm.lifetime.start.p0i8(i64 4, i8* %p0)
+  store i32 10, i32* %p
+  %v = load i32, i32* %p
+  call void @llvm.lifetime.end.p0i8(i64 4, i8* %p0)
+  ret i32 %v
+}
+

--- a/tests/alive-tv/memory/lifetime-2.src.ll
+++ b/tests/alive-tv/memory/lifetime-2.src.ll
@@ -1,0 +1,17 @@
+declare void @llvm.lifetime.start.p0i8(i64, i8*)
+declare void @llvm.lifetime.end.p0i8(i64, i8*)
+
+define i32 @f() {
+  %p = alloca i32
+
+  store i32 10, i32* %p
+  ; load before lifetime.start can be optimized to undef
+  %v = load i32, i32* %p
+
+  %p0 = bitcast i32* %p to i8*
+  call void @llvm.lifetime.start.p0i8(i64 4, i8* %p0)
+  call void @llvm.lifetime.end.p0i8(i64 4, i8* %p0)
+
+  ret i32 %v
+}
+

--- a/tests/alive-tv/memory/lifetime-2.tgt.ll
+++ b/tests/alive-tv/memory/lifetime-2.tgt.ll
@@ -1,0 +1,13 @@
+declare void @llvm.lifetime.start.p0i8(i64, i8*)
+declare void @llvm.lifetime.end.p0i8(i64, i8*)
+
+define i32 @f() {
+  %p = alloca i32
+
+  %p0 = bitcast i32* %p to i8*
+  call void @llvm.lifetime.start.p0i8(i64 4, i8* %p0)
+  call void @llvm.lifetime.end.p0i8(i64 4, i8* %p0)
+
+  ret i32 undef
+}
+

--- a/tests/alive-tv/memory/lifetime-3.src.ll
+++ b/tests/alive-tv/memory/lifetime-3.src.ll
@@ -1,0 +1,18 @@
+declare void @llvm.lifetime.start.p0i8(i64, i8*)
+declare void @llvm.lifetime.end.p0i8(i64, i8*)
+
+define i32 @f() {
+  %p = alloca i32
+
+  %p0 = bitcast i32* %p to i8*
+  call void @llvm.lifetime.start.p0i8(i64 4, i8* %p0)
+  store i32 10, i32* %p
+  call void @llvm.lifetime.end.p0i8(i64 4, i8* %p0)
+
+  ; store after lifetime.end can be optimized out
+  store i32 20, i32* %p
+  %v = load i32, i32* %p
+
+  ret i32 %v
+}
+

--- a/tests/alive-tv/memory/lifetime-3.tgt.ll
+++ b/tests/alive-tv/memory/lifetime-3.tgt.ll
@@ -1,0 +1,17 @@
+declare void @llvm.lifetime.start.p0i8(i64, i8*)
+declare void @llvm.lifetime.end.p0i8(i64, i8*)
+
+define i32 @f() {
+  %p = alloca i32
+
+  %p0 = bitcast i32* %p to i8*
+  call void @llvm.lifetime.start.p0i8(i64 4, i8* %p0)
+  store i32 10, i32* %p
+  call void @llvm.lifetime.end.p0i8(i64 4, i8* %p0)
+
+  ; store after lifetime.end can be optimized out
+  %v = load i32, i32* %p
+
+  ret i32 %v
+}
+

--- a/tests/alive-tv/memory/lifetime-4.src.ll
+++ b/tests/alive-tv/memory/lifetime-4.src.ll
@@ -1,0 +1,17 @@
+declare void @llvm.lifetime.start.p0i8(i64, i8*)
+declare void @llvm.lifetime.end.p0i8(i64, i8*)
+
+define i8 @f() {
+  %p = alloca i32
+
+  %p0 = bitcast i32* %p to i8*
+  call void @llvm.lifetime.start.p0i8(i64 4, i8* %p0)
+  %p1 = getelementptr i8, i8* %p0, i32 1
+  store i8 10, i8* %p1
+  %v = load i8, i8* %p1
+  call void @llvm.lifetime.end.p0i8(i64 4, i8* %p0)
+
+  ret i8 %v
+}
+
+; ERROR: Source is more defined than target

--- a/tests/alive-tv/memory/lifetime-4.tgt.ll
+++ b/tests/alive-tv/memory/lifetime-4.tgt.ll
@@ -1,0 +1,15 @@
+declare void @llvm.lifetime.start.p0i8(i64, i8*)
+declare void @llvm.lifetime.end.p0i8(i64, i8*)
+
+define i8 @f() {
+  %p = alloca i32
+
+  %p0 = bitcast i32* %p to i8*
+  call void @llvm.lifetime.start.p0i8(i64 4, i8* %p0)
+  %p1 = getelementptr i8, i8* %p0, i32 1
+  store i8 10, i8* %p1
+  %v = load i8, i8* %p1
+  call void @llvm.lifetime.end.p0i8(i64 4, i8* %p0)
+
+  unreachable
+}

--- a/tests/alive-tv/memory/lifetime-reorder.src.ll
+++ b/tests/alive-tv/memory/lifetime-reorder.src.ll
@@ -1,0 +1,52 @@
+declare void @llvm.lifetime.start.p0i8(i64, i8*)
+declare void @llvm.lifetime.end.p0i8(i64, i8*)
+
+define i8 @gep1() {
+  %p = alloca i32
+
+  %p0 = bitcast i32* %p to i8*
+  call void @llvm.lifetime.start.p0i8(i64 4, i8* %p0)
+  %p1 = getelementptr i8, i8* %p0, i32 1
+  store i8 10, i8* %p1
+  %v = load i8, i8* %p1
+  call void @llvm.lifetime.end.p0i8(i64 4, i8* %p0)
+
+  ret i8 %v
+}
+
+define i8 @gep2() {
+  %p = alloca i32
+
+  %p0 = bitcast i32* %p to i8*
+  %p1 = getelementptr i8, i8* %p0, i32 1
+  call void @llvm.lifetime.start.p0i8(i64 4, i8* %p0)
+  store i8 10, i8* %p1
+  %v = load i8, i8* %p1
+  call void @llvm.lifetime.end.p0i8(i64 4, i8* %p0)
+
+  ret i8 %v
+}
+
+define i64 @ptrtoint1() {
+  %p = alloca i32
+  %dummy = alloca i64
+
+  %p0 = bitcast i32* %p to i8*
+  %i = ptrtoint i32* %p to i64
+  call void @llvm.lifetime.start.p0i8(i64 4, i8* %p0)
+  call void @llvm.lifetime.end.p0i8(i64 4, i8* %p0)
+
+  ret i64 %i
+}
+
+define i64 @ptrtoint2() {
+  %p = alloca i32
+  %dummy = alloca i64
+
+  %p0 = bitcast i32* %p to i8*
+  call void @llvm.lifetime.start.p0i8(i64 4, i8* %p0)
+  %i = ptrtoint i32* %p to i64
+  call void @llvm.lifetime.end.p0i8(i64 4, i8* %p0)
+
+  ret i64 %i
+}

--- a/tests/alive-tv/memory/lifetime-reorder.tgt.ll
+++ b/tests/alive-tv/memory/lifetime-reorder.tgt.ll
@@ -1,0 +1,52 @@
+declare void @llvm.lifetime.start.p0i8(i64, i8*)
+declare void @llvm.lifetime.end.p0i8(i64, i8*)
+
+define i8 @gep1() {
+  %p = alloca i32
+
+  %p0 = bitcast i32* %p to i8*
+  %p1 = getelementptr i8, i8* %p0, i32 1
+  call void @llvm.lifetime.start.p0i8(i64 4, i8* %p0)
+  store i8 10, i8* %p1
+  %v = load i8, i8* %p1
+  call void @llvm.lifetime.end.p0i8(i64 4, i8* %p0)
+
+  ret i8 %v
+}
+
+define i8 @gep2() {
+  %p = alloca i32
+
+  %p0 = bitcast i32* %p to i8*
+  call void @llvm.lifetime.start.p0i8(i64 4, i8* %p0)
+  %p1 = getelementptr i8, i8* %p0, i32 1
+  store i8 10, i8* %p1
+  %v = load i8, i8* %p1
+  call void @llvm.lifetime.end.p0i8(i64 4, i8* %p0)
+
+  ret i8 %v
+}
+
+define i64 @ptrtoint1() {
+  %p = alloca i32
+  %dummy = alloca i64
+
+  %p0 = bitcast i32* %p to i8*
+  call void @llvm.lifetime.start.p0i8(i64 4, i8* %p0)
+  %i = ptrtoint i32* %p to i64
+  call void @llvm.lifetime.end.p0i8(i64 4, i8* %p0)
+
+  ret i64 %i
+}
+
+define i64 @ptrtoint2() {
+  %p = alloca i32
+  %dummy = alloca i64
+
+  %p0 = bitcast i32* %p to i8*
+  %i = ptrtoint i32* %p to i64
+  call void @llvm.lifetime.start.p0i8(i64 4, i8* %p0)
+  call void @llvm.lifetime.end.p0i8(i64 4, i8* %p0)
+
+  ret i64 %i
+}


### PR DESCRIPTION
This PR adds llvm.lifetime.start/end.

