### PR TITLE
this adds another mode for using alive-tv that is intended to be

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,13 @@
+Alive2 unit tests
+=================
+
+three test file formats are supported:
+
+- if a unit test has the suffix ".srctgt.ll" then this file will be sent to
+  alive-tv. it should stand on its own.
+
+- if a unit test has the suffix ".src.ll" then ".tgt.ll" must also exist, and
+  this pair of files will be sent to alive-tv
+
+- otherwise, the test is assumed to be written in the Alive domain
+  specific language and it will be sent to alive

--- a/tests/alive-tv/easy-1.srctgt.ll
+++ b/tests/alive-tv/easy-1.srctgt.ll
@@ -1,0 +1,9 @@
+define i32 @src(i32, i32) {
+  %x = add nsw i32 %0, %1
+  ret i32 %x
+}
+
+define i32 @tgt(i32, i32) {
+  %x = add i32 %0, %1
+  ret i32 %x
+}

--- a/tests/alive-tv/easy-2.srctgt.ll
+++ b/tests/alive-tv/easy-2.srctgt.ll
@@ -1,0 +1,7 @@
+define i32 @foo(i32, i32) {
+  %x1 = add i32 %0, 1
+  %x2 = mul i32 %x1, 10
+  %x3 = add i32 %x2, 7
+  %x4 = udiv i32 %x3, 5
+  ret i32 %x4
+}

--- a/tests/lit/lit/formats/alive2test.py
+++ b/tests/lit/lit/formats/alive2test.py
@@ -49,20 +49,29 @@ class Alive2Test(TestFormat):
       filepath = os.path.join(source_path, filename)
       if not filename.startswith('.') and \
           not os.path.isdir(filepath) and \
-          (filename.endswith('.opt') or filename.endswith('.src.ll')):
+          (filename.endswith('.opt') or filename.endswith('.src.ll') or
+           filename.endswith('.srctgt.ll')):
         yield lit.Test.Test(testSuite, path_in_suite + (filename,), localConfig)
 
 
   def execute(self, test, litConfig):
     test = test.getSourcePath()
 
-    alive_tv = test.endswith('.src.ll')
-    if alive_tv:
+    alive_tv_1 = test.endswith('.srctgt.ll')
+    if alive_tv_1:
       cmd = ['./alive-tv']
       ok_string = 'Transformation seems to be correct!'
       if not os.path.isfile('alive-tv'):
         return lit.Test.UNSUPPORTED, ''
-    else:
+
+    alive_tv_2 = test.endswith('.src.ll')
+    if alive_tv_2:
+      cmd = ['./alive-tv']
+      ok_string = 'Transformation seems to be correct!'
+      if not os.path.isfile('alive-tv'):
+        return lit.Test.UNSUPPORTED, ''
+
+    if not alive_tv_1 and not alive_tv_2:
       cmd = ['./alive']
       ok_string = 'Optimization is correct!'
 
@@ -73,7 +82,7 @@ class Alive2Test(TestFormat):
     if m != None:
       cmd += m.group(1).split()
 
-    if alive_tv:
+    if alive_tv_2:
        # Run identity check first
        srcpath = test
        invalid_expr = 'Invalid expr'
@@ -92,7 +101,7 @@ class Alive2Test(TestFormat):
 
 
     cmd.append(test)
-    if alive_tv:
+    if alive_tv_2:
       cmd.append(test.replace('.src.ll', '.tgt.ll'))
     out, err, exitCode = executeCommand(cmd)
 


### PR DESCRIPTION
convenient from compiler explorer

if alive-tv is handed a single file and it contains a function called
src and a function called tgt, then check refinment of that

also, add a new test mode for single files, and document our test formats
in a README.md file in the tests directory