### PR TITLE
Call finishInitializer before jump is called

### DIFF
--- a/tests/alive-tv/call.src.ll
+++ b/tests/alive-tv/call.src.ll
@@ -9,6 +9,12 @@ define i8 @f2(i8* %a) {
   ret i8 %b
 }
 
+@glb = constant i8 0
+define i8 @f2glb() {
+  %b = call i8 @g(i8* @glb)
+  ret i8 %b
+}
+
 define i8 @f3(i8* %a) {
   store i8 undef, i8* %a
   %b = call i8 @g(i8* %a)

--- a/tests/alive-tv/call.tgt.ll
+++ b/tests/alive-tv/call.tgt.ll
@@ -10,6 +10,12 @@ define i8 @f2(i8* %a) {
   ret i8 %b
 }
 
+@glb = constant i8 0
+define i8 @f2glb() {
+  %b = call i8 @g(i8* @glb)
+  ret i8 %b
+}
+
 define i8 @f3(i8* %a) {
   store i8 3, i8* %a
   %b = call i8 @g(i8* %a)

--- a/util/symexec.cpp
+++ b/util/symexec.cpp
@@ -37,6 +37,8 @@ void sym_exec(State &s) {
       continue;
 
     for (auto &i : bb->instrs()) {
+      if (first && dynamic_cast<const JumpInstr *>(&i))
+        s.finishInitializer();
       auto val = s.exec(i);
       auto &name = i.getName();
 
@@ -44,8 +46,6 @@ void sym_exec(State &s) {
         cout << name << " = " << val << '\n';
     }
 
-    if (first)
-      s.finishInitializer();
     first = false;
   }
 


### PR DESCRIPTION
finishInitializer() is called too late, causing the Memory::initial_non_local_block_val of the next basic block to be uninitialized.

This resolves 50 invalid expr errors from LLVM unit tests.