### PR TITLE
*in_memory() fails if domain is false, add loop-precond example

### DIFF
--- a/ir/state.cpp
+++ b/ir/state.cpp
@@ -134,7 +134,8 @@ bool State::startBB(const BasicBlock &bb) {
 
   domain.path = path();
   domain.UB.add(*UB());
-  memory = *in_memory();
+  if (domain)
+    memory = *in_memory();
 
   return domain;
 }

--- a/tests/alive-tv/loop-precond.srctgt.ll
+++ b/tests/alive-tv/loop-precond.srctgt.ll
@@ -1,0 +1,31 @@
+; This example checks whether issue #281 is not reproduced.
+define i32 @src(i32* %diff) {
+entry:
+  br label %for.body
+
+for.body:
+  %indvars.iv = phi i64 [ 0, %entry ], [ %indvars.iv.next, %for.body ]
+  %indvars.iv.next = add nuw nsw i64 %indvars.iv, 1
+  %exitcond = icmp eq i64 %indvars.iv.next, 8
+  br i1 %exitcond, label %for.end, label %for.body
+
+for.end:
+  ret i32 0
+}
+
+define i32 @tgt(i32* %diff) {
+entry:
+  br label %for.body
+
+for.body:
+  %indvars.iv = phi i64 [ 0, %entry ], [ %indvars.iv.next, %for.body ]
+  load i32, i32* %diff, align 4
+  %indvars.iv.next = add nuw nsw i64 %indvars.iv, 1
+  %exitcond = icmp eq i64 %indvars.iv.next, 8
+  br i1 %exitcond, label %for.end, label %for.body
+
+for.end:
+  ret i32 0
+}
+
+; ERROR: Precondition is always false


### PR DESCRIPTION
This patch resolves alive-tv/memory/calloc-overflow.src.ll failure which happens when there is an unreachable block, and adds the loop-precond example from #281