### PR TITLE
Use Python3-compliant find

### DIFF
--- a/tests/lit/lit/formats/alive2test.py
+++ b/tests/lit/lit/formats/alive2test.py
@@ -104,7 +104,7 @@ class Alive2Test(TestFormat):
       return lit.Test.FAIL, out + err
 
     if expect_err is None and xfail is None:
-      if exitCode == 0 and string.find(out + err, ok_string) != -1:
+      if exitCode == 0 and (out + err).find(ok_string) != -1:
         return lit.Test.PASS, ''
       return lit.Test.FAIL, out + err
 


### PR DESCRIPTION
I met #225 as well and turns out that the reason was incorrect string.find use at alive2test.py