### PR TITLE
Make null ptr byte and zero int byte compatible

### DIFF
--- a/ir/memory.h
+++ b/ir/memory.h
@@ -53,7 +53,10 @@ public:
   smt::expr ptr_byteoffset() const;
   smt::expr nonptr_nonpoison() const;
   smt::expr nonptr_value() const;
-  smt::expr is_poison() const;
+  smt::expr is_poison(bool fullbit = true) const;
+  // Returns whether its value is integer zero or null pointer.
+  // If poison is true, poison value is allowed
+  smt::expr is_zero(bool allow_poison = true) const;
 
   const smt::expr& operator()() const { return p; }
 

--- a/tests/alive-tv/memory/gep-struct2.src.ll
+++ b/tests/alive-tv/memory/gep-struct2.src.ll
@@ -1,3 +1,4 @@
+; TEST-ARGS: -smt-to=2000
 target datalayout = "e-i32:32-i128:32-i8:8"
 
 %0 = type [10 x { i32, i128, [5 x { i32, i8, i8 }] }]

--- a/tests/alive-tv/memory/pre-bigendian.src.ll
+++ b/tests/alive-tv/memory/pre-bigendian.src.ll
@@ -1,4 +1,5 @@
 ; This was excerpted from GVN/PRE/rle.ll
+; TEST-ARGS: -smt-to=2000
 target datalayout = "E-p:32:32:32-p1:16:16:16-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:32:64-f32:32:32-f64:64:64-n32"
 
 define i8 @coerce_mustalias_pre0(i16* %P, i1 %cond) {

--- a/tests/alive-tv/memory/punning-intptr.src.ll
+++ b/tests/alive-tv/memory/punning-intptr.src.ll
@@ -1,4 +1,4 @@
-; TEST-ARGS: -smt-to=9000
+; TEST-ARGS: -smt-to=9000 -disable-undef-input
 
 target datalayout = "e-m:o-i64:64-f80:128-n8:16:32:64-S128"
 

--- a/tests/alive-tv/memory/punning-ptrint.src.ll
+++ b/tests/alive-tv/memory/punning-ptrint.src.ll
@@ -1,14 +1,7 @@
-; TEST-ARGS: -disable-undef-input -disable-poison-input -smt-to=10000
-
-target datalayout = "e-m:o-i64:64-f80:128-n8:16:32:64-S128"
+; TEST-ARGS: -disable-undef-input -smt-to=10000
 
 define i8 @ptr_int_punning(i8** %pptr, i64 %n) {
-  %ptr = call i8* @malloc(i64 1)
-  %cmp = icmp eq i8* %ptr, null
-  br i1 %cmp, label %BB1, label %BB2
-BB1:
-  ret i8 0
-BB2:
+  %ptr = alloca i8
   store i8* %ptr, i8** %pptr
   %pi8 = bitcast i8** %pptr to i8*
   %n2 = and i64 %n, 7
@@ -17,4 +10,3 @@ BB2:
   ; %v is poison.
   ret i8 %v
 }
-declare noalias i8* @malloc(i64)

--- a/tests/alive-tv/memory/punning-ptrint.tgt.ll
+++ b/tests/alive-tv/memory/punning-ptrint.tgt.ll
@@ -1,12 +1,5 @@
-target datalayout = "e-m:o-i64:64-f80:128-n8:16:32:64-S128"
-
 define i8 @ptr_int_punning(i8** %pptr, i64 %n) {
-  %ptr = call i8* @malloc(i64 1)
-  %cmp = icmp eq i8* %ptr, null
-  br i1 %cmp, label %BB1, label %BB2
-BB1:
-  ret i8 0
-BB2:
+  %ptr = alloca i8
   store i8* %ptr, i8** %pptr
   ret i8 undef
 }

--- a/tests/alive-tv/memory/store-removal.src.ll
+++ b/tests/alive-tv/memory/store-removal.src.ll
@@ -3,3 +3,9 @@ define void @f(i8* %p) {
   store i8 %v, i8* %p
   ret void
 }
+
+define void @f2(i8** %p) {
+  %v = load i8*, i8** %p
+  store i8* %v, i8** %p
+  ret void
+}

--- a/tests/alive-tv/memory/store-removal.tgt.ll
+++ b/tests/alive-tv/memory/store-removal.tgt.ll
@@ -1,3 +1,7 @@
 define void @f(i8* %p) {
   ret void
 }
+
+define void @f2(i8** %p) {
+  ret void
+}

--- a/tests/alive-tv/memory/zeroinit-memset.src.ll
+++ b/tests/alive-tv/memory/zeroinit-memset.src.ll
@@ -1,0 +1,15 @@
+; From Transforms/MemCpyOpt/fca2memcpy.ll
+; TEST-ARGS: -smt-to=15000 -disable-undef-input
+target datalayout = "e-i64:64-f80:128-n8:16:32:64"
+target triple = "x86_64-unknown-linux-gnu"
+
+%S = type { i8*, i8, i32 }
+
+define void @destroysrc(%S* %src, %S* %dst) {
+  %1 = load %S, %S* %src
+  store %S zeroinitializer, %S* %src
+  store %S %1, %S* %dst
+  ret void
+}
+
+

--- a/tests/alive-tv/memory/zeroinit-memset.tgt.ll
+++ b/tests/alive-tv/memory/zeroinit-memset.tgt.ll
@@ -1,0 +1,17 @@
+; ModuleID = 'zeroinit-memset.src.ll'
+source_filename = "zeroinit-memset.src.ll"
+target datalayout = "e-i64:64-f80:128-n8:16:32:64"
+target triple = "x86_64-unknown-linux-gnu"
+
+%S = type { i8*, i8, i32 }
+define void @destroysrc(%S* %src, %S* %dst) {
+  %1 = load %S, %S* %src
+  %2 = bitcast %S* %src to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 8 %2, i8 0, i64 16, i1 false)
+  store %S %1, %S* %dst
+  ret void
+}
+; Function Attrs: argmemonly nounwind willreturn
+declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1 immarg) #0
+
+attributes #0 = { argmemonly nounwind willreturn }

--- a/tests/alive-tv/refinement/zero-null.src.ll
+++ b/tests/alive-tv/refinement/zero-null.src.ll
@@ -1,0 +1,10 @@
+define void @f(i64* %p) {
+  store i64 0, i64* %p
+  ret void
+}
+
+define void @f2(i64* %p) {
+  %p2 = bitcast i64* %p to i8**
+  store i8* null, i8** %p2, align 4
+  ret void
+}

--- a/tests/alive-tv/refinement/zero-null.tgt.ll
+++ b/tests/alive-tv/refinement/zero-null.tgt.ll
@@ -1,0 +1,10 @@
+define void @f(i64* %p) {
+  %p2 = bitcast i64* %p to i8**
+  store i8* null, i8** %p2, align 4
+  ret void
+}
+
+define void @f2(i64* %p) {
+  store i64 0, i64* %p
+  ret void
+}


### PR DESCRIPTION
This addresses #236 .
Reading null pointer byte as int yields 0, and zero int byte as pointer yields null pointer.
Further optimization can be done by redefining layout of a byte, so pointer value and int value can overlap.