### PR TITLE
Support lifetime.end

### DIFF
--- a/ir/instr.cpp
+++ b/ir/instr.cpp
@@ -1817,13 +1817,14 @@ void Free::rauw(const Value &what, Value &with) {
 }
 
 void Free::print(std::ostream &os) const {
-  os << "free " << *ptr;
+  os << "free " << *ptr << (heaponly ? "" : " unconstrained");
 }
 
 StateValue Free::toSMT(State &s) const {
   auto &[p, np] = s[*ptr];
   s.addUB(np);
-  s.getMemory().free(p);
+  // If not heaponly, don't encode constraints
+  s.getMemory().free(p, !heaponly);
   return {};
 }
 
@@ -1832,7 +1833,7 @@ expr Free::getTypeConstraints(const Function &f) const {
 }
 
 unique_ptr<Instr> Free::dup(const string &suffix) const {
-  return make_unique<Free>(*ptr);
+  return make_unique<Free>(*ptr, heaponly);
 }
 
 

--- a/ir/instr.h
+++ b/ir/instr.h
@@ -422,8 +422,10 @@ public:
 
 class Free final : public Instr {
   Value *ptr;
+  bool heaponly;
 public:
-  Free(Value &ptr) : Instr(Type::voidTy, "free"), ptr(&ptr) {}
+  Free(Value &ptr, bool heaponly = true) : Instr(Type::voidTy, "free"),
+      ptr(&ptr), heaponly(heaponly) {}
 
   std::vector<Value*> operands() const override;
   void rauw(const Value &what, Value &with) override;

--- a/ir/memory.cpp
+++ b/ir/memory.cpp
@@ -837,12 +837,13 @@ expr Memory::alloc(const expr &size, unsigned align, BlockKind blockKind,
   return expr::mkIf(allocated, p(), Pointer::mkNullPointer(*this)());
 }
 
-void Memory::free(const expr &ptr) {
+void Memory::free(const expr &ptr, bool unconstrained) {
   assert(!memory_unused() && has_free);
   Pointer p(*this, ptr);
-  state->addUB(p.isNull() || (p.get_offset() == 0 &&
-                              p.is_block_alive() &&
-                              p.get_alloc_type() == Pointer::MALLOC));
+  if (!unconstrained)
+    state->addUB(p.isNull() || (p.get_offset() == 0 &&
+                                p.is_block_alive() &&
+                                p.get_alloc_type() == Pointer::MALLOC));
   store(p, false, local_block_liveness, non_local_block_liveness, true);
 
   // optimization: if this is a local block, remove all associated information

--- a/ir/memory.h
+++ b/ir/memory.h
@@ -213,7 +213,9 @@ public:
                   unsigned *bid_out = nullptr,
                   const smt::expr &precond = true);
 
-  void free(const smt::expr &ptr);
+  // If unconstrained is true, the pointer offset, liveness, and block kind
+  // are not checked.
+  void free(const smt::expr &ptr, bool unconstrained);
 
   void store(const smt::expr &ptr, const StateValue &val, const Type &type,
              unsigned align, bool deref_check = true);

--- a/llvm_util/llvm2alive.cpp
+++ b/llvm_util/llvm2alive.cpp
@@ -588,11 +588,7 @@ public:
       if (!llvm::isa<llvm::AllocaInst>(llvm::GetUnderlyingObject(
           i.getOperand(1), DL())))
         return error(i);
-      // TODO: a dummy instruction
-      static int lifetime_end_dummy = 0;
-      string name = "__unused_le_" + to_string(lifetime_end_dummy++);
-      RETURN_IDENTIFIER(make_unique<UnaryOp>(b->getType(), move(name), *b,
-                                             UnaryOp::Copy));
+      RETURN_IDENTIFIER(make_unique<Free>(*b, false));
     }
 
     // do nothing intrinsics

--- a/tests/alive-tv/memory/lifetime-2.src.ll
+++ b/tests/alive-tv/memory/lifetime-2.src.ll
@@ -1,0 +1,16 @@
+declare void @llvm.lifetime.start.p0i8(i64, i8*)
+declare void @llvm.lifetime.end.p0i8(i64, i8*)
+
+define i32 @f() {
+  %p = alloca i32
+
+  %p0 = bitcast i32* %p to i8*
+  call void @llvm.lifetime.start.p0i8(i64 4, i8* %p0)
+  call void @llvm.lifetime.end.p0i8(i64 4, i8* %p0)
+
+  store i32 10, i32* %p
+  %v = load i32, i32* %p
+
+  ret i32 %v
+}
+

--- a/tests/alive-tv/memory/lifetime-2.tgt.ll
+++ b/tests/alive-tv/memory/lifetime-2.tgt.ll
@@ -1,0 +1,15 @@
+declare void @llvm.lifetime.start.p0i8(i64, i8*)
+declare void @llvm.lifetime.end.p0i8(i64, i8*)
+
+define i32 @f() {
+  %p = alloca i32
+
+  %p0 = bitcast i32* %p to i8*
+  call void @llvm.lifetime.start.p0i8(i64 4, i8* %p0)
+  call void @llvm.lifetime.end.p0i8(i64 4, i8* %p0)
+
+  store i32 10, i32* %p
+
+  ret i32 undef
+}
+

--- a/tests/alive-tv/memory/lifetime-noub.src.ll
+++ b/tests/alive-tv/memory/lifetime-noub.src.ll
@@ -1,0 +1,15 @@
+declare void @llvm.lifetime.start.p0i8(i64, i8*)
+declare void @llvm.lifetime.end.p0i8(i64, i8*)
+
+define void @f() {
+  %p = alloca i32
+
+  %p0 = bitcast i32* %p to i8*
+  %p1 = getelementptr i8, i8* %p0, i32 1
+  call void @llvm.lifetime.start.p0i8(i64 4, i8* %p1)
+  call void @llvm.lifetime.end.p0i8(i64 4, i8* %p1)
+
+  ret void
+}
+
+; ERROR: Source is more defined than target

--- a/tests/alive-tv/memory/lifetime-noub.tgt.ll
+++ b/tests/alive-tv/memory/lifetime-noub.tgt.ll
@@ -1,0 +1,14 @@
+declare void @llvm.lifetime.start.p0i8(i64, i8*)
+declare void @llvm.lifetime.end.p0i8(i64, i8*)
+
+define void @f() {
+  %p = alloca i32
+
+  %p0 = bitcast i32* %p to i8*
+  %p1 = getelementptr i8, i8* %p0, i32 1
+  call void @llvm.lifetime.start.p0i8(i64 4, i8* %p1)
+  call void @llvm.lifetime.end.p0i8(i64 4, i8* %p1)
+
+  unreachable
+}
+


### PR DESCRIPTION
This adds encoding of  lifetime.end.

To finish lifetime of alloca, Free instruction with `unconstrained` parameter set as true is used.

It is allowed to give a pointer to alloca with non-zero offset, and I couldn't find an example that needs the double lifetime.end() call to be UB, so I named it as unconstrained.
(Note that it raises unsupported if non-alloca is given to lifetime.end)