### PR TITLE
README.md: BUILD_SHARED_LIBS works inplace of LLVM_BUILD_LLVM_DYLIB

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ cd llvm
 mkdir build
 cmake -GNinja -DLLVM_ENABLE_RTTI=ON -DLLVM_ENABLE_EH=ON -DLLVM_BUILD_LLVM_DYLIB=ON -DCMAKE_BUILD_TYPE=Release -DLLVM_TARGETS_TO_BUILD=X86 -DLLVM_ENABLE_ASSERTIONS=ON -DLLVM_ENABLE_PROJECTS="llvm;clang" ../llvm
 ```
+Note that `-DLLVM_BUILD_LLVM_DYLIB=ON` is optional, `-DBUILD_SHARED_LIBS=ON` works too.
 
 Alive2 should then be configured as follows:
 ```


### PR DESCRIPTION
For normal day-to-day usage, `LLVM_BUILD_LLVM_DYLIB` may perhaps be a somewhat larger entry cost
as compared to the other prerequisites (RTTI+EH). It may be helpful to document
that `BUILD_SHARED_LIBS` (which is likely already enabled if one works on LLVM) is sufficient instead.