### PR TITLE
Call smt_initializer::reset before exiting alive-tv

### DIFF
--- a/tools/alive-tv.cpp
+++ b/tools/alive-tv.cpp
@@ -372,6 +372,7 @@ int main(int argc, char **argv) {
       unsigned goodCount = 0, badCount = 0, errorCount = 0;
       bool result = compareFunctions(*SRC, *TGT, targetTriple, goodCount, badCount,
                                      errorCount);
+      smt_init.reset();
       // exit alive-tv
       return result;
     } else {


### PR DESCRIPTION
This resolves an error that appears on my machine when running a srctgt test:
```
libc++abi.dylib: Pure virtual function called!
Abort trap: 6
```