### PR TITLE
Let memset raise UB if vbytes is larger than bits_size_t

### DIFF
--- a/ir/instr.cpp
+++ b/ir/instr.cpp
@@ -2048,6 +2048,9 @@ StateValue Memset::toSMT(State &s) const {
   auto &[vbytes, np_bytes] = s[*bytes];
   s.addUB(vbytes.ugt(0).implies(np_ptr));
   s.addUB(np_bytes);
+  if (vbytes.bits() > bits_size_t)
+    s.addUB(np_bytes.implies(vbytes.ule(
+        expr::mkInt(-1, bits_size_t).zext(vbytes.bits() - bits_size_t))));
   s.getMemory().memset(vptr, s[*val].zextOrTrunc(8), vbytes, align);
   return {};
 }

--- a/tests/alive-tv/memory/memset-large.src.ll
+++ b/tests/alive-tv/memory/memset-large.src.ll
@@ -1,0 +1,8 @@
+; TEST-ARGS: -smt-to=2000 -disable-undef-input
+declare void @llvm.memset.p0i8.i128(i8*, i8, i128, i1)
+
+define void @f(i8* %p, i128 %n) {
+  %n2 = add nuw i128 %n, 1
+  call void @llvm.memset.p0i8.i128(i8* %p, i8 0, i128 %n2, i1 0)
+  ret void
+}

--- a/tests/alive-tv/memory/memset-large.tgt.ll
+++ b/tests/alive-tv/memory/memset-large.tgt.ll
@@ -1,0 +1,8 @@
+declare void @llvm.memset.p0i8.i128(i8*, i8, i128, i1)
+
+define void @f(i8* %p, i128 %n) {
+  store i8 0, i8* %p
+  %p2 = getelementptr i8, i8* %p, i64 1
+  call void @llvm.memset.p0i8.i128(i8* %p2, i8 0, i128 %n, i1 0)
+  ret void
+}


### PR DESCRIPTION
This PR makes memset raise UB if the size does not fit in the pointer size.

Before this patch, memset's size was truncated to bits_size_t. This causes optimization that reduces memset's size to raise when overflow could happen.
ex)
```
memset(p, 0, i128 0x0000...10000...) // after truncation, size is 0
*p = 1;
->
memset(p+1, 0, i128 0x0000..0FFFF...) // after truncation, size is FFFF...
*p = 1;
```

This resolves Transforms/MemCpyOpt/memset-memcpy-redundant-memset.ll 's `@test_different_types_i128_i32`.
