### PR TITLE
fix the build on Mac

### DIFF
--- a/tv/tv.cpp
+++ b/tv/tv.cpp
@@ -16,7 +16,7 @@
 #include <unordered_map>
 #include <utility>
 
-#if __GNUC__ < 8
+#if (__GNUC__ < 8) && (!__APPLE__)
 # include <experimental/filesystem>
   namespace fs = std::experimental::filesystem;
 #else


### PR DESCRIPTION
the ```#if __GNUC__ < 8``` is no longer sufficient to make alive2 compile using LLVM 9 on OS X.
the fix below is certainly the wrong one, but I'm not certain what the right one is.