### PR TITLE
Register undef variables used by the size argument of malloc

### DIFF
--- a/ir/instr.cpp
+++ b/ir/instr.cpp
@@ -1758,9 +1758,7 @@ void Malloc::print(std::ostream &os) const {
 }
 
 StateValue Malloc::toSMT(State &s) const {
-  auto &[sz, np] = s[*size];
-  for (auto uvar: s.at(*size).second)
-    s.addQuantVar(move(uvar));
+  auto &[sz, np] = s.getAndAddUndefs(*size);
   // TODO: malloc's alignment is implementation defined.
   expr nonnull = expr::mkBoolVar("malloc_never_fails");
   auto [p, allocated] = s.getMemory().alloc(sz, 8, Memory::HEAP, true, nonnull);
@@ -1799,12 +1797,8 @@ void Calloc::print(std::ostream &os) const {
 }
 
 StateValue Calloc::toSMT(State &s) const {
-  auto &[nm, np_num] = s[*num];
-  auto &[sz, np_sz] = s[*size];
-  for (auto uvar: s.at(*size).second)
-    s.addQuantVar(move(uvar));
-  for (auto uvar: s.at(*num).second)
-    s.addQuantVar(move(uvar));
+  auto &[nm, np_num] = s.getAndAddUndefs(*num);
+  auto &[sz, np_sz] = s.getAndAddUndefs(*size);
 
   // TODO: check calloc align.
   expr size = nm * sz;

--- a/ir/instr.cpp
+++ b/ir/instr.cpp
@@ -1759,6 +1759,8 @@ void Malloc::print(std::ostream &os) const {
 
 StateValue Malloc::toSMT(State &s) const {
   auto &[sz, np] = s[*size];
+  for (auto uvar: s.at(*size).second)
+    s.addQuantVar(move(uvar));
   // TODO: malloc's alignment is implementation defined.
   expr nonnull = expr::mkBoolVar("malloc_never_fails");
   auto [p, allocated] = s.getMemory().alloc(sz, 8, Memory::HEAP, true, nonnull);
@@ -1799,6 +1801,10 @@ void Calloc::print(std::ostream &os) const {
 StateValue Calloc::toSMT(State &s) const {
   auto &[nm, np_num] = s[*num];
   auto &[sz, np_sz] = s[*size];
+  for (auto uvar: s.at(*size).second)
+    s.addQuantVar(move(uvar));
+  for (auto uvar: s.at(*num).second)
+    s.addQuantVar(move(uvar));
 
   // TODO: check calloc align.
   expr size = nm * sz;

--- a/ir/state.cpp
+++ b/ir/state.cpp
@@ -69,6 +69,13 @@ const StateValue& State::operator[](const Value &val) {
   return tmp_values[i_tmp_values++] = move(sval_new);
 }
 
+const StateValue& State::getAndAddUndefs(const Value &val) {
+  auto &v = (*this)[val];
+  for (auto uvar: at(val).second)
+    addQuantVar(move(uvar));
+  return v;
+}
+
 const State::ValTy& State::at(const Value &val) const {
   return get<1>(values[values_map.at(&val)]);
 }

--- a/ir/state.h
+++ b/ir/state.h
@@ -86,6 +86,7 @@ public:
 
   const StateValue& exec(const Value &v);
   const StateValue& operator[](const Value &val);
+  const StateValue& getAndAddUndefs(const Value &val);
   const ValTy& at(const Value &val) const;
   const smt::expr* jumpCondFrom(const BasicBlock &bb) const;
 

--- a/tests/alive-tv/memory/alloca-removal.src.ll
+++ b/tests/alive-tv/memory/alloca-removal.src.ll
@@ -1,4 +1,3 @@
-; TEST-ARGS: -disable-undef-input
 define i8* @f(i64 %size) {
 entry:
   %items.addr = alloca i32, align 4
@@ -14,4 +13,13 @@ entry:
   ret i8* %call
 }
 
-declare dso_local noalias i8* @malloc(i64)
+define i8* @f_observed2(i64 %size) {
+entry:
+  %items.addr = alloca i32, align 8
+  %call = call noalias i8* @calloc(i64 4, i64 %size)
+  %unused = ptrtoint i8* %call to i64
+  ret i8* %call
+}
+
+declare noalias i8* @malloc(i64)
+declare noalias i8* @calloc(i64, i64)

--- a/tests/alive-tv/memory/alloca-removal.src.ll
+++ b/tests/alive-tv/memory/alloca-removal.src.ll
@@ -1,3 +1,5 @@
+; TEST-ARGS: -smt-to=5000
+
 define i8* @f(i64 %size) {
 entry:
   %items.addr = alloca i32, align 4
@@ -15,6 +17,15 @@ entry:
 
 define i8* @f_observed2(i64 %size) {
 entry:
+  %items.addr = alloca i32, align 8
+  %call = call noalias i8* @calloc(i64 4, i64 %size)
+  %unused = ptrtoint i8* %call to i64
+  ret i8* %call
+}
+
+define i8* @f_observed3(i64 %size) {
+entry:
+  %unused0 = bitcast i64 %size to i64
   %items.addr = alloca i32, align 8
   %call = call noalias i8* @calloc(i64 4, i64 %size)
   %unused = ptrtoint i8* %call to i64

--- a/tests/alive-tv/memory/alloca-removal.tgt.ll
+++ b/tests/alive-tv/memory/alloca-removal.tgt.ll
@@ -18,5 +18,13 @@ entry:
   ret i8* %call
 }
 
+define i8* @f_observed3(i64 %size) {
+entry:
+  %unused0 = bitcast i64 %size to i64
+  %call = call noalias i8* @calloc(i64 4, i64 %size)
+  %unused = ptrtoint i8* %call to i64
+  ret i8* %call
+}
+
 declare noalias i8* @malloc(i64)
 declare noalias i8* @calloc(i64, i64)

--- a/tests/alive-tv/memory/alloca-removal.tgt.ll
+++ b/tests/alive-tv/memory/alloca-removal.tgt.ll
@@ -1,4 +1,3 @@
-; TEST-ARGS: -disable-undef-input
 define i8* @f(i64 %size) {
 entry:
   %call = call noalias i8* @malloc(i64 %size)
@@ -12,4 +11,12 @@ entry:
   ret i8* %call
 }
 
-declare dso_local noalias i8* @malloc(i64)
+define i8* @f_observed2(i64 %size) {
+entry:
+  %call = call noalias i8* @calloc(i64 4, i64 %size)
+  %unused = ptrtoint i8* %call to i64
+  ret i8* %call
+}
+
+declare noalias i8* @malloc(i64)
+declare noalias i8* @calloc(i64, i64)


### PR DESCRIPTION
This helps the removal of alloca test work even when `-disable-undef-input` is not given, by registering the undef Z3 variables used by the size value.