### PR TITLE
Exclude invalid expr from identity test

### DIFF
--- a/tests/alive-tv/inttoptr.src.ll
+++ b/tests/alive-tv/inttoptr.src.ll
@@ -1,0 +1,6 @@
+define i64* @f(i64 %x, i64 %y) {
+  %p = inttoptr i64 %x to i64*
+  ret i64* %p
+}
+
+; XFAIL: Invalid expr

--- a/tests/alive-tv/inttoptr.tgt.ll
+++ b/tests/alive-tv/inttoptr.tgt.ll
@@ -1,0 +1,3 @@
+define i64* @f(i64 %x, i64 %y) {
+  ret i64* null
+}

--- a/tests/lit/lit/formats/alive2test.py
+++ b/tests/lit/lit/formats/alive2test.py
@@ -76,10 +76,10 @@ class Alive2Test(TestFormat):
     if alive_tv:
        # Run identity check first
        srcpath = test
-       looperr_string = 'Loops are not supported yet! Skipping function'
+       invalid_expr = 'Invalid expr'
        resultchk = lambda msg, exitCode: \
            (exitCode == 0 and msg.find(ok_string) != -1) or \
-           (exitCode != 0 and msg.find(looperr_string) != -1)
+           (exitCode != 0 and msg.find(invalid_expr) != -1)
 
        out, err, exitCode = executeCommand(cmd + [srcpath, srcpath])
        if not resultchk(out + err, exitCode):


### PR DESCRIPTION
This helps adding a unit test for #270 