### PR TITLE
Ignore -attributor , -functionattrs

### DIFF
--- a/scripts/opt-alive.sh
+++ b/scripts/opt-alive.sh
@@ -7,7 +7,8 @@ set -e
 # place-safepoints: places new function calls (@do_safepoint)
 # loop-extract: extracts a top-level loop into a distinct function
 # extract-blocks: extract specified blocks into a distinct function
-PASSES="argpromotion deadargelim globalopt hotcoldsplit inline ipconstprop ipsccp mergefunc partial-inliner tbaa insert-gcov-profiling switch-to-lookup safe-stack pgo-instr-gen loop-extract extract-blocks place-safepoints -Os -Oz -O1 -O2 -O3"
+# attributor, functionattrs: inter procedural pass that deduces and/or propagates attributes
+PASSES="argpromotion deadargelim globalopt hotcoldsplit inline ipconstprop ipsccp mergefunc partial-inliner tbaa insert-gcov-profiling switch-to-lookup safe-stack pgo-instr-gen loop-extract extract-blocks place-safepoints attributor functionattrs -Os -Oz -O1 -O2 -O3"
 
 TV="-tv"
 for p in $PASSES; do


### PR DESCRIPTION
Ignore -attributor , -functionattrs when running tv because they are interprocedural passes.

attributor (Attributor.cpp):
```
// This file implements an inter procedural pass that deduces and/or propagating
// attributes. This is done in an abstract interpretation style fixpoint
// iteration. See the Attributor.h file comment and the class descriptions in
// that file for more information.
```

functionattrs (FunctionAttrs.cpp):
```
/// This file implements interprocedural passes which walk the
/// call-graph deducing and/or propagating function attributes.
```