### PR TITLE
[TV] Do explicitly link to LLVMTransformUtils that provides llvm::CloneModule()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -151,7 +151,7 @@ target_link_libraries(alive PRIVATE ${ALIVE_LIBS})
 add_library(alive2 SHARED ${IR_SRCS} ${SMT_SRCS} ${TOOLS_SRCS} ${UTIL_SRCS} ${LLVM_UTIL_SRCS})
 
 if (BUILD_LLVM_UTILS OR BUILD_TV)
-  llvm_map_components_to_libnames(llvm_libs support core irreader analysis passes)
+  llvm_map_components_to_libnames(llvm_libs support core irreader analysis passes transformutils)
   target_link_libraries(alive2 PRIVATE ${llvm_libs})
   target_link_libraries(alive-tv PRIVATE ${ALIVE_LIBS_LLVM} ${llvm_libs})
 endif()


### PR DESCRIPTION
llvm::CloneModule() is used by alive-tv, but we don't explicitly
link to the library that provides it, but only implicitly.
And even after purging alive2 build dir, with local llvm trunk being at
https://github.com/llvm/llvm-project/commit/857b655d7aac50462ffd0154b9d6c4f18119ddfb
i can no longer successfully build alive2:
```
[62/65] Linking CXX executable alive-tv
FAILED: alive-tv
: && /usr/local/bin/clang++  -Wall -Werror -march=native -fPIC -flto=thin -fuse-ld=lld -Wno-error=unused-command-line-argument -O3 -DNDEBUG -O3 -DNDEBUG  -Wl,-O3 -Wl,--gc-sections CMakeFiles/alive-tv.dir/tools/alive-tv.cpp.o  -o alive-tv  -Wl,-rpath,"\$ORIGIN/../lib:/builddirs/llvm-project/build-Clang9-unknown/./lib"  -lpthread  libllvm_util.a  libir.a  libsmt.a  libtools.a  libutil.a  /builddirs/llvm-project/build-Clang9-unknown/lib/libLLVMPasses.so.11git  /usr/lib/x86_64-linux-gnu/libz3.so  /builddirs/llvm-project/build-Clang9-unknown/lib/libLLVMIRReader.so.11git  /builddirs/llvm-project/build-Clang9-unknown/lib/libLLVMAnalysis.so.11git  /builddirs/llvm-project/build-Clang9-unknown/lib/libLLVMCore.so.11git  /builddirs/llvm-project/build-Clang9-unknown/lib/libLLVMSupport.so.11git  -Wl,-rpath-link,/builddirs/llvm-project/build-Clang9-unknown/lib && :
ld.lld: error: undefined symbol: llvm::CloneModule(llvm::Module const&)
>>> referenced by alive-tv.cpp
>>>               lto.tmp:(main)
clang: error: linker command failed with exit code 1 (use -v to see invocation)
[65/65] Linking CXX shared module tv/tv.so
ninja: build stopped: subcommand failed.
```
Explicitly linking to the LLVMTransformUtils solves this issue for me,
and build passes again.