### PR TITLE
Fix a bug regarding nonlocal ptr's align

### DIFF
--- a/ir/memory.h
+++ b/ir/memory.h
@@ -127,7 +127,8 @@ public:
 
   smt::expr inbounds() const;
   smt::expr block_alignment() const;
-  smt::expr is_aligned(unsigned align, bool exact = false) const;
+  smt::expr is_block_aligned(unsigned align, bool exact = false) const;
+  smt::expr is_aligned(unsigned align) const;
   void is_dereferenceable(unsigned bytes, unsigned align, bool iswrite);
   void is_dereferenceable(const smt::expr &bytes, unsigned align, bool iswrite);
   void is_disjoint(const smt::expr &len1, const Pointer &ptr2,

--- a/tests/alive-tv/memory/align.src.ll
+++ b/tests/alive-tv/memory/align.src.ll
@@ -1,0 +1,10 @@
+define i32 @foo1(i32* %a) {
+  %v = load i32, i32* %a, align 4
+  %ptrint = ptrtoint i32* %a to i64
+  %maskedptr = and i64 %ptrint, 31
+  %maskcond = icmp eq i64 %maskedptr, 0
+  tail call void @llvm.assume(i1 %maskcond)
+  ret i32 %v
+}
+
+declare void @llvm.assume(i1)

--- a/tests/alive-tv/memory/align.tgt.ll
+++ b/tests/alive-tv/memory/align.tgt.ll
@@ -1,0 +1,10 @@
+define i32 @foo1(i32* %a) {
+  %v = load i32, i32* %a, align 32
+  %ptrint = ptrtoint i32* %a to i64
+  %maskedptr = and i64 %ptrint, 31
+  %maskcond = icmp eq i64 %maskedptr, 0
+  tail call void @llvm.assume(i1 %maskcond)
+  ret i32 %v
+}
+
+declare void @llvm.assume(i1)


### PR DESCRIPTION
This fixes a bug of encoding of nonlocal pointer's alignments.

The original is_aligned was only checking block's alignment (using the `blk_align` array), and didn't consider offsets, which perhaps caused the confusion.

I renamed the original is_aligned to is_block_aligned & defined is_aligned to address this.