### PR TITLE
Let GEP's ptr duplicate undef vars when idx is a vector type

### DIFF
--- a/ir/instr.cpp
+++ b/ir/instr.cpp
@@ -2019,8 +2019,8 @@ StateValue GEP::toSMT(State &s) const {
         else
           offsets.emplace_back(sz, s[*idx]);
       }
-      vals.emplace_back(scalar(ptr_isvect ? aty->extract(ptrval, i) : ptrval,
-                               offsets));
+      vals.emplace_back(scalar(ptr_isvect ? aty->extract(ptrval, i) :
+                               (i == 0 ? ptrval : s[*ptr]), offsets));
     }
     return getType().getAsAggregateType()->aggregateVals(vals);
   }

--- a/ir/value.cpp
+++ b/ir/value.cpp
@@ -43,13 +43,11 @@ void UndefValue::print(ostream &os) const {
   UNREACHABLE();
 }
 
-
 StateValue UndefValue::toSMT(State &s) const {
   auto val = getType().getDummyValue(true);
   expr var = expr::mkFreshVar("undef", val.value);
   s.addUndefVar(expr(var));
-  StateValue undefv(move(var), move(val.non_poison));
-  return undefv;
+  return { move(var), move(val.non_poison) };
 }
 
 

--- a/ir/value.cpp
+++ b/ir/value.cpp
@@ -43,11 +43,13 @@ void UndefValue::print(ostream &os) const {
   UNREACHABLE();
 }
 
+
 StateValue UndefValue::toSMT(State &s) const {
   auto val = getType().getDummyValue(true);
   expr var = expr::mkFreshVar("undef", val.value);
   s.addUndefVar(expr(var));
-  return { move(var), move(val.non_poison) };
+  StateValue undefv(move(var), move(val.non_poison));
+  return undefv;
 }
 
 

--- a/tests/alive-tv/vector_undefptr.src.ll
+++ b/tests/alive-tv/vector_undefptr.src.ll
@@ -1,4 +1,4 @@
 define <2 x i8*> @f() {
-   %a = getelementptr i8, i8* undef, <2 x i64> <i64 0, i64 0>
-   ret <2 x i8*> %a
- }
+  %a = getelementptr i8, i8* undef, <2 x i64> <i64 0, i64 0>
+  ret <2 x i8*> %a
+}

--- a/tests/alive-tv/vector_undefptr.src.ll
+++ b/tests/alive-tv/vector_undefptr.src.ll
@@ -1,0 +1,5 @@
+define <2 x i8*> @f() {
+  %a0 = insertelement <2 x i8*> zeroinitializer, i8* undef, i32 0
+  %a = insertelement <2 x i8*> %a0, i8* undef, i32 1
+  ret <2 x i8*> %a
+}

--- a/tests/alive-tv/vector_undefptr.src.ll
+++ b/tests/alive-tv/vector_undefptr.src.ll
@@ -1,5 +1,4 @@
 define <2 x i8*> @f() {
-  %a0 = insertelement <2 x i8*> zeroinitializer, i8* undef, i32 0
-  %a = insertelement <2 x i8*> %a0, i8* undef, i32 1
-  ret <2 x i8*> %a
-}
+   %a = getelementptr i8, i8* undef, <2 x i64> <i64 0, i64 0>
+   ret <2 x i8*> %a
+ }

--- a/tests/alive-tv/vector_undefptr.tgt.ll
+++ b/tests/alive-tv/vector_undefptr.tgt.ll
@@ -1,3 +1,3 @@
 define <2 x i8*> @f() {
-   ret <2 x i8*> undef
- }
+  ret <2 x i8*> undef
+}

--- a/tests/alive-tv/vector_undefptr.tgt.ll
+++ b/tests/alive-tv/vector_undefptr.tgt.ll
@@ -1,0 +1,3 @@
+define <2 x i8*> @f() {
+  ret <2 x i8*> undef
+}

--- a/tests/alive-tv/vector_undefptr.tgt.ll
+++ b/tests/alive-tv/vector_undefptr.tgt.ll
@@ -1,3 +1,3 @@
 define <2 x i8*> @f() {
-  ret <2 x i8*> undef
-}
+   ret <2 x i8*> undef
+ }


### PR DESCRIPTION
This PR adds constraint to undef aggregate value's pointer elements so they have correct values. 