### PR TITLE
Let Pointer::is_dereferenceable and Memory::load return UB constraints

### DIFF
--- a/ir/instr.cpp
+++ b/ir/instr.cpp
@@ -1206,7 +1206,7 @@ static StateValue pack_return(Type &ty, vector<StateValue> &vals,
 
 StateValue FnCall::toSMT(State &s) const {
   if (!valid) {
-    s.addUB({});
+    s.addUB(expr());
     return {};
   }
 
@@ -1671,7 +1671,7 @@ StateValue Switch::toSMT(State &s) const {
   }
 
   s.addJump({ move(default_cond), expr(val.non_poison) }, default_target);
-  s.addUB(false);
+  s.addUB(expr(false));
   return {};
 }
 
@@ -2109,7 +2109,9 @@ void Load::print(std::ostream &os) const {
 StateValue Load::toSMT(State &s) const {
   auto &[p, np] = s[*ptr];
   s.addUB(np);
-  return s.getMemory().load(p, getType(), align);
+  auto [sv, ub] = s.getMemory().load(p, getType(), align);
+  s.addUB(move(ub));
+  return sv;
 }
 
 expr Load::getTypeConstraints(const Function &f) const {

--- a/ir/memory.h
+++ b/ir/memory.h
@@ -147,8 +147,9 @@ public:
   smt::expr block_alignment() const; // log(bits)
   smt::expr is_block_aligned(unsigned align, bool exact = false) const;
   smt::expr is_aligned(unsigned align) const;
-  void is_dereferenceable(unsigned bytes, unsigned align, bool iswrite);
-  void is_dereferenceable(const smt::expr &bytes, unsigned align, bool iswrite);
+  smt::AndExpr is_dereferenceable(unsigned bytes, unsigned align, bool iswrite);
+  smt::AndExpr is_dereferenceable(const smt::expr &bytes, unsigned align,
+                                  bool iswrite);
   void is_disjoint(const smt::expr &len1, const Pointer &ptr2,
                    const smt::expr &len2) const;
   smt::expr is_block_alive() const;
@@ -267,8 +268,8 @@ public:
   static unsigned getStoreByteSize(const Type &ty);
   void store(const smt::expr &ptr, const StateValue &val, const Type &type,
              unsigned align, bool deref_check = true);
-  StateValue load(const smt::expr &ptr, const Type &type, unsigned align,
-                  bool deref_check = true);
+  std::pair<StateValue, smt::AndExpr> load(const smt::expr &ptr,
+      const Type &type, unsigned align);
 
   // raw load
   Byte load(const Pointer &p) const;

--- a/ir/state.cpp
+++ b/ir/state.cpp
@@ -160,7 +160,7 @@ void State::addJump(const BasicBlock &dst0, expr &&cond) {
 
 void State::addJump(const BasicBlock &dst) {
   addJump(dst, true);
-  addUB(false);
+  addUB(expr(false));
 }
 
 void State::addJump(StateValue &&cond, const BasicBlock &dst) {
@@ -173,7 +173,7 @@ void State::addCondJump(const StateValue &cond, const BasicBlock &dst_true,
   addUB(cond.non_poison);
   addJump(dst_true,  cond.value == 1);
   addJump(dst_false, cond.value == 0);
-  addUB(false);
+  addUB(expr(false));
 }
 
 void State::addReturn(const StateValue &val) {
@@ -183,7 +183,7 @@ void State::addReturn(const StateValue &val) {
   return_undef_vars.insert(undef_vars.begin(), undef_vars.end());
   return_undef_vars.insert(domain.undef_vars.begin(), domain.undef_vars.end());
   undef_vars.clear();
-  addUB(false);
+  addUB(expr(false));
 }
 
 void State::addUB(expr &&ub) {
@@ -193,6 +193,11 @@ void State::addUB(expr &&ub) {
 
 void State::addUB(const expr &ub) {
   domain.UB.add(ub);
+  domain.undef_vars.insert(undef_vars.begin(), undef_vars.end());
+}
+
+void State::addUB(AndExpr &&ubs) {
+  domain.UB.add(ubs);
   domain.undef_vars.insert(undef_vars.begin(), undef_vars.end());
 }
 

--- a/ir/state.h
+++ b/ir/state.h
@@ -123,6 +123,7 @@ public:
   void addPre(smt::expr &&cond) { precondition.add(std::move(cond)); }
   void addUB(smt::expr &&ub);
   void addUB(const smt::expr &ub);
+  void addUB(smt::AndExpr &&ubs);
   void addOOM(smt::expr &&oom) { ooms.add(std::move(oom)); }
 
   const std::vector<StateValue>


### PR DESCRIPTION
As discussed at #298, this PR makes Pointer::is_dereferenceable and Memory::load return UB constraints rather than directly updating State.