### PR TITLE
Deal with the case when # args don't match

### DIFF
--- a/ir/state.cpp
+++ b/ir/state.cpp
@@ -359,7 +359,8 @@ void State::mkAxioms(State &tgt) {
         auto &[ins2, ptr_ins2, mem2, reads2, argmem2] = I2->first;
         auto &[rets2, ub2, mem_state2] = I2->second;
 
-        if (reads != reads2 || argmem != argmem2)
+        if (reads != reads2 || argmem != argmem2 || ins.size() != ins2.size()
+            || ptr_ins.size() != ptr_ins2.size())
           continue;
 
         expr refines(true), is_val_eq(true);

--- a/tests/alive-tv/fncall-vararg.src.ll
+++ b/tests/alive-tv/fncall-vararg.src.ll
@@ -1,0 +1,8 @@
+target triple = "x86_64-unknown-linux-gnu"
+
+declare void @g(i8*, ...)
+define void @f() {
+  tail call void (i8*, ...) @g(i8* null, i32 0)
+  ret void
+}
+; ERROR: Source is more defined than target

--- a/tests/alive-tv/fncall-vararg.tgt.ll
+++ b/tests/alive-tv/fncall-vararg.tgt.ll
@@ -1,0 +1,7 @@
+target triple = "x86_64-unknown-linux-gnu"
+
+declare void @g(i8*, ...)
+define void @f() {
+  tail call void (i8*, ...) @g(i8* null)
+  ret void
+}


### PR DESCRIPTION
This can happen when a function has variadic arguments.