### PR TITLE
Pointer::get_value should check validity of p

### DIFF
--- a/ir/memory.cpp
+++ b/ir/memory.cpp
@@ -366,6 +366,9 @@ expr Pointer::get_attrs() const {
 expr Pointer::get_value(const char *name, const FunctionExpr &local_fn,
                         const FunctionExpr &nonlocal_fn,
                         const expr &ret_type, bool src_name) const {
+  if (!p.isValid())
+    return {};
+
   auto bid = get_short_bid();
   expr non_local;
 

--- a/tests/alive-tv/intptrload.src.ll
+++ b/tests/alive-tv/intptrload.src.ll
@@ -1,4 +1,4 @@
-define i64 @f(i64 %x, i64 %y) {
+define i64 @f(i64 %x) {
   %p = inttoptr i64 %x to i64*
   %a = load i64, i64* %p
   ret i64 %a

--- a/tests/alive-tv/intptrload.src.ll
+++ b/tests/alive-tv/intptrload.src.ll
@@ -1,0 +1,7 @@
+define i64 @f(i64 %x, i64 %y) {
+  %p = inttoptr i64 %x to i64*
+  %a = load i64, i64* %p
+  ret i64 %a
+}
+
+; XFAIL: Invalid expr

--- a/tests/alive-tv/intptrload.tgt.ll
+++ b/tests/alive-tv/intptrload.tgt.ll
@@ -1,0 +1,3 @@
+define i64 @f(i64 %x, i64 %y) {
+  unreachable
+}

--- a/tests/alive-tv/intptrload.tgt.ll
+++ b/tests/alive-tv/intptrload.tgt.ll
@@ -1,3 +1,3 @@
-define i64 @f(i64 %x, i64 %y) {
+define i64 @f(i64 %x) {
   unreachable
 }


### PR DESCRIPTION
Sanity check (this couldn't be added to unit test because src identity check should succeed):
```
define i64 @f(i64 %x, i64 %y) {
  %p = inttoptr i64 %x to i64*
  %a = load i64, i64* %p
  ret i64 %a
}
=>
define i64 @f(i64 %x, i64 %y) {
  unreachable
}
```
This example should raise `Invalid expr`.