### PR TITLE
Print 'loops are not supported' instead of 'Unsupported phi'

### DIFF
--- a/tests/alive-tv/phi-loop.src.ll
+++ b/tests/alive-tv/phi-loop.src.ll
@@ -1,0 +1,13 @@
+define i32 @f() {
+  br label %header
+header:
+  br label %loop
+loop:
+  %i = phi i32 [0, %header], [%i, %loop]
+  %c = icmp eq i32 %i, 10
+  br i1 %c, label %exit, label %loop
+exit:
+  ret i32 10
+}
+
+; ERROR: Loops are not supported yet! Skipping function.

--- a/tests/alive-tv/phi-loop.tgt.ll
+++ b/tests/alive-tv/phi-loop.tgt.ll
@@ -1,0 +1,3 @@
+define i32 @f() {
+  ret i32 10
+}


### PR DESCRIPTION
This makes alive-tv print 'Loops are not supported yet' rather than 'Unsupported phi instruction' when the phi is in a loop.
When phi is in a loop, get_operand() returns none, which led to the unsupported instruction error message.