### PR TITLE
Add attribute bits to pointer & support nocapture

### DIFF
--- a/ir/globals.cpp
+++ b/ir/globals.cpp
@@ -8,6 +8,7 @@ namespace IR {
 unsigned num_max_nonlocals_inst;
 unsigned num_locals;
 unsigned num_nonlocals;
+unsigned bits_for_ptrattrs;
 unsigned bits_for_bid;
 unsigned bits_for_offset;
 unsigned bits_size_t;

--- a/ir/globals.cpp
+++ b/ir/globals.cpp
@@ -19,6 +19,7 @@ bool has_int2ptr;
 bool has_ptr2int;
 bool has_malloc;
 bool has_free;
+bool has_nocapture;
 bool has_dead_allocas;
 bool does_int_mem_access;
 bool does_ptr_mem_access;

--- a/ir/globals.h
+++ b/ir/globals.h
@@ -14,6 +14,9 @@ extern unsigned num_locals;
 // Upperbound of the number of nonlocal blocks
 extern unsigned num_nonlocals;
 
+/// Number of bits needed for attributes of pointers (e.g. nocapture).
+extern unsigned bits_for_ptrattrs;
+
 /// Number of bits needed for encoding a memory block id
 extern unsigned bits_for_bid;
 

--- a/ir/globals.h
+++ b/ir/globals.h
@@ -42,6 +42,9 @@ extern bool has_ptr2int;
 extern bool has_malloc;
 extern bool has_free;
 
+/// Whether any function argument (not function call arg) has the attribute
+extern bool has_nocapture;
+
 /// Whether there are allocas that are initially dead (need start_lifetime)
 extern bool has_dead_allocas;
 

--- a/ir/instr.cpp
+++ b/ir/instr.cpp
@@ -1233,9 +1233,7 @@ StateValue ICmp::toSMT(State &s) const {
        elem_ty.getAsAggregateType()->getChild(0).isPtrType())) {
     fn = [&](auto &av, auto &bv, Cond cond) {
       Pointer lhs(s.getMemory(), av);
-      lhs.strip_attrs();
       Pointer rhs(s.getMemory(), bv);
-      rhs.strip_attrs();
       switch (cond) {
       case EQ:  return StateValue(lhs == rhs, true);
       case NE:  return StateValue(lhs != rhs, true);

--- a/ir/instr.cpp
+++ b/ir/instr.cpp
@@ -1233,7 +1233,9 @@ StateValue ICmp::toSMT(State &s) const {
        elem_ty.getAsAggregateType()->getChild(0).isPtrType())) {
     fn = [&](auto &av, auto &bv, Cond cond) {
       Pointer lhs(s.getMemory(), av);
+      lhs.strip_attrs();
       Pointer rhs(s.getMemory(), bv);
+      rhs.strip_attrs();
       switch (cond) {
       case EQ:  return StateValue(lhs == rhs, true);
       case NE:  return StateValue(lhs != rhs, true);
@@ -1640,8 +1642,28 @@ void Return::print(ostream &os) const {
   os << val->getName();
 }
 
+static void addUBForNoCaptureRet(State &s, const StateValue &svret,
+                                 const Type &t) {
+  auto &[vret, npret] = svret;
+  if (t.isPtrType()) {
+    s.addUB(npret.implies(!Pointer(s.getMemory(), vret).is_nocapture()));
+    return;
+  }
+
+  if (auto agg = t.getAsAggregateType()) {
+    for (unsigned i = 0, e = agg->numElementsConst(); i != e; ++i) {
+      addUBForNoCaptureRet(s, agg->extract(svret, i), agg->getChild(i));
+    }
+  }
+}
+
 StateValue Return::toSMT(State &s) const {
-  s.addReturn(s[*val]);
+  // Encode nocapture semantics.
+  auto &retval = s[*val];
+  s.addUB(s.getMemory().check_nocapture());
+  addUBForNoCaptureRet(s, retval, val->getType());
+  s.addReturn(retval);
+
   return {};
 }
 

--- a/ir/memory.cpp
+++ b/ir/memory.cpp
@@ -276,13 +276,15 @@ static unsigned bits_shortbid() {
 namespace IR {
 
 Pointer::Pointer(const Memory &m, const char *var_name, const expr &local,
-                 bool unique_name) : m(m) {
+                 bool unique_name, bool has_attr) : m(m) {
   string name = var_name;
   if (unique_name)
     name += '!' + to_string(ptr_next_idx++);
-  p = prepend_if(local.toBVBool(),
-                 expr::mkVar(name.c_str(), total_bits() - ptr_has_local_bit()),
-                 ptr_has_local_bit());
+  unsigned bits = total_bits() - ptr_has_local_bit() -
+                  (has_attr ? 0 : bits_for_ptrattrs);
+  p = prepend_if(local.toBVBool(), expr::mkVar(name.c_str(), bits),
+                 ptr_has_local_bit())
+                 .concat_zeros(has_attr ? 0 : bits_for_ptrattrs);
   assert(!p.isValid() || p.bits() == total_bits());
 }
 
@@ -291,21 +293,28 @@ Pointer::Pointer(const Memory &m, expr repr) : m(m), p(move(repr)) {
 }
 
 Pointer::Pointer(const Memory &m, unsigned bid, bool local)
-  : m(m), p(prepend_if(expr::mkUInt(local, 1),
-                       expr::mkUInt(bid, bits_shortbid())
-                         .concat(expr::mkUInt(0, bits_for_offset)),
-                       ptr_has_local_bit())) {
+  : m(m), p(
+    prepend_if(expr::mkUInt(local, 1),
+               expr::mkUInt(bid, bits_shortbid())
+                 .concat(expr::mkUInt(0, bits_for_offset + bits_for_ptrattrs)),
+               ptr_has_local_bit())) {
   assert((local && bid < num_locals) || (!local && bid < num_nonlocals));
   assert(p.bits() == total_bits());
 }
 
 Pointer::Pointer(const Memory &m, const expr &bid, const expr &offset)
-  : m(m), p(bid.concat(offset)) {
+  : m(m), p(bid.concat(offset).concat_zeros(bits_for_ptrattrs)) {
+  assert(!p.isValid() || p.bits() == total_bits());
+}
+
+Pointer::Pointer(const Memory &m, const expr &bid, const expr &offset,
+                 const expr &attrs)
+  : m(m), p(bid.concat(offset).concat(attrs)) {
   assert(!p.isValid() || p.bits() == total_bits());
 }
 
 unsigned Pointer::total_bits() {
-  return bits_for_bid + bits_for_offset;
+  return bits_for_ptrattrs + bits_for_bid + bits_for_offset;
 }
 
 expr Pointer::is_local() const {
@@ -318,15 +327,21 @@ expr Pointer::is_local() const {
 }
 
 expr Pointer::get_bid() const {
-  return p.extract(total_bits() - 1, bits_for_offset);
+  return p.extract(total_bits() - 1, bits_for_offset + bits_for_ptrattrs);
 }
 
 expr Pointer::get_short_bid() const {
-  return p.extract(total_bits() - 1 - ptr_has_local_bit(), bits_for_offset);
+  return p.extract(total_bits() - 1 - ptr_has_local_bit(),
+                   bits_for_offset + bits_for_ptrattrs);
 }
 
 expr Pointer::get_offset() const {
-  return p.extract(bits_for_offset - 1, 0).sextOrTrunc(bits_size_t);
+  return p.extract(bits_for_offset + bits_for_ptrattrs - 1, bits_for_ptrattrs)
+          .sextOrTrunc(bits_size_t);
+}
+
+expr Pointer::get_attrs() const {
+  return p.extract(bits_for_ptrattrs - 1, 0);
 }
 
 expr Pointer::get_value(const char *name, const FunctionExpr &local_fn,
@@ -380,12 +395,15 @@ expr Pointer::block_size() const {
 }
 
 expr Pointer::short_ptr() const {
-  return p.extract(total_bits() - 1 - ptr_has_local_bit(), 0);
+  return p.extract(total_bits() - 1 - ptr_has_local_bit(), bits_for_ptrattrs);
 }
 
 Pointer Pointer::operator+(const expr &bytes) const {
   expr off = (get_offset() + bytes.zextOrTrunc(bits_size_t));
-  return { m, get_bid(), off.trunc(bits_for_offset) };
+  if (bits_for_ptrattrs)
+    return { m, get_bid(), off.trunc(bits_for_offset), get_attrs() };
+  else
+    return { m, get_bid(), off.trunc(bits_for_offset) };
 }
 
 Pointer Pointer::operator+(unsigned bytes) const {
@@ -410,6 +428,7 @@ expr Pointer::operator!=(const Pointer &rhs) const {
 
 #define DEFINE_CMP(op)                                                      \
 StateValue Pointer::op(const Pointer &rhs) const {                          \
+  /* Note that attrs are not compared. */                                   \
   return { get_offset().op(rhs.get_offset()), get_bid() == rhs.get_bid() }; \
 }
 
@@ -572,6 +591,7 @@ expr Pointer::refined(const Pointer &other) const {
   expr local = get_alloc_type() == other.get_alloc_type();
   local &= block_size() == other.block_size();
   local &= get_offset() == other.get_offset();
+  // Attributes are ignored at refinement.
 
   // TODO: this induces an infinite loop
   //local &= block_refined(other);
@@ -682,9 +702,15 @@ expr Pointer::is_byval() const {
   return !is_local() && non_local;
 }
 
+expr Pointer::is_nocapture() const {
+  if (bits_for_ptrattrs == 0)
+    return false;
+  return get_attrs() == 1;
+}
+
 Pointer Pointer::mkNullPointer(const Memory &m) {
   assert(num_nonlocals > 0);
-  // A null pointer points to block 0.
+  // A null pointer points to block 0 without any attribute.
   return { m, 0, false };
 }
 
@@ -700,6 +726,13 @@ expr Pointer::isNonZero() const {
   return !isNull();
 }
 
+void Pointer::strip_attrs() {
+  if (!bits_for_ptrattrs)
+    return;
+  p = p.extract(total_bits() - 1, bits_for_ptrattrs)
+       .concat_zeros(bits_for_ptrattrs);
+}
+
 ostream& operator<<(ostream &os, const Pointer &p) {
   if (p.isNull().isTrue())
     return os << "null";
@@ -709,6 +742,11 @@ ostream& operator<<(ostream &os, const Pointer &p) {
   p.get_bid().printUnsigned(os);
   os << ", offset=";
   p.get_offset().printSigned(os);
+
+  if (bits_for_ptrattrs) {
+    os << ", attrs=";
+    p.get_attrs().printUnsigned(os);
+  }
   return os << ')';
 }
 
@@ -763,9 +801,10 @@ Memory::Memory(State &state) : state(&state) {
                     expr::mkUInt(0, bits_shortbid() + bits_for_offset),
                     expr::mkUInt(0, Byte::bitsByte()));
 
-  // Non-local blocks cannot initially contain pointers to local blocks.
+  // Non-local blocks cannot initially contain pointers to local blocks
+  // and no-capture pointers.
   if (does_ptr_mem_access) {
-    auto idx = Pointer(*this, "#idx", false, false).short_ptr();
+    auto idx = Pointer(*this, "#idx", false, false, false).short_ptr();
 #if 0
     if (num_nonlocals > 0) {
       expr is_ptr = expr::mkUF("blk_init_isptr", { idx }, true);
@@ -799,6 +838,7 @@ Memory::Memory(State &state) : state(&state) {
       state.addAxiom(
         expr::mkForAll({ idx },
           byte.is_ptr().implies(!loadedptr.is_local() &&
+                                !loadedptr.is_nocapture() &&
                                 bid.ule(num_nonlocals - 1))));
     }
 #endif
@@ -914,10 +954,7 @@ void Memory::markByVal(unsigned bid) {
 }
 
 expr Memory::mkInput(const char *name, unsigned attributes) const {
-  Pointer p(*this,
-    prepend_if(expr::mkUInt(0, 1),
-               expr::mkVar(name, bits_shortbid() + bits_for_offset),
-               ptr_has_local_bit()));
+  Pointer p(*this, name, false, false);
   state->addAxiom(p.get_short_bid().ule(num_nonlocals - 1));
 
   if (attributes & Input::NonNull)
@@ -941,13 +978,14 @@ pair<expr, expr> Memory::mkUndefInput(unsigned attributes) const {
                           one << var.zextOrTrunc(bits_for_offset));
     offset = undef.extract(bits_undef - 1, log_offset) | shl;
   }
+  // Undef pointer does not have any attribute.
   Pointer p(*this, expr::mkUInt(0, bits_for_bid), offset);
   return { p.release(), move(undef) };
 }
 
 expr Memory::mkFnRet(const char *name) const {
   // TODO: can only alias with escaped local blocks!
-  Pointer p(*this, expr::mkVar(name, bits_for_bid + bits_for_offset));
+  Pointer p(*this, expr::mkVar(name, Pointer::total_bits()));
   state->addAxiom(expr::mkIf(p.is_local(),
                              p.get_short_bid().ule(num_locals - 1),
                              p.get_short_bid().ule(num_nonlocals - 1)));

--- a/ir/memory.cpp
+++ b/ir/memory.cpp
@@ -707,7 +707,7 @@ expr Pointer::is_byval() const {
 expr Pointer::is_nocapture() const {
   if (bits_for_ptrattrs == 0)
     return false;
-  return get_attrs() == 1;
+  return p.extract(0, 0) == 1;
 }
 
 Pointer Pointer::mkNullPointer(const Memory &m) {

--- a/ir/memory.cpp
+++ b/ir/memory.cpp
@@ -955,7 +955,7 @@ expr Memory::mkInput(const char *name, unsigned attributes) const {
             bits_for_ptrattrs ? expr::mkUInt(is_nocapture, bits_for_ptrattrs) :
                                 expr());
   if (attributes & Input::NonNull)
-    state->addPre(p.isNonZero());
+    state->addAxiom(p.isNonZero());
   state->addAxiom(p.get_short_bid().ule(num_nonlocals - 1));
 
   return p.release();

--- a/ir/memory.cpp
+++ b/ir/memory.cpp
@@ -421,7 +421,8 @@ expr Pointer::add_no_overflow(const expr &offset) const {
 }
 
 expr Pointer::operator==(const Pointer &rhs) const {
-  return p == rhs.p;
+  return p.extract(total_bits() - 1, bits_for_ptrattrs) ==
+         rhs.p.extract(total_bits() - 1, bits_for_ptrattrs);
 }
 
 expr Pointer::operator!=(const Pointer &rhs) const {
@@ -726,13 +727,6 @@ expr Pointer::isNonZero() const {
   if (observes_addresses())
     return get_address() != 0;
   return !isNull();
-}
-
-void Pointer::strip_attrs() {
-  if (!bits_for_ptrattrs)
-    return;
-  p = p.extract(total_bits() - 1, bits_for_ptrattrs)
-       .concat_zeros(bits_for_ptrattrs);
 }
 
 ostream& operator<<(ostream &os, const Pointer &p) {

--- a/ir/memory.cpp
+++ b/ir/memory.cpp
@@ -706,7 +706,7 @@ expr Pointer::is_byval() const {
 }
 
 expr Pointer::is_nocapture() const {
-  if (bits_for_ptrattrs == 0)
+  if (!has_nocapture)
     return false;
   return p.extract(0, 0) == 1;
 }

--- a/ir/memory.h
+++ b/ir/memory.h
@@ -96,7 +96,7 @@ class Pointer {
 public:
   Pointer(const Memory &m, const char *var_name,
           const smt::expr &local = false, bool unique_name = true,
-          bool has_attr = true);
+          const smt::expr &attr = smt::expr());
   Pointer(const Memory &m, smt::expr p);
   Pointer(const Memory &m, unsigned bid, bool local);
   Pointer(const Memory &m, const smt::expr &bid, const smt::expr &offset);

--- a/ir/memory.h
+++ b/ir/memory.h
@@ -173,8 +173,6 @@ public:
   smt::expr isNull() const;
   smt::expr isNonZero() const;
 
-  void strip_attrs();
-
   friend std::ostream& operator<<(std::ostream &os, const Pointer &p);
 };
 

--- a/ir/memory.h
+++ b/ir/memory.h
@@ -254,6 +254,9 @@ public:
 
   std::pair<smt::expr,Pointer> refined(const Memory &other) const;
 
+  // Returns true if a nocapture pointer byte is not in the memory.
+  smt::expr check_nocapture() const;
+
   static Memory mkIf(const smt::expr &cond, const Memory &then,
                      const Memory &els);
 

--- a/ir/type.cpp
+++ b/ir/type.cpp
@@ -4,7 +4,6 @@
 #include "ir/type.h"
 #include "ir/globals.h"
 #include "ir/state.h"
-#include "ir/value.h"
 #include "smt/solver.h"
 #include "util/compiler.h"
 #include <array>
@@ -816,7 +815,7 @@ expr AggregateType::mkInput(State &s, const char *name, unsigned attrs) const {
   expr val;
   for (unsigned i = 0; i < elements; ++i) {
     string c_name = string(name) + "#" + to_string(i);
-    auto v = children[i]->mkInput(s, c_name.c_str(), 0); // don't propagate attr
+    auto v = children[i]->mkInput(s, c_name.c_str(), attrs);
     v = children[i]->toBV(move(v));
     val = i == 0 ? move(v) : val.concat(v);
   }
@@ -829,7 +828,7 @@ AggregateType::mkUndefInput(State &s, unsigned attrs) const {
   vector<expr> vars;
 
   for (unsigned i = 0; i < elements; ++i) {
-    auto [v, vs] = children[i]->mkUndefInput(s, 0); // don't propagate attr
+    auto [v, vs] = children[i]->mkUndefInput(s, attrs);
     v = children[i]->toBV(move(v));
     val = i == 0 ? move(v) : val.concat(v);
     vars.insert(vars.end(), vs.begin(), vs.end());

--- a/ir/type.cpp
+++ b/ir/type.cpp
@@ -4,6 +4,7 @@
 #include "ir/type.h"
 #include "ir/globals.h"
 #include "ir/state.h"
+#include "ir/value.h"
 #include "smt/solver.h"
 #include "util/compiler.h"
 #include <array>
@@ -815,7 +816,7 @@ expr AggregateType::mkInput(State &s, const char *name, unsigned attrs) const {
   expr val;
   for (unsigned i = 0; i < elements; ++i) {
     string c_name = string(name) + "#" + to_string(i);
-    auto v = children[i]->mkInput(s, c_name.c_str(), attrs);
+    auto v = children[i]->mkInput(s, c_name.c_str(), 0); // don't propagate attr
     v = children[i]->toBV(move(v));
     val = i == 0 ? move(v) : val.concat(v);
   }
@@ -828,7 +829,7 @@ AggregateType::mkUndefInput(State &s, unsigned attrs) const {
   vector<expr> vars;
 
   for (unsigned i = 0; i < elements; ++i) {
-    auto [v, vs] = children[i]->mkUndefInput(s, attrs);
+    auto [v, vs] = children[i]->mkUndefInput(s, 0); // don't propagate attr
     v = children[i]->toBV(move(v));
     val = i == 0 ? move(v) : val.concat(v);
     vars.insert(vars.end(), vs.begin(), vs.end());

--- a/ir/type.cpp
+++ b/ir/type.cpp
@@ -538,7 +538,7 @@ expr PtrType::ASVar() const {
 }
 
 unsigned PtrType::bits() const {
-  return bits_for_offset + bits_for_bid;
+  return Pointer::total_bits();
 }
 
 StateValue PtrType::getDummyValue(bool non_poison) const {

--- a/ir/value.cpp
+++ b/ir/value.cpp
@@ -202,11 +202,6 @@ StateValue Input::toSMT(State &s) const {
     val = expr::mkIf(type.extract(0, 0) == 0, val, undef);
   }
 
-  if (getType().isPtrType()) {
-    auto nocap = Pointer(s.getMemory(), val).is_nocapture();
-    s.addAxiom((attributes & NoCapture) ? nocap : !nocap);
-  }
-
   expr poison = getType().getDummyValue(false).non_poison;
   expr non_poison = getType().getDummyValue(true).non_poison;
 

--- a/ir/value.cpp
+++ b/ir/value.cpp
@@ -162,6 +162,8 @@ static string attr_str(unsigned attributes) {
     ret += "nonnull ";
   if (attributes & Input::ByVal)
     ret += "byval ";
+  if (attributes & Input::NoCapture)
+    ret += "nocapture ";
   return ret;
 }
 
@@ -198,6 +200,11 @@ StateValue Input::toSMT(State &s) const {
       s.addUndefVar(move(v));
     }
     val = expr::mkIf(type.extract(0, 0) == 0, val, undef);
+  }
+
+  if (getType().isPtrType()) {
+    auto nocap = Pointer(s.getMemory(), val).is_nocapture();
+    s.addAxiom((attributes & NoCapture) ? nocap : !nocap);
   }
 
   expr poison = getType().getDummyValue(false).non_poison;

--- a/ir/value.h
+++ b/ir/value.h
@@ -109,7 +109,7 @@ public:
 
 class Input final : public Value {
 public:
-  enum Attribute { None = 0, NonNull = 1<<0, ByVal = 1<<1 };
+  enum Attribute { None = 0, NonNull = 1<<0, ByVal = 1<<1, NoCapture = 1<<2 };
 private:
   std::string smt_name;
   unsigned attributes;
@@ -117,6 +117,7 @@ public:
   Input(Type &type, std::string &&name, unsigned attributes = 0);
   void copySMTName(const Input &other);
   void print(std::ostream &os) const override;
+  bool hasAttribute(Attribute a) const { return (attributes & a) != 0; }
   StateValue toSMT(State &s) const override;
   smt::expr getTyVar() const;
 };

--- a/llvm_util/llvm2alive.cpp
+++ b/llvm_util/llvm2alive.cpp
@@ -746,6 +746,10 @@ public:
         attrs |= Input::NonNull;
         continue;
 
+      case llvm::Attribute::NoCapture:
+        attrs |= Input::NoCapture;
+        continue;
+
       default:
         *out << "ERROR: Unsupported attribute: " << attr.getAsString() << '\n';
         return {};

--- a/smt/expr.cpp
+++ b/smt/expr.cpp
@@ -1196,6 +1196,10 @@ expr expr::concat(const expr &rhs) const {
   return binop_fold(rhs, Z3_mk_concat);
 }
 
+expr expr::concat_zeros(unsigned bits) const {
+  return bits ? concat(expr::mkUInt(0, bits)) : *this;
+}
+
 expr expr::extract(unsigned high, unsigned low) const {
   C();
   assert(high >= low && high < bits());

--- a/smt/expr.h
+++ b/smt/expr.h
@@ -244,6 +244,7 @@ public:
   expr zextOrTrunc(unsigned tobw) const;
 
   expr concat(const expr &rhs) const;
+  expr concat_zeros(unsigned bits) const;
   expr extract(unsigned high, unsigned low) const;
 
   expr toBVBool() const;

--- a/tests/alive-tv/attrs/nocapture-icmp.src.ll
+++ b/tests/alive-tv/attrs/nocapture-icmp.src.ll
@@ -1,0 +1,5 @@
+define i1 @f(i8* nocapture %p, i8* %q) {
+  %c = icmp eq i8* %p, %q
+  ret i1 %c
+}
+; ERROR: Value mismatch

--- a/tests/alive-tv/attrs/nocapture-icmp.tgt.ll
+++ b/tests/alive-tv/attrs/nocapture-icmp.tgt.ll
@@ -1,0 +1,3 @@
+define i1 @f(i8* nocapture %p, i8* %q) {
+  ret i1 false
+}

--- a/tests/alive-tv/attrs/nocapture-replace.src.ll
+++ b/tests/alive-tv/attrs/nocapture-replace.src.ll
@@ -1,0 +1,10 @@
+define i8* @f6(i8* nocapture %p, i8* %q) {
+  %c = icmp eq i8* %p, %q
+  br i1 %c, label %A, label %B
+A:
+  ret i8* %q
+B:
+  ret i8* null
+}
+
+; ERROR: Source is more defined than target

--- a/tests/alive-tv/attrs/nocapture-replace.tgt.ll
+++ b/tests/alive-tv/attrs/nocapture-replace.tgt.ll
@@ -1,0 +1,8 @@
+define i8* @f6(i8* nocapture %p, i8* %q) {
+  %c = icmp eq i8* %p, %q
+  br i1 %c, label %A, label %B
+A:
+  ret i8* %p
+B:
+  ret i8* null
+}

--- a/tests/alive-tv/attrs/nocapture.src.ll
+++ b/tests/alive-tv/attrs/nocapture.src.ll
@@ -1,0 +1,35 @@
+@x = global i8* null
+
+define void @f1(i8* nocapture %p) {
+  store i8* %p, i8** @x
+  ret void
+}
+
+define void @f2(i8* nocapture %p0) {
+  %p = getelementptr i8, i8* %p0, i32 1
+  store i8* %p, i8** @x
+  ret void
+}
+
+define i8* @f3(i8* nocapture %p) {
+  ret i8* %p
+}
+
+define i8* @f4(i8* nocapture %p) {
+  %p2 = getelementptr i8, i8* %p, i32 1
+  ret i8* %p2
+}
+
+define <2 x i8*> @f5(i8* nocapture %p) {
+  %v = insertelement <2 x i8*> undef, i8* %p, i32 1
+  ret <2 x i8*> %v
+}
+
+define i8* @f6(i8* nocapture %p, i8* %q) {
+  %c = icmp eq i8* %p, %q
+  br i1 %c, label %A, label %B
+A:
+  ret i8* %p
+B:
+  ret i8* null
+}

--- a/tests/alive-tv/attrs/nocapture.tgt.ll
+++ b/tests/alive-tv/attrs/nocapture.tgt.ll
@@ -1,0 +1,38 @@
+@x = global i8* null
+
+define void @f1(i8* nocapture %p) {
+  %poison = getelementptr inbounds i8, i8* null, i64 1
+  store i8* %poison, i8** @x
+  ret void
+}
+
+define void @f2(i8* nocapture %p) {
+  %poison = getelementptr inbounds i8, i8* null, i64 1
+  store i8* %poison, i8** @x
+  ret void
+}
+
+define i8* @f3(i8* nocapture %p) {
+  %poison = getelementptr inbounds i8, i8* null, i64 1
+  ret i8* %poison
+}
+
+define i8* @f4(i8* nocapture %p) {
+  %poison = getelementptr inbounds i8, i8* null, i64 1
+  ret i8* %poison
+}
+
+define <2 x i8*> @f5(i8* nocapture %p) {
+  %poison = getelementptr inbounds i8, i8* null, i64 1
+  %v = insertelement <2 x i8*> undef, i8* %poison, i32 1
+  ret <2 x i8*> %v
+}
+
+define i8* @f6(i8* nocapture %p, i8* %q) {
+  %c = icmp eq i8* %p, %q
+  br i1 %c, label %A, label %B
+A:
+  ret i8* %q
+B:
+  ret i8* null
+}

--- a/tools/transform.cpp
+++ b/tools/transform.cpp
@@ -583,8 +583,9 @@ static void calculateAndInitConstants(Transform &t) {
     return false;
   };
   // The number of bits needed to encode pointer attributes
-  // NonNull isn't encoded in ptr attribute bits
-  bits_for_ptrattrs = has_attr(Input::NoCapture);
+  // nonnull and byval isn't encoded in ptr attribute bits
+  has_nocapture = has_attr(Input::NoCapture);
+  bits_for_ptrattrs = has_nocapture;
 
   // ceil(log2(maxblks)) + 1 for local bit
   bits_for_bid = max(1u, ilog2_ceil(max(num_locals, num_nonlocals)))

--- a/tools/transform.cpp
+++ b/tools/transform.cpp
@@ -537,8 +537,16 @@ static void calculateAndInitConstants(Transform &t) {
   uint64_t min_access_size = 16;
   bool does_mem_access = false;
   bool has_load = false;
+  // The number of bits needed to encode pointer attributes
+  bits_for_ptrattrs = 0;
 
   for (auto fn : { &t.src, &t.tgt }) {
+    for (auto &v : fn->getInputs()) {
+      auto i = dynamic_cast<const Input*>(&v);
+      if (i && i->hasAttribute(Input::NoCapture))
+        bits_for_ptrattrs = 1;
+    }
+
     for (auto BB : fn->getBBs()) {
       for (auto &I : BB->instrs()) {
         for (auto op : I.operands()) {

--- a/tools/transform.cpp
+++ b/tools/transform.cpp
@@ -572,7 +572,7 @@ static void calculateAndInitConstants(Transform &t) {
   if (num_nonlocals > 0 || nullptr_is_used || has_malloc || has_load)
     ++num_nonlocals;
 
-  auto has_attr = [&](Input::Attributes a) -> bool {
+  auto has_attr = [&](Input::Attribute a) -> bool {
     for (auto fn : { &t.src, &t.tgt }) {
       for (auto &v : fn->getInputs()) {
         auto i = dynamic_cast<const Input*>(&v);


### PR DESCRIPTION
Splitted the diffs into two commits for easier review.

LLVM unit test failures: 63 -> 67

I think all 4 added failures are bugs in alive2 - 1 is the floating point bug, 3 are oggenc's DSE example. I'm investigating the reason.
```
Transforms/SLPVectorizer/X86/phi.ll: floating point bug
Transforms/DeadStoreElimination/OverwriteStoreBegin.ll
Transforms/DeadStoreElimination/OverwriteStoreEnd.ll
Transforms/MemCpyOpt/profitable-memset.ll
```