### PR TITLE
Add -max-mem to alive-tv

### DIFF
--- a/tools/alive-tv.cpp
+++ b/tools/alive-tv.cpp
@@ -68,6 +68,10 @@ static llvm::cl::opt<bool> opt_smt_stats(
     "smt-stats", llvm::cl::desc("Alive: show SMT statistics"),
     llvm::cl::cat(opt_alive), llvm::cl::init(false));
 
+static llvm::cl::opt<unsigned> opt_max_mem(
+     "max-mem", llvm::cl::desc("Alive: max memory (aprox)"),
+     llvm::cl::init(1024), llvm::cl::value_desc("MB"));
+
 static llvm::cl::opt<bool> opt_bidirectional("bidirectional",
     llvm::cl::init(false), llvm::cl::cat(opt_alive),
     llvm::cl::desc("Alive: Run refinement check in both directions"));
@@ -283,7 +287,7 @@ int main(int argc, char **argv) {
   smt::solver_print_queries(opt_smt_verbose);
   smt::solver_tactic_verbose(false);
   smt::set_query_timeout(to_string(opt_smt_to));
-  smt::set_memory_limit(1024 * 1024 * 1024);
+  smt::set_memory_limit((uint64_t)opt_max_mem * 1024 * 1024);
   //config::skip_smt = opt_smt_skip;
   config::symexec_print_each_value = opt_se_verbose;
   config::disable_undef_input = opt_disable_undef;


### PR DESCRIPTION
This PR adds the -max-mem option to alive-tv which only existed for tv.