### PR TITLE
Support nocapture

### DIFF
--- a/ir/instr.cpp
+++ b/ir/instr.cpp
@@ -1674,11 +1674,12 @@ StateValue Return::toSMT(State &s) const {
     nonpoisons.emplace_back(np1);
     bids.emplace_back(bid);
   }
+  auto &retval = s[*val];
   if (bids.size() != 0) {
-    addUBForNoCaptureRet(s, nonpoisons, bids, s[*val], val->getType());
+    addUBForNoCaptureRet(s, nonpoisons, bids, retval, val->getType());
     s.addUB(s.getMemory().has_noptrbyte(nonpoisons, bids));
   }
-  s.addReturn(s[*val]);
+  s.addReturn(retval);
 
   return {};
 }

--- a/ir/memory.cpp
+++ b/ir/memory.cpp
@@ -1233,19 +1233,22 @@ pair<expr,Pointer> Memory::refined(const Memory &other) const {
             move(ptr) };
 }
 
-expr Memory::has_noptrbyte(const expr &short_bid) const {
-  assert(short_bid.bits() == bits_for_bid - 1);
-
-  auto res = expr(true);
+expr Memory::has_noptrbyte(const vector<expr> &conds,
+                           const vector<expr> &bids) const {
+  assert(conds.size() != 0 && conds.size() == bids.size());
+  expr res(true);
   auto ofs = expr::mkFreshVar("ofs", expr::mkUInt(0, bits_for_offset));
 
   for (unsigned bid = 1; bid < num_nonlocals; ++bid) {
     Pointer p(*this, expr::mkUInt(bid, bits_for_bid), ofs);
     Byte b(*this, non_local_block_val.load(p.short_ptr()));
     Pointer loadp(*this, b.ptr_value());
+
+    expr c(true);
+    for (unsigned i = 0, e = bids.size(); i < e; ++i)
+      c &= conds[i].implies(loadp.get_bid() != bids[i]);
     res &= p.is_block_alive().implies(
-      expr::mkForAll({ ofs }, (b.is_ptr() && b.ptr_nonpoison()).implies(
-                                  loadp.get_short_bid() != short_bid)));
+      expr::mkForAll({ ofs }, (b.is_ptr() && b.ptr_nonpoison()).implies(c)));
   }
   return res;
 }

--- a/ir/memory.h
+++ b/ir/memory.h
@@ -238,8 +238,10 @@ public:
 
   std::pair<smt::expr,Pointer> refined(const Memory &other) const;
 
-  // Encodes existence of a pointer byte with a non-local short_bid.
-  smt::expr has_noptrbyte(const smt::expr &short_bid) const;
+  // Encodes existence of a pointer byte, bid of which is one of bids.
+  // If conds[i] is false, bids[i] is ignored.
+  smt::expr has_noptrbyte(const std::vector<smt::expr> &conds,
+                          const std::vector<smt::expr> &bids) const;
 
   static Memory mkIf(const smt::expr &cond, const Memory &then,
                      const Memory &els);

--- a/ir/memory.h
+++ b/ir/memory.h
@@ -238,6 +238,9 @@ public:
 
   std::pair<smt::expr,Pointer> refined(const Memory &other) const;
 
+  // Encodes existence of a pointer byte with a non-local short_bid.
+  smt::expr has_noptrbyte(const smt::expr &short_bid) const;
+
   static Memory mkIf(const smt::expr &cond, const Memory &then,
                      const Memory &els);
 

--- a/ir/value.cpp
+++ b/ir/value.cpp
@@ -154,6 +154,8 @@ static string attr_str(unsigned attributes) {
   string ret;
   if (attributes & Input::NonNull)
     ret += "nonnull ";
+  if (attributes & Input::NoCapture)
+    ret += "nocapture ";
   return ret;
 }
 

--- a/ir/value.h
+++ b/ir/value.h
@@ -109,7 +109,7 @@ public:
 
 class Input final : public Value {
 public:
-  enum Attributes { None = 0, NonNull = 1<<0 };
+  enum Attributes { None = 0, NonNull = 1<<0, NoCapture = 1<<1 };
 private:
   std::string smt_name;
   unsigned attributes;
@@ -117,6 +117,7 @@ public:
   Input(Type &type, std::string &&name, unsigned attributes = 0);
   void copySMTName(const Input &other);
   void print(std::ostream &os) const override;
+  bool hasAttribute(Attributes a) const { return (attributes & a) != 0; }
   StateValue toSMT(State &s) const override;
   smt::expr getTyVar() const;
 };

