### PR TITLE
a few changes, the main one is to allow people to verify an optimization without trying to remember the tricky "opt" invocation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,8 @@ if (CYGWIN)
   set(CMAKE_FIND_LIBRARY_SUFFIXES ".dll")
 endif()
 
+find_package(ZLIB REQUIRED)
+
 find_package(Z3 4.8.5 REQUIRED)
 include_directories(${Z3_INCLUDE_DIR})
 
@@ -150,7 +152,7 @@ target_link_libraries(alive PRIVATE ${ALIVE_LIBS})
 add_library(alive2 SHARED ${IR_SRCS} ${SMT_SRCS} ${TOOLS_SRCS} ${UTIL_SRCS} ${LLVM_UTIL_SRCS})
 
 if (BUILD_LLVM_UTILS OR BUILD_TV)
-  llvm_map_components_to_libnames(llvm_libs support core irreader analysis)
+  llvm_map_components_to_libnames(llvm_libs support core irreader analysis passes)
   target_link_libraries(alive2 PRIVATE ${llvm_libs})
   target_link_libraries(alive-tv PRIVATE ${ALIVE_LIBS_LLVM} ${llvm_libs})
 endif()


### PR DESCRIPTION
- after a CMake update (on Ubuntu 18.04) we now need to explicitly find ZLIB

- some improvements to alive-tv's help output: a more detailed
  summary, removed "Alive:" from in front of the help text since our
  options are clearly in the alive option category, and tell the
  command line library to hide all unrelated command line options

- support running alive-tv with just a single file, in which case
  we run opt -O2 on it and verify refinment of that