### PR TITLE
add realloc

### DIFF
--- a/ir/instr.cpp
+++ b/ir/instr.cpp
@@ -1870,7 +1870,7 @@ expr Malloc::getTypeConstraints(const Function &f) const {
 
 unique_ptr<Instr> Malloc::dup(const string &suffix) const {
   if (ptr)
-    return make_unique<Malloc>(getType(), getName() + suffix, *size, *ptr);
+    return make_unique<Malloc>(getType(), getName() + suffix, *ptr, *size);
   return make_unique<Malloc>(getType(), getName() + suffix, *size, isNonNull);
 }
 

--- a/ir/instr.cpp
+++ b/ir/instr.cpp
@@ -1820,29 +1820,26 @@ void Malloc::print(std::ostream &os) const {
 }
 
 StateValue Malloc::toSMT(State &s) const {
-  if (!isRealloc) {
-    auto &[sz, np] = s.getAndAddUndefs(*size);
-    // TODO: malloc's alignment is implementation defined.
-    expr nonnull = expr::mkBoolVar("malloc_never_fails");
-    auto [p, allocated] = s.getMemory().alloc(sz, 8, Memory::HEAP, np, nonnull);
+  auto &[sz, np_size] = s.getAndAddUndefs(*size);
+  // TODO: malloc's alignment is implementation defined.
+  expr nonnull = expr::mkBoolVar("malloc_never_fails");
+  auto [p_new, allocated] = s.getMemory().alloc(sz, 8, Memory::HEAP, np_size,
+                                                nonnull);
 
+  if (!isRealloc) {
     if (isNonNull) {
-      // TODO: In C++ we need to throw an exception if the allocation fails, but
-      // exception hasn't been modeled yet
+      // TODO: In C++ we need to throw an exception if the allocation fails,
+      // but exception hasn't been modeled yet
       s.addPre(move(allocated));
     }
 
-    return { move(p), expr(np) };
+    return { move(p_new), expr(np_size) };
   } else {
     auto &[p, np_ptr] = s.getAndAddUndefs(*ptr);
-    auto &[sz, np_size] = s.getAndAddUndefs(*size);
     s.addUB(np_ptr);
 
-    // If sz > p_sz, it is filled it with poison (local_block_val is
+    // If sz > p_sz, it is filled it with poison in malloc (local_block_val is
     // initialized with poison).
-    expr nonnull = expr::mkBoolVar("malloc_never_fails");
-    auto [p_new, allocated] = s.getMemory().alloc(sz, 8, Memory::HEAP, np_size,
-                                                  nonnull);
 
     Pointer ptr(s.getMemory(), p);
     expr p_sz = ptr.block_size();

--- a/ir/instr.h
+++ b/ir/instr.h
@@ -408,8 +408,7 @@ public:
   Malloc(Type &type, std::string &&name, Value &size, bool isNonNull)
     : Instr(type, std::move(name)), size(&size), isNonNull(isNonNull) {}
 
-  Malloc(Type &type, std::string &&name, Value &ptr, Value &size,
-         bool isNonNull = false, bool isRealloc = true)
+  Malloc(Type &type, std::string &&name, Value &ptr, Value &size)
     : Instr(type, std::move(name)), ptr(&ptr), size(&size), isRealloc(true) {}
 
   Value& getSize() const { return *size; }

--- a/ir/instr.h
+++ b/ir/instr.h
@@ -402,23 +402,23 @@ class Malloc final : public Instr {
   Value *ptr = nullptr, *size;
   // Is this malloc (or equivalent operation, like new()) never returning
   // null?
-  bool isNonNull = false, isRealloc = false;
+  bool isNonNull = false;
 
 public:
   Malloc(Type &type, std::string &&name, Value &size, bool isNonNull)
     : Instr(type, std::move(name)), size(&size), isNonNull(isNonNull) {}
 
   Malloc(Type &type, std::string &&name, Value &ptr, Value &size)
-    : Instr(type, std::move(name)), ptr(&ptr), size(&size), isRealloc(true) {}
+    : Instr(type, std::move(name)), ptr(&ptr), size(&size) {}
 
   Value& getSize() const { return *size; }
+  bool isRealloc() const { return ptr != nullptr; }
   std::vector<Value*> operands() const override;
   void rauw(const Value &what, Value &with) override;
   void print(std::ostream &os) const override;
   StateValue toSMT(State &s) const override;
   smt::expr getTypeConstraints(const Function &f) const override;
   std::unique_ptr<Instr> dup(const std::string &suffix) const override;
-  bool isReallocCall() const { return isRealloc; }
 };
 
 

--- a/ir/instr.h
+++ b/ir/instr.h
@@ -399,17 +399,18 @@ public:
 
 
 class Malloc final : public Instr {
-  Value *ptr, *size;
+  Value *ptr = nullptr, *size;
   // Is this malloc (or equivalent operation, like new()) never returning
   // null?
-  bool isNonNull;
-  bool isRealloc;
+  bool isNonNull = false, isRealloc = false;
 
 public:
+  Malloc(Type &type, std::string &&name, Value &size, bool isNonNull)
+    : Instr(type, std::move(name)), size(&size), isNonNull(isNonNull) {}
+
   Malloc(Type &type, std::string &&name, Value &ptr, Value &size,
-         bool isNonNull, bool isRealloc = false)
-    : Instr(type, std::move(name)), ptr(&ptr), size(&size),
-      isNonNull(isNonNull), isRealloc(isRealloc) {}
+         bool isNonNull = false, bool isRealloc = true)
+    : Instr(type, std::move(name)), ptr(&ptr), size(&size), isRealloc(true) {}
 
   Value& getSize() const { return *size; }
   std::vector<Value*> operands() const override;

--- a/ir/instr.h
+++ b/ir/instr.h
@@ -399,13 +399,17 @@ public:
 
 
 class Malloc final : public Instr {
-  Value *size;
+  Value *ptr, *size;
   // Is this malloc (or equivalent operation, like new()) never returning
   // null?
   bool isNonNull;
+  bool isRealloc;
+
 public:
-  Malloc(Type &type, std::string &&name, Value &size, bool isNonNull)
-    : Instr(type, std::move(name)), size(&size), isNonNull(isNonNull) {}
+  Malloc(Type &type, std::string &&name, Value &ptr, Value &size,
+         bool isNonNull, bool isRealloc = false)
+    : Instr(type, std::move(name)), ptr(&ptr), size(&size),
+      isNonNull(isNonNull), isRealloc(isRealloc) {}
 
   Value& getSize() const { return *size; }
   std::vector<Value*> operands() const override;
@@ -414,6 +418,7 @@ public:
   StateValue toSMT(State &s) const override;
   smt::expr getTypeConstraints(const Function &f) const override;
   std::unique_ptr<Instr> dup(const std::string &suffix) const override;
+  bool isReallocCall() const { return isRealloc; }
 };
 
 

--- a/llvm_util/known_fns.cpp
+++ b/llvm_util/known_fns.cpp
@@ -38,14 +38,11 @@ known_call(llvm::CallInst &i, const llvm::TargetLibraryInfo &TLI,
   // TODO: add support for checking mismatch of C vs C++ alloc fns
   if (llvm::isMallocLikeFn(&i, &TLI, false)) {
     bool isNonNull = i.getCalledFunction()->getName() != "malloc";
-    auto nullp = NullPointerValue(*ty);
-    RETURN_KNOWN(make_unique<Malloc>(*ty, value_name(i), nullp, *args[0],
-                                     isNonNull));
+    RETURN_KNOWN(make_unique<Malloc>(*ty, value_name(i), *args[0], isNonNull));
   } else if (llvm::isCallocLikeFn(&i, &TLI, false)) {
     RETURN_KNOWN(make_unique<Calloc>(*ty, value_name(i), *args[0], *args[1]));
   } else if (llvm::isReallocLikeFn(&i, &TLI, false)) {
-    RETURN_KNOWN(make_unique<Malloc>(*ty, value_name(i), *args[0], *args[1],
-                                     false, true));
+    RETURN_KNOWN(make_unique<Malloc>(*ty, value_name(i), *args[0], *args[1]));
   } else if (llvm::isFreeCall(&i, &TLI)) {
     RETURN_KNOWN(make_unique<Free>(*args[0]));
   }

--- a/llvm_util/known_fns.cpp
+++ b/llvm_util/known_fns.cpp
@@ -38,9 +38,14 @@ known_call(llvm::CallInst &i, const llvm::TargetLibraryInfo &TLI,
   // TODO: add support for checking mismatch of C vs C++ alloc fns
   if (llvm::isMallocLikeFn(&i, &TLI, false)) {
     bool isNonNull = i.getCalledFunction()->getName() != "malloc";
-    RETURN_KNOWN(make_unique<Malloc>(*ty, value_name(i), *args[0], isNonNull));
+    auto nullp = NullPointerValue(*ty);
+    RETURN_KNOWN(make_unique<Malloc>(*ty, value_name(i), nullp, *args[0],
+                                     isNonNull));
   } else if (llvm::isCallocLikeFn(&i, &TLI, false)) {
     RETURN_KNOWN(make_unique<Calloc>(*ty, value_name(i), *args[0], *args[1]));
+  } else if (llvm::isReallocLikeFn(&i, &TLI, false)) {
+    RETURN_KNOWN(make_unique<Malloc>(*ty, value_name(i), *args[0], *args[1],
+                                     false, true));
   } else if (llvm::isFreeCall(&i, &TLI)) {
     RETURN_KNOWN(make_unique<Free>(*args[0]));
   }

--- a/tests/alive-tv/memory/realloc-fail.src.ll
+++ b/tests/alive-tv/memory/realloc-fail.src.ll
@@ -1,0 +1,31 @@
+target datalayout = "e-m:o-i64:64-f80:128-n8:16:32:64-S128"
+
+define i8 @realloc-fail() {
+  %ptr = call noalias i8* @malloc(i64 4)
+  %cmp = icmp eq i8* %ptr, null
+  br i1 %cmp, label %BB1, label %BB2
+BB1:
+  ret i8 -1
+BB2:
+  store i8 5, i8* %ptr
+  %ptr2 = call noalias i8* @realloc(i8* %ptr, i64 100)
+  %cmp2 = icmp eq i8* %ptr2, null
+  br i1 %cmp2, label %BB3, label %BB4
+BB3:
+  %a = load i8, i8* %ptr
+  store i8 1, i8* %ptr
+  %b = load i8, i8* %ptr
+  %s = add i8 %a, %b
+  ret i8 %s
+BB4:
+  %a2 = load i8, i8* %ptr2
+  store i8 2, i8* %ptr2
+  %b2 = load i8, i8* %ptr2
+  %s2 = add i8 %a2, %b2
+  ret i8 %s2
+}
+
+declare noalias i8* @malloc(i64)
+declare noalias i8* @realloc(i8*, i64)
+
+; ERROR: Value mismatch

--- a/tests/alive-tv/memory/realloc-fail.tgt.ll
+++ b/tests/alive-tv/memory/realloc-fail.tgt.ll
@@ -1,0 +1,16 @@
+target datalayout = "e-m:o-i64:64-f80:128-n8:16:32:64-S128"
+
+define i8 @realloc-fail() {
+  %ptr = call noalias i8* @malloc(i64 4)
+  %cmp = icmp eq i8* %ptr, null
+  br i1 %cmp, label %BB1, label %BB2
+BB1:
+  ret i8 -1
+BB2:
+  store i8 5, i8* %ptr
+  %ptr2 = call noalias i8* @realloc(i8* %ptr, i64 100)
+  ret i8 6
+}
+
+declare noalias i8* @malloc(i64)
+declare noalias i8* @realloc(i8*, i64)

--- a/tests/alive-tv/memory/realloc-null.src.ll
+++ b/tests/alive-tv/memory/realloc-null.src.ll
@@ -1,0 +1,10 @@
+target datalayout = "e-m:o-i64:64-f80:128-n8:16:32:64-S128"
+
+define i8 @realloc-null() {
+  %ptr = call noalias i8* @realloc(i8* null, i64 3)
+  store i8 5, i8* %ptr
+  %v = load i8, i8* %ptr
+  ret i8 %v
+}
+
+declare noalias i8* @realloc(i8*, i64)

--- a/tests/alive-tv/memory/realloc-null.tgt.ll
+++ b/tests/alive-tv/memory/realloc-null.tgt.ll
@@ -1,0 +1,10 @@
+target datalayout = "e-m:o-i64:64-f80:128-n8:16:32:64-S128"
+
+define i8 @realloc-null() {
+  %ptr = call noalias i8* @malloc(i64 3)
+  store i8 5, i8* %ptr
+  %v = load i8, i8* %ptr
+  ret i8 %v
+}
+
+declare noalias i8* @malloc(i64)

--- a/tests/alive-tv/memory/realloc-zero.src.ll
+++ b/tests/alive-tv/memory/realloc-zero.src.ll
@@ -1,0 +1,11 @@
+target datalayout = "e-m:o-i64:64-f80:128-n8:16:32:64-S128"
+
+define i64 @realloc-check() {
+  %ptr = call noalias i8* @malloc(i64 4)
+  %ptr2 = call noalias i8* @realloc(i8* %ptr, i64 0)
+  %v = load i8, i8* %ptr
+  ret i64 0
+}
+
+declare noalias i8* @malloc(i64)
+declare noalias i8* @realloc(i8*, i64)

--- a/tests/alive-tv/memory/realloc-zero.tgt.ll
+++ b/tests/alive-tv/memory/realloc-zero.tgt.ll
@@ -1,0 +1,8 @@
+target datalayout = "e-m:o-i64:64-f80:128-n8:16:32:64-S128"
+
+define i64 @realloc-check() {
+  ret i64 -1
+}
+
+declare noalias i8* @malloc(i64)
+declare noalias i8* @realloc(i8*, i64)

--- a/tests/alive-tv/memory/realloc.src.ll
+++ b/tests/alive-tv/memory/realloc.src.ll
@@ -2,16 +2,14 @@ target datalayout = "e-m:o-i64:64-f80:128-n8:16:32:64-S128"
 
 define i8 @realloc-check() {
   %ptr = call noalias i8* @malloc(i64 4)
-  %i = ptrtoint i8* %ptr to i64
-  %cmp = icmp eq i64 %i, 0
+  %cmp = icmp eq i8* %ptr, null
   br i1 %cmp, label %BB1, label %BB2
 BB1:
   ret i8 -1
 BB2:
   store i8 5, i8* %ptr
   %ptr2 = call noalias i8* @realloc(i8* %ptr, i64 1)
-  %i2 = ptrtoint i8* %ptr2 to i64
-  %cmp2 = icmp eq i64 %i2, 0
+  %cmp2 = icmp eq i8* %ptr2, null
   br i1 %cmp2, label %BB3, label %BB4
 BB3:
   %a = load i8, i8* %ptr

--- a/tests/alive-tv/memory/realloc.src.ll
+++ b/tests/alive-tv/memory/realloc.src.ll
@@ -1,0 +1,31 @@
+target datalayout = "e-m:o-i64:64-f80:128-n8:16:32:64-S128"
+
+define i8 @realloc-check() {
+  %ptr = call noalias i8* @malloc(i64 4)
+  %i = ptrtoint i8* %ptr to i64
+  %cmp = icmp eq i64 %i, 0
+  br i1 %cmp, label %BB1, label %BB2
+BB1:
+  ret i8 -1
+BB2:
+  store i8 5, i8* %ptr
+  %ptr2 = call noalias i8* @realloc(i8* %ptr, i64 1)
+  %i2 = ptrtoint i8* %ptr2 to i64
+  %cmp2 = icmp eq i64 %i2, 0
+  br i1 %cmp2, label %BB3, label %BB4
+BB3:
+  %a = load i8, i8* %ptr
+  store i8 1, i8* %ptr
+  %b = load i8, i8* %ptr
+  %s = add i8 %a, %b
+  ret i8 %s
+BB4:
+  %a2 = load i8, i8* %ptr2
+  store i8 2, i8* %ptr2
+  %b2 = load i8, i8* %ptr2
+  %s2 = add i8 %a2, %b2
+  ret i8 %s2
+}
+
+declare noalias i8* @malloc(i64)
+declare noalias i8* @realloc(i8*, i64)

--- a/tests/alive-tv/memory/realloc.tgt.ll
+++ b/tests/alive-tv/memory/realloc.tgt.ll
@@ -2,16 +2,14 @@ target datalayout = "e-m:o-i64:64-f80:128-n8:16:32:64-S128"
 
 define i8 @realloc-check() {
   %ptr = call noalias i8* @malloc(i64 4)
-  %i = ptrtoint i8* %ptr to i64
-  %cmp = icmp eq i64 %i, 0
+  %cmp = icmp eq i8* %ptr, null
   br i1 %cmp, label %BB1, label %BB2
 BB1:
   ret i8 -1
 BB2:
   store i8 5, i8* %ptr
   %ptr2 = call noalias i8* @realloc(i8* %ptr, i64 1)
-  %i2 = ptrtoint i8* %ptr2 to i64
-  %cmp2 = icmp eq i64 %i2, 0
+  %cmp2 = icmp eq i8* %ptr2, null
   br i1 %cmp2, label %BB3, label %BB4
 BB3:
   ret i8 6

--- a/tests/alive-tv/memory/realloc.tgt.ll
+++ b/tests/alive-tv/memory/realloc.tgt.ll
@@ -1,0 +1,23 @@
+target datalayout = "e-m:o-i64:64-f80:128-n8:16:32:64-S128"
+
+define i8 @realloc-check() {
+  %ptr = call noalias i8* @malloc(i64 4)
+  %i = ptrtoint i8* %ptr to i64
+  %cmp = icmp eq i64 %i, 0
+  br i1 %cmp, label %BB1, label %BB2
+BB1:
+  ret i8 -1
+BB2:
+  store i8 5, i8* %ptr
+  %ptr2 = call noalias i8* @realloc(i8* %ptr, i64 1)
+  %i2 = ptrtoint i8* %ptr2 to i64
+  %cmp2 = icmp eq i64 %i2, 0
+  br i1 %cmp2, label %BB3, label %BB4
+BB3:
+  ret i8 6
+BB4:
+  ret i8 7
+}
+
+declare noalias i8* @malloc(i64)
+declare noalias i8* @realloc(i8*, i64)

--- a/tools/alive_parser.cpp
+++ b/tools/alive_parser.cpp
@@ -934,7 +934,8 @@ static unique_ptr<Instr> parse_malloc(string_view name) {
   auto &op = parse_operand(ty);
   // Malloc returns a pointer at address space 0
   Type &pointer_type = get_pointer_type(0);
-  return make_unique<Malloc>(pointer_type, string(name), op, false);
+  auto nullp = NullPointerValue(pointer_type);
+  return make_unique<Malloc>(pointer_type, string(name), nullp, op, false);
 }
 
 static unique_ptr<Instr> parse_extractelement(string_view name) {

--- a/tools/alive_parser.cpp
+++ b/tools/alive_parser.cpp
@@ -934,8 +934,7 @@ static unique_ptr<Instr> parse_malloc(string_view name) {
   auto &op = parse_operand(ty);
   // Malloc returns a pointer at address space 0
   Type &pointer_type = get_pointer_type(0);
-  auto nullp = NullPointerValue(pointer_type);
-  return make_unique<Malloc>(pointer_type, string(name), nullp, op, false);
+  return make_unique<Malloc>(pointer_type, string(name), op, false);
 }
 
 static unique_ptr<Instr> parse_extractelement(string_view name) {

--- a/tools/transform.cpp
+++ b/tools/transform.cpp
@@ -682,7 +682,11 @@ static void calculateAndInitConstants(Transform &t) {
         if (auto alloc = dynamic_cast<const Alloc*>(&I))
           has_dead_allocas |= alloc->initDead();
 
-        has_malloc |= dynamic_cast<const Malloc*>(&I) != nullptr;
+        if (auto alloc = dynamic_cast<const Malloc*>(&I)) {
+          has_malloc |= true;
+          has_free |= alloc->isReallocCall();
+        }
+
         has_malloc |= dynamic_cast<const Calloc*>(&I) != nullptr;
         has_free   |= dynamic_cast<const Free*>(&I) != nullptr;
         has_load   |= dynamic_cast<const Load*>(&I) != nullptr;

--- a/tools/transform.cpp
+++ b/tools/transform.cpp
@@ -684,7 +684,7 @@ static void calculateAndInitConstants(Transform &t) {
 
         if (auto alloc = dynamic_cast<const Malloc*>(&I)) {
           has_malloc |= true;
-          has_free |= alloc->isReallocCall();
+          has_free |= alloc->isRealloc();
         }
 
         has_malloc |= dynamic_cast<const Calloc*>(&I) != nullptr;


### PR DESCRIPTION
I added realloc instruction.

Realloc is implemented using malloc, memcpy and free.
First, allocate pointer with the size.
If the allocation is success, copy the previous pointer's value to new pointer and free it.
If not, preserve the previous pointer.

However, there is one restriction.
In this implementation, allocation is run before free.
So, the result of realloc is always disjoint with the previous one.
If free precede allocation, then memcpy isn't available.
Could you help me in this matter?