### PR TITLE
Unsupport byval attribute

### DIFF
--- a/llvm_util/llvm2alive.cpp
+++ b/llvm_util/llvm2alive.cpp
@@ -679,7 +679,6 @@ public:
     for (auto &attr : arg.getParent()->getAttributes()
                          .getParamAttributes(arg.getArgNo())) {
       switch (attr.getKindAsEnum()) {
-      case llvm::Attribute::ByVal:
       case llvm::Attribute::InReg:
       case llvm::Attribute::SExt:
       case llvm::Attribute::ZExt:


### PR DESCRIPTION
Transforms/DeadStoreElimination/simple.ll has tests that exploit byval attributes, and alive-tv fails with the tests