### PR TITLE
Fix a crash, add an empty array test, ignore place-safepoints pass

### DIFF
--- a/scripts/opt-alive.sh
+++ b/scripts/opt-alive.sh
@@ -7,7 +7,7 @@ set -e
 # place-safepoints: places new function calls (@do_safepoint)
 # loop-extract: extracts a top-level loop into a distinct function
 # extract-blocks: extract specified blocks into a distinct function
-PASSES="argpromotion deadargelim globalopt hotcoldsplit inline ipconstprop ipsccp mergefunc partial-inliner tbaa insert-gcov-profiling switch-to-lookup safe-stack pgo-instr-gen loop-extract extract-blocks -Os -Oz -O1 -O2 -O3"
+PASSES="argpromotion deadargelim globalopt hotcoldsplit inline ipconstprop ipsccp mergefunc partial-inliner tbaa insert-gcov-profiling switch-to-lookup safe-stack pgo-instr-gen loop-extract extract-blocks place-safepoints -Os -Oz -O1 -O2 -O3"
 
 TV="-tv"
 for p in $PASSES; do

--- a/tests/alive-tv/memory/aggregate-empty.src.ll
+++ b/tests/alive-tv/memory/aggregate-empty.src.ll
@@ -1,0 +1,8 @@
+@g7 = constant {[0 x i32], [0 x i8], {}*} { [0 x i32] undef, [0 x i8] undef, {}* null }
+
+define i64* @test_leading_zero_size_elems() {
+  %v = load i64*, i64** bitcast ({[0 x i32], [0 x i8], {}*}* @g7 to i64**)
+  ret i64* %v
+}
+
+

--- a/tests/alive-tv/memory/aggregate-empty.tgt.ll
+++ b/tests/alive-tv/memory/aggregate-empty.tgt.ll
@@ -1,0 +1,5 @@
+@g7 = constant {[0 x i32], [0 x i8], {}*} { [0 x i32] undef, [0 x i8] undef, {}* null }
+
+define i64* @test_leading_zero_size_elems() {
+  ret i64* null
+}


### PR DESCRIPTION
- Fixes a crash regarding opaque type
- Adds a test for empty arrays
- Ignore `place-safepoints` because it is introducing function calls (`@do_safepoint`)