--- a/llvm_util/llvm2alive.cpp
+++ b/llvm_util/llvm2alive.cpp
@@ -742,6 +742,10 @@ public:
         attrs |= Input::NonNull;
         continue;
 
+      case llvm::Attribute::NoCapture:
+        attrs |= Input::NoCapture;
+        continue;
+
       default:
         *out << "ERROR: Unsupported attribute: " << attr.getAsString() << '\n';
         return {};

--- a/tests/alive-tv/attrs/nocapture.src.ll
+++ b/tests/alive-tv/attrs/nocapture.src.ll
@@ -1,0 +1,22 @@
+; TEST-ARGS: -disable-undef-input -disable-poison-input
+@x = global i8* null
+
+define void @f1(i8* nocapture %p) {
+  store i8* %p, i8** @x
+  ret void
+}
+
+define void @f2(i8* nocapture %p0) {
+  %p = getelementptr i8, i8* %p0, i32 1
+  store i8* %p, i8** @x
+  ret void
+}
+
+define i8* @f3(i8* nocapture %p) {
+  ret i8* %p
+}
+
+define i8* @f4(i8* nocapture %p) {
+  %p2 = getelementptr i8, i8* %p, i32 1
+  ret i8* %p2
+}

--- a/tests/alive-tv/attrs/nocapture.src.ll
+++ b/tests/alive-tv/attrs/nocapture.src.ll
@@ -1,4 +1,3 @@
-; TEST-ARGS: -disable-undef-input -disable-poison-input
 @x = global i8* null
 
 define void @f1(i8* nocapture %p) {

--- a/tests/alive-tv/attrs/nocapture.src.ll
+++ b/tests/alive-tv/attrs/nocapture.src.ll
@@ -20,13 +20,8 @@ define i8* @f4(i8* nocapture %p) {
   ret i8* %p2
 }
 
-;define {i8*, i8*} @f5(i8* nocapture %p) {
-;  %v = insertvalue {i8*, i8*} undef, i8* %p, 1
-;  ret {i8*, i8*} %v
-;}
+define <2 x i8*> @f5(i8* nocapture %p) {
+  %v = insertelement <2 x i8*> undef, i8* %p, i32 1
+  ret <2 x i8*> %v
+}
 
-;define {i8*, {i8*, i8*}} @f6(i8* nocapture %p) {
-;  %v = insertvalue {i8*, i8*} undef, i8* %p, 0
-;  %w = insertvalue {i8*, {i8*, i8*}} undef, {i8*, i8*} %v, 1
-;  ret {i8*, {i8*, i8*}} %w
-;}

--- a/tests/alive-tv/attrs/nocapture.src.ll
+++ b/tests/alive-tv/attrs/nocapture.src.ll
@@ -19,3 +19,14 @@ define i8* @f4(i8* nocapture %p) {
   %p2 = getelementptr i8, i8* %p, i32 1
   ret i8* %p2
 }
+
+;define {i8*, i8*} @f5(i8* nocapture %p) {
+;  %v = insertvalue {i8*, i8*} undef, i8* %p, 1
+;  ret {i8*, i8*} %v
+;}
+
+;define {i8*, {i8*, i8*}} @f6(i8* nocapture %p) {
+;  %v = insertvalue {i8*, i8*} undef, i8* %p, 0
+;  %w = insertvalue {i8*, {i8*, i8*}} undef, {i8*, i8*} %v, 1
+;  ret {i8*, {i8*, i8*}} %w
+;}

--- a/tests/alive-tv/attrs/nocapture.tgt.ll
+++ b/tests/alive-tv/attrs/nocapture.tgt.ll
@@ -22,15 +22,8 @@ define i8* @f4(i8* nocapture %p) {
   ret i8* %poison
 }
 
-;define {i8*, i8*} @f5(i8* nocapture %p) {
-;  %poison = getelementptr inbounds i8, i8* null, i64 1
-;  %v = insertvalue {i8*, i8*} undef, i8* %poison, 1
-;  ret {i8*, i8*} %v
-;}
-
-;define {i8*, {i8*, i8*}} @f6(i8* nocapture %p) {
-;  %poison = getelementptr inbounds i8, i8* null, i64 1
-;  %v = insertvalue {i8*, i8*} undef, i8* %poison, 0
-;  %w = insertvalue {i8*, {i8*, i8*}} undef, {i8*, i8*} %v, 1
-;  ret {i8*, {i8*, i8*}} %w
-;}
+define <2 x i8*> @f5(i8* nocapture %p) {
+  %poison = getelementptr inbounds i8, i8* null, i64 1
+  %v = insertelement <2 x i8*> undef, i8* %poison, i32 1
+  ret <2 x i8*> %v
+}

--- a/tests/alive-tv/attrs/nocapture.tgt.ll
+++ b/tests/alive-tv/attrs/nocapture.tgt.ll
@@ -21,3 +21,16 @@ define i8* @f4(i8* nocapture %p) {
   %poison = getelementptr inbounds i8, i8* null, i64 1
   ret i8* %poison
 }
+
+;define {i8*, i8*} @f5(i8* nocapture %p) {
+;  %poison = getelementptr inbounds i8, i8* null, i64 1
+;  %v = insertvalue {i8*, i8*} undef, i8* %poison, 1
+;  ret {i8*, i8*} %v
+;}
+
+;define {i8*, {i8*, i8*}} @f6(i8* nocapture %p) {
+;  %poison = getelementptr inbounds i8, i8* null, i64 1
+;  %v = insertvalue {i8*, i8*} undef, i8* %poison, 0
+;  %w = insertvalue {i8*, {i8*, i8*}} undef, {i8*, i8*} %v, 1
+;  ret {i8*, {i8*, i8*}} %w
+;}

--- a/tests/alive-tv/attrs/nocapture.tgt.ll
+++ b/tests/alive-tv/attrs/nocapture.tgt.ll
@@ -1,0 +1,23 @@
+@x = global i8* null
+
+define void @f1(i8* nocapture %p) {
+  %poison = getelementptr inbounds i8, i8* null, i64 1
+  store i8* %poison, i8** @x
+  ret void
+}
+
+define void @f2(i8* nocapture %p) {
+  %poison = getelementptr inbounds i8, i8* null, i64 1
+  store i8* %poison, i8** @x
+  ret void
+}
+
+define i8* @f3(i8* nocapture %p) {
+  %poison = getelementptr inbounds i8, i8* null, i64 1
+  ret i8* %poison
+}
+
+define i8* @f4(i8* nocapture %p) {
+  %poison = getelementptr inbounds i8, i8* null, i64 1
+  ret i8* %poison
+}


### PR DESCRIPTION
This is a PR for supporting nocapture attribute.

Fully supporting it requires significant job (and its semantics is not clear when poison is involved as discussed).

This patch is WIP; feel free to leave comments. I'll be back and update this soon.

Here is the list of sanity checks of nocapture that I think should be satisfied + sanity checks from LLVM's nocapture tests.

1.
```
define void @f(i8* nocapture %p) {
    store %p, @glb // should be UB
}
```

2. 
```
define void @g(i8* nocapture %p, i8* %q) {
    // p == q can happen unless noalias is given
    store %q, @glb // should not be UB even if p == q.
}
```

3.
```
define void @g(i8* nocapture %ptr) {
  ret ptr // UB. Transforms/Attributor/nocapture-2.ll
}

define void @g(i8* nocapture %ptr) {
  ret (gep ptr, 1) // UB. Transforms/Attributor/nocapture-2.ll
}
```

4.
```
define void @f(i8** %p, i8** %q, i8* nocapture %r) { 
    i8* %tmp = *p; // %tmp can be %r
    *%p = null;
    *%q = %tmp; // this should not be UB.
}
```

The list above does not include tests regarding ptrtoints. nocapture should be applied when the pointer is casted to integer and something dependent on the value happened too, but this should be the next PR (or the future work).