### PR TITLE
Support lifetime.start (2/2)

### DIFF
--- a/ir/instr.cpp
+++ b/ir/instr.cpp
@@ -1805,8 +1805,9 @@ void StartLifetime::print(std::ostream &os) const {
 
 StateValue StartLifetime::toSMT(State &s) const {
   auto &[p, np] = s[*ptr];
-  s.addUB(np);
-  s.getMemory().start_lifetime(p);
+  expr allocated = s.getMemory().start_lifetime(p);
+  // This should be coherent with Alloc's OOM semantics
+  s.addUB(np && allocated);
   return {};
 }
 

--- a/ir/instr.h
+++ b/ir/instr.h
@@ -372,9 +372,12 @@ public:
 class Alloc final : public Instr {
   Value *size;
   unsigned align;
+  bool initially_dead;
 public:
-  Alloc(Type &type, std::string &&name, Value &size, unsigned align)
-    : Instr(type, std::move(name)), size(&size), align(align) {}
+  Alloc(Type &type, std::string &&name, Value &size, unsigned align,
+        bool initially_dead)
+    : Instr(type, std::move(name)), size(&size), align(align),
+      initially_dead(initially_dead) {}
 
   std::vector<Value*> operands() const override;
   void rauw(const Value &what, Value &with) override;

--- a/ir/memory.cpp
+++ b/ir/memory.cpp
@@ -886,7 +886,7 @@ pair<expr, expr> Memory::alloc(const expr &size, unsigned align, BlockKind block
   (is_local ? local_blk_kind : non_local_blk_kind)
     .add(short_bid, expr::mkUInt(alloc_ty, 2));
 
-  return { p(), allocated };
+  return { p.release(), move(allocated) };
 }
 
 expr Memory::start_lifetime(const expr &ptr_local) {

--- a/ir/memory.cpp
+++ b/ir/memory.cpp
@@ -793,7 +793,7 @@ static expr disjoint_local_blocks(const Memory &m, const expr &addr,
   return disj;
 }
 
-expr Memory::alloc(const expr &size, unsigned align, BlockKind blockKind,
+pair<expr, expr> Memory::alloc(const expr &size, unsigned align, BlockKind blockKind,
                    optional<unsigned> bidopt, unsigned *bid_out,
                    const expr &precond) {
   assert(!memory_unused());
@@ -886,14 +886,33 @@ expr Memory::alloc(const expr &size, unsigned align, BlockKind blockKind,
   (is_local ? local_blk_kind : non_local_blk_kind)
     .add(short_bid, expr::mkUInt(alloc_ty, 2));
 
-  return expr::mkIf(allocated, p(), Pointer::mkNullPointer(*this)());
+  return { p(), allocated };
 }
 
 void Memory::start_lifetime(const expr &ptr_local) {
   assert(!memory_unused());
   Pointer p(*this, ptr_local);
+
+  if (observes_addresses()) {
+    auto align = *local_blk_align(p.get_short_bid());
+    auto size_upperbound = p.block_size() + align.zextOrTrunc(bits_size_t) -
+                           expr::mkUInt(1, bits_size_t);
+    auto allocated = !local_block_liveness.load(p.get_short_bid()) &&
+                     size_upperbound.ule(local_avail_space.zext(1));
+
+    // Disjointness of block's address range with other local blocks
+    state->addPre(
+      allocated.implies(disjoint_local_blocks(*this, p.get_address(),
+                                      p.block_size(), local_blk_addr)));
+
+    // size_upperbound should be subtracted here (not size_zext0) because we
+    // need to consider blocks' alignment.
+    auto size_upperbound_trunc = size_upperbound.trunc(bits_size_t - 1);
+    local_avail_space = expr::mkIf(allocated,
+                                   local_avail_space - size_upperbound_trunc,
+                                   local_avail_space);
+  }
   local_block_liveness = local_block_liveness.store(p.get_short_bid(), true);
-  // TODO: encode disjointness of lock blocks if lifetime starts
 }
 
 void Memory::free(const expr &ptr, bool unconstrained) {

--- a/ir/memory.h
+++ b/ir/memory.h
@@ -200,17 +200,15 @@ public:
   smt::expr mkInput(const char *name) const;
   std::pair<smt::expr, smt::expr> mkUndefInput() const;
 
-  // Allocates a new memory block.
+  // Allocates a new memory block and returns (pointer expr, allocated).
   // If bid is not specified, it creates a fresh block id by increasing
   // last_bid.
   // If bid is specified, the bid is used, and last_bid is not increased.
-  // In this case, it is caller's responsibility to give a unique bid, and
-  // bumpLastBid() should be called in advance to correctly do this.
+  // In this case, it is caller's responsibility to give a unique bid.
   // The newly assigned bid is stored to bid_out if bid_out != nullptr.
-  smt::expr alloc(const smt::expr &size, unsigned align, BlockKind blockKind,
-                  std::optional<unsigned> bid = std::nullopt,
-                  unsigned *bid_out = nullptr,
-                  const smt::expr &precond = true);
+  std::pair<smt::expr, smt::expr> alloc(const smt::expr &size, unsigned align,
+      BlockKind blockKind, std::optional<unsigned> bid = std::nullopt,
+      unsigned *bid_out = nullptr, const smt::expr &precond = true);
 
   // Start lifetime of a local block.
   void start_lifetime(const smt::expr &ptr_local);

--- a/ir/memory.h
+++ b/ir/memory.h
@@ -211,7 +211,8 @@ public:
       unsigned *bid_out = nullptr, const smt::expr &precond = true);
 
   // Start lifetime of a local block.
-  void start_lifetime(const smt::expr &ptr_local);
+  // Returns whether it is successfully allocated.
+  smt::expr start_lifetime(const smt::expr &ptr_local);
 
   // If unconstrained is true, the pointer offset, liveness, and block kind
   // are not checked.

--- a/ir/value.cpp
+++ b/ir/value.cpp
@@ -94,14 +94,14 @@ StateValue GlobalVariable::toSMT(State &s) const {
     if (!allocated) {
       // Use the same block id that is used by src
       assert(!s.isSource());
-      ptrval = s.getMemory().alloc(sizeexpr, align, blkkind, glbvar_bid);
+      ptrval = s.getMemory().alloc(sizeexpr, align, blkkind, glbvar_bid).first;
       s.markGlobalAsAllocated(getName());
     } else {
       ptrval = Pointer(s.getMemory(), glbvar_bid, false).release();
     }
   } else {
     ptrval = s.getMemory().alloc(sizeexpr, align, blkkind, nullopt,
-                                 &glbvar_bid);
+                                 &glbvar_bid).first;
     s.addGlobalVarBid(getName(), glbvar_bid);
   }
   return { move(ptrval), true };

--- a/llvm_util/llvm2alive.cpp
+++ b/llvm_util/llvm2alive.cpp
@@ -9,6 +9,8 @@
 #include "llvm/IR/GlobalVariable.h"
 #include "llvm/IR/InstVisitor.h"
 #include "llvm/IR/Operator.h"
+#include <queue>
+#include <set>
 #include <utility>
 #include <vector>
 
@@ -349,6 +351,34 @@ public:
     RETURN_IDENTIFIER(move(inst));
   }
 
+  bool hasLifetimeStart(llvm::AllocaInst &i) {
+    // If the alloca has any lifetime.start use, the alloca is initially dead.
+    std::set<llvm::Value *> visited;
+    std::queue<llvm::Value *> q;
+    q.push(&i);
+
+    while (!q.empty()) {
+      auto V = q.front();
+      q.pop();
+
+      for (auto I = V->user_begin(), E = V->user_end(); I != E; ++I) {
+        llvm::User *U = *I;
+        if (visited.count(U))
+          continue;
+        else if (auto I = llvm::dyn_cast<llvm::IntrinsicInst>(U)) {
+          if (I->getIntrinsicID() == llvm::Intrinsic::lifetime_start)
+            return true;
+        }
+        visited.insert(U);
+        if (llvm::isa<llvm::BitCastInst>(U) ||
+            llvm::isa<llvm::GetElementPtrInst>(U) ||
+            llvm::isa<llvm::PHINode>(U))
+          q.push(U);
+      }
+    }
+    return false;
+  }
+
   RetTy visitAllocaInst(llvm::AllocaInst &i) {
     // TODO
     if (i.isArrayAllocation() || !i.isStaticAlloca())
@@ -361,7 +391,8 @@ public:
     // FIXME: size bits shouldn't be a constant
     auto size = make_intconst(DL().getTypeAllocSize(i.getAllocatedType()), 64);
     RETURN_IDENTIFIER(make_unique<Alloc>(*ty, value_name(i), *size,
-                        pref_alignment(i, i.getAllocatedType())));
+                        pref_alignment(i, i.getAllocatedType()),
+                        hasLifetimeStart(i)));
   }
 
   RetTy visitGetElementPtrInst(llvm::GetElementPtrInst &i) {

--- a/tests/alive-tv/memory/lifetime-2.src.ll
+++ b/tests/alive-tv/memory/lifetime-2.src.ll
@@ -1,7 +1,7 @@
 declare void @llvm.lifetime.start.p0i8(i64, i8*)
 declare void @llvm.lifetime.end.p0i8(i64, i8*)
 
-define i32 @f() {
+define i32 @f_end() {
   %p = alloca i32
 
   %p0 = bitcast i32* %p to i8*
@@ -10,6 +10,20 @@ define i32 @f() {
 
   store i32 10, i32* %p
   %v = load i32, i32* %p
+
+  ret i32 %v
+}
+
+define i32 @f_start() {
+  %p = alloca i32
+
+  store i32 10, i32* %p
+  ; load before lifetime.start can be optimized to undef
+  %v = load i32, i32* %p
+
+  %p0 = bitcast i32* %p to i8*
+  call void @llvm.lifetime.start.p0i8(i64 4, i8* %p0)
+  call void @llvm.lifetime.end.p0i8(i64 4, i8* %p0)
 
   ret i32 %v
 }

--- a/tests/alive-tv/memory/lifetime-2.tgt.ll
+++ b/tests/alive-tv/memory/lifetime-2.tgt.ll
@@ -1,7 +1,7 @@
 declare void @llvm.lifetime.start.p0i8(i64, i8*)
 declare void @llvm.lifetime.end.p0i8(i64, i8*)
 
-define i32 @f() {
+define i32 @f_end() {
   %p = alloca i32
 
   %p0 = bitcast i32* %p to i8*
@@ -9,6 +9,16 @@ define i32 @f() {
   call void @llvm.lifetime.end.p0i8(i64 4, i8* %p0)
 
   store i32 10, i32* %p
+
+  ret i32 undef
+}
+
+define i32 @f_start() {
+  %p = alloca i32
+
+  %p0 = bitcast i32* %p to i8*
+  call void @llvm.lifetime.start.p0i8(i64 4, i8* %p0)
+  call void @llvm.lifetime.end.p0i8(i64 4, i8* %p0)
 
   ret i32 undef
 }

--- a/tests/alive-tv/memory/lifetime-reorder.src.ll
+++ b/tests/alive-tv/memory/lifetime-reorder.src.ll
@@ -1,0 +1,52 @@
+declare void @llvm.lifetime.start.p0i8(i64, i8*)
+declare void @llvm.lifetime.end.p0i8(i64, i8*)
+
+define i8 @gep1() {
+  %p = alloca i32
+
+  %p0 = bitcast i32* %p to i8*
+  call void @llvm.lifetime.start.p0i8(i64 4, i8* %p0)
+  %p1 = getelementptr i8, i8* %p0, i32 1
+  store i8 10, i8* %p1
+  %v = load i8, i8* %p1
+  call void @llvm.lifetime.end.p0i8(i64 4, i8* %p0)
+
+  ret i8 %v
+}
+
+define i8 @gep2() {
+  %p = alloca i32
+
+  %p0 = bitcast i32* %p to i8*
+  %p1 = getelementptr i8, i8* %p0, i32 1
+  call void @llvm.lifetime.start.p0i8(i64 4, i8* %p0)
+  store i8 10, i8* %p1
+  %v = load i8, i8* %p1
+  call void @llvm.lifetime.end.p0i8(i64 4, i8* %p0)
+
+  ret i8 %v
+}
+
+define i64 @ptrtoint1() {
+  %p = alloca i32
+  %dummy = alloca i64
+
+  %p0 = bitcast i32* %p to i8*
+  %i = ptrtoint i32* %p to i64
+  call void @llvm.lifetime.start.p0i8(i64 4, i8* %p0)
+  call void @llvm.lifetime.end.p0i8(i64 4, i8* %p0)
+
+  ret i64 %i
+}
+
+define i64 @ptrtoint2() {
+  %p = alloca i32
+  %dummy = alloca i64
+
+  %p0 = bitcast i32* %p to i8*
+  call void @llvm.lifetime.start.p0i8(i64 4, i8* %p0)
+  %i = ptrtoint i32* %p to i64
+  call void @llvm.lifetime.end.p0i8(i64 4, i8* %p0)
+
+  ret i64 %i
+}

--- a/tests/alive-tv/memory/lifetime-reorder.tgt.ll
+++ b/tests/alive-tv/memory/lifetime-reorder.tgt.ll
@@ -1,0 +1,52 @@
+declare void @llvm.lifetime.start.p0i8(i64, i8*)
+declare void @llvm.lifetime.end.p0i8(i64, i8*)
+
+define i8 @gep1() {
+  %p = alloca i32
+
+  %p0 = bitcast i32* %p to i8*
+  %p1 = getelementptr i8, i8* %p0, i32 1
+  call void @llvm.lifetime.start.p0i8(i64 4, i8* %p0)
+  store i8 10, i8* %p1
+  %v = load i8, i8* %p1
+  call void @llvm.lifetime.end.p0i8(i64 4, i8* %p0)
+
+  ret i8 %v
+}
+
+define i8 @gep2() {
+  %p = alloca i32
+
+  %p0 = bitcast i32* %p to i8*
+  call void @llvm.lifetime.start.p0i8(i64 4, i8* %p0)
+  %p1 = getelementptr i8, i8* %p0, i32 1
+  store i8 10, i8* %p1
+  %v = load i8, i8* %p1
+  call void @llvm.lifetime.end.p0i8(i64 4, i8* %p0)
+
+  ret i8 %v
+}
+
+define i64 @ptrtoint1() {
+  %p = alloca i32
+  %dummy = alloca i64
+
+  %p0 = bitcast i32* %p to i8*
+  call void @llvm.lifetime.start.p0i8(i64 4, i8* %p0)
+  %i = ptrtoint i32* %p to i64
+  call void @llvm.lifetime.end.p0i8(i64 4, i8* %p0)
+
+  ret i64 %i
+}
+
+define i64 @ptrtoint2() {
+  %p = alloca i32
+  %dummy = alloca i64
+
+  %p0 = bitcast i32* %p to i8*
+  %i = ptrtoint i32* %p to i64
+  call void @llvm.lifetime.start.p0i8(i64 4, i8* %p0)
+  call void @llvm.lifetime.end.p0i8(i64 4, i8* %p0)
+
+  ret i64 %i
+}


### PR DESCRIPTION
Key changes are:

1. Alloca now takes 'is_dead' bool. If it is true, the block's liveness is initially set as false. But, the alloca still returns a non-null pointer to allow using the alloca (e.g. bitcast, gep) before lifetime.start().
This involves updating Memory::alloc()'s return type as a pair of expr, which is <a pointer to the block, is allocated?>.

2. llvm2alive.cpp checks whether alloca has lifetime.start uses. If it has, is_dead is set as true.

3. Memory::start_lifetime encodes disjointness as well as updates memory usage, if lifetime is updated.