### PR TITLE
Make several memory operations const

### DIFF
--- a/ir/memory.cpp
+++ b/ir/memory.cpp
@@ -937,7 +937,7 @@ static void store_lambda(const Pointer &p, const expr &cond, const expr &val,
                   expr::mkIf(!is_local && cond, val, non_local.load(idx)));
 }
 
-static expr load(const Pointer &p, expr &local, expr &non_local) {
+static expr load(const Pointer &p, const expr &local, const expr &non_local) {
   auto idx = p.short_ptr();
   return expr::mkIf(p.is_local(), local.load(idx), non_local.load(idx));
 }
@@ -1465,7 +1465,7 @@ StateValue Memory::load(const expr &p, const Type &type, unsigned align,
   return state->rewriteUndef(move(ret));
 }
 
-Byte Memory::load(const Pointer &p) {
+Byte Memory::load(const Pointer &p) const {
   return { *this, ::load(p, local_block_val, non_local_block_val) };
 }
 
@@ -1540,12 +1540,12 @@ void Memory::memcpy(const expr &d, const expr &s, const expr &bytesize,
   }
 }
 
-expr Memory::ptr2int(const expr &ptr) {
+expr Memory::ptr2int(const expr &ptr) const {
   assert(!memory_unused());
   return Pointer(*this, ptr).get_address();
 }
 
-expr Memory::int2ptr(const expr &val) {
+expr Memory::int2ptr(const expr &val) const {
   assert(!memory_unused());
   // TODO
   return {};

--- a/ir/memory.h
+++ b/ir/memory.h
@@ -271,7 +271,7 @@ public:
                   bool deref_check = true);
 
   // raw load
-  Byte load(const Pointer &p);
+  Byte load(const Pointer &p) const;
 
   void memset(const smt::expr &ptr, const StateValue &val,
               const smt::expr &bytesize, unsigned align);
@@ -279,8 +279,8 @@ public:
               const smt::expr &bytesize, unsigned align_dst, unsigned align_src,
               bool move);
 
-  smt::expr ptr2int(const smt::expr &ptr);
-  smt::expr int2ptr(const smt::expr &val);
+  smt::expr ptr2int(const smt::expr &ptr) const;
+  smt::expr int2ptr(const smt::expr &val) const;
 
   std::pair<smt::expr,Pointer>
     refined(const Memory &other,


### PR DESCRIPTION
This PR makes raw load/ptrtoint/inttoptr const methods.
inttoptr is marked as const as well because it does not change memory according to the twin memory model.