### PR TITLE
Report fatal error even if tv-exit-on-error is not given

### DIFF
--- a/tv/tv.cpp
+++ b/tv/tv.cpp
@@ -92,6 +92,7 @@ unordered_map<string, pair<Function, unsigned>> fns;
 unsigned initialized = 0;
 bool showed_stats = false;
 bool report_dir_created = false;
+bool has_failure = false;
 
 
 struct TVPass : public llvm::FunctionPass {
@@ -159,6 +160,7 @@ struct TVPass : public llvm::FunctionPass {
 
         llvm::report_fatal_error("Alive2: Transform doesn't verify; aborting!");
       }
+      has_failure |= errs.isUnsound();
     } else {
       *out << "Transformation seems to be correct!\n\n";
     }
@@ -224,6 +226,13 @@ struct TVPass : public llvm::FunctionPass {
     if (opt_smt_stats && !showed_stats) {
       smt::solver_print_stats(*out);
       showed_stats = true;
+
+      if (has_failure) {
+        if (!report_filename.empty())
+          cerr << "Report written to " << report_filename << endl;
+
+        llvm::report_fatal_error("Alive2: Transform doesn't verify; aborting!");
+      }
     }
     llvm_util_init.reset();
     smt_init.reset();


### PR DESCRIPTION
Currently LLVM unit tests are run with `-tv-exit-on-error`, which hides succeeding tests after the first failure.

To run all tests, `-tv-exit-on-error` should be dropped, but it causes tv to report success to llvm-lit even if there was an incorrect optimization.

This PR resolves it. I think making tv explicitly fail is better because it allows tv to report any unit test having failure.