### PR TITLE
Implement dominator tree

### DIFF
--- a/ir/function.cpp
+++ b/ir/function.cpp
@@ -317,7 +317,7 @@ void DomTree::buildDominators() {
           ++srcIt;
           ++dstIt;
         } else {
-          ++dstIt;
+          break;
         }
       }
       dstDoms.insert(dstDoms.end(), &dst);

--- a/ir/function.cpp
+++ b/ir/function.cpp
@@ -298,9 +298,9 @@ void DomTree::buildDominators() {
     (void)instr;
 
     // Make sure each bb dominates itself.
-    std::vector<const BasicBlock*> &srcDoms = (dominators.try_emplace(&src, 
+    std::vector<const BasicBlock*> &srcDoms = (dominators.try_emplace(&src,
                       std::vector<const BasicBlock*>{&src})).first->second;
-    std::vector<const BasicBlock*> &dstDoms = (dominators.try_emplace(&dst, 
+    std::vector<const BasicBlock*> &dstDoms = (dominators.try_emplace(&dst,
                       std::vector<const BasicBlock*>{&dst})).first->second;
 
     if (dstDoms.size() > 1) {

--- a/ir/function.cpp
+++ b/ir/function.cpp
@@ -289,58 +289,74 @@ void CFG::printDot(ostream &os) const {
   os << "}\n";
 }
 
-// Cooper, Keith D.; Harvey, Timothy J.; and Kennedy, Ken (2001). 
-// A Simple, Fast Dominance Algorithm
-// http://www.cs.rice.edu/~keith/EMBED/dom.pdf
-void DomTree::buildDominators() {
-  unsigned bb_count = f.getBBs().size();
 
-  // build predecessor relationships
+void DomTree::buildDominators() {
+  // build predecessor and successor relationships
   for (const auto &[p, b, instr] : cfg) {
     (void)instr;
 
-    auto &b_node = doms.try_emplace(&b, DomTreeNode(b)).first->second;
-    auto &pred = doms.try_emplace(&p, DomTreeNode(p)).first->second;
-    b_node.preds.emplace_back(&pred);
+    auto &b_node = doms.try_emplace(&b, b).first->second;
+    auto &pred = doms.try_emplace(&p, p).first->second;
+    b_node.dominator = nullptr;
+    b_node.preds.push_back(&pred);
+    pred.children.push_back(&b_node);
   }
 
-  // initialization
-  unsigned i = bb_count-1;
-  for (auto &b : f.getBBs()) {
-    auto I = doms.find(b);
-    if (I == doms.end())
-      continue;
-    
-    auto &b_node = I->second;
-    b_node.order = i;
-    b_node.dominator = nullptr;
-    if (i == bb_count-1)
-      b_node.dominator = &b_node;
-    --i;
-  }
+  // JOHN B. KAM AND JEFFREY D. ULLMAN (1976).
+  // Adapted from Algorithm D in article "Global Data Flow Analysis 
+  // and Iterative Algorithms".
+  // This adapted version is almost identical to top_sort in sort.cpp.
+  // The resulting reverse post order works for building dominator trees
+  // even when CFG is cyclic.
+  // Sort a vector of DomTreeNode into reverse postorder.
+  vector<DomTreeNode*> sorted;
+  unordered_map<DomTreeNode*, bool> visited;
+  unsigned reverse_post_order = 1;
+  
+  function<void(DomTreeNode*)> visit = [&](DomTreeNode *node) {
+    if (visited[node])
+      return;
+    visited[node] = true;
+
+    for (auto child : node->children) {
+      visit(child);
+    }
+    // visit parent after visiting all children
+    sorted.push_back(node);
+    node->order = reverse_post_order;
+    // incr instead of decr because sorted is reversed later
+    ++reverse_post_order;
+  };
+
+  // assuming first bb is never moved
+  auto &entry = doms.at(&f.getFirstBB());
+  visit(&entry);
+  reverse(sorted.begin(), sorted.end());
+
+  // Cooper, Keith D.; Harvey, Timothy J.; and Kennedy, Ken (2001). 
+  // A Simple, Fast Dominance Algorithm
+  // http://www.cs.rice.edu/~keith/EMBED/dom.pdf
+  // Makes multiple passes when CFG is cyclic to update incorrect initial
+  // dominator guesses.
+  entry.dominator = &entry;
 
   DomTreeNode *new_idom;
   bool changed = true;
   while (changed) {
     changed = false;
-    for (auto &b : f.getBBs()) {
-      auto I = doms.find(b);
-      if (I == doms.end())
-        continue;
-      auto &b_node = I->second;
-      
-      if (b_node.preds.empty())
+    for (auto b : sorted) {
+      if (b->preds.empty())
         continue;
       
-      new_idom = b_node.preds.front();
-      for (auto p : b_node.preds) {
+      new_idom = b->preds.front();
+      for (auto p : b->preds) {
         if (p->dominator != nullptr) {
           new_idom = intersect(p, new_idom);
         }
       }
 
-      if (b_node.dominator != new_idom) {
-        b_node.dominator = new_idom;
+      if (b->dominator != new_idom) {
+        b->dominator = new_idom;
         changed = true;
       }
     }

--- a/ir/function.h
+++ b/ir/function.h
@@ -173,9 +173,9 @@ public:
 
 // Does not support loops
 class DomTree final {
-    Function& f;
-    CFG& cfg;
-    // src -> vec<bb's that dominate src in order of their depth in the CFG>
+    Function &f;
+    CFG &cfg;
+    // bb -> vec<dominator bb's ordered by depth in the CFG lowest first>.
     std::unordered_map<const BasicBlock*,
                       std::vector<const BasicBlock*>> dominators;
     void buildDominators();

--- a/ir/function.h
+++ b/ir/function.h
@@ -179,7 +179,6 @@ class DomTree final {
     public:
       const BasicBlock &bb;
       std::vector<DomTreeNode*> preds; // predecessors
-      std::vector<DomTreeNode*> children;
       DomTreeNode *dominator; // dominator of bb
       unsigned order;
 
@@ -189,7 +188,7 @@ class DomTree final {
     std::unordered_map<const BasicBlock*, DomTreeNode> doms;
 
     void buildDominators();
-    DomTreeNode* intersect(DomTreeNode *b1, DomTreeNode *b2);
+    static DomTreeNode* intersect(DomTreeNode *b1, DomTreeNode *b2);
   public:
     DomTree(Function &f, CFG &cfg) : f(f), cfg(cfg) { buildDominators(); }
     const BasicBlock* getIDominator(const BasicBlock &bb) const;

--- a/ir/function.h
+++ b/ir/function.h
@@ -182,18 +182,16 @@ class DomTree final {
       DomTreeNode *dominator; // dominator of bb
       unsigned order;
 
-      DomTreeNode();
       DomTreeNode(const BasicBlock &bb) : bb(bb) {}
-      DomTreeNode(const BasicBlock &bb, int order) : bb(bb), order(order) {}
     };
 
-    std::unordered_map<const BasicBlock*,std::unique_ptr<DomTreeNode>> doms;
+    std::unordered_map<const BasicBlock*, DomTreeNode> doms;
 
     void buildDominators();
     DomTreeNode* intersect(DomTreeNode *b1, DomTreeNode *b2);
   public:
     DomTree(Function &f, CFG &cfg) : f(f), cfg(cfg) { buildDominators(); }
-    auto getIDominator(const BasicBlock &bb) const;
+    const BasicBlock* getIDominator(const BasicBlock &bb) const;
     void printDot(std::ostream &os) const;
 };
 

--- a/ir/function.h
+++ b/ir/function.h
@@ -171,4 +171,17 @@ public:
   void printDot(std::ostream &os) const;
 };
 
+// Does not support loops
+class DomTree final {
+    Function& f;
+    CFG& cfg;
+    // src -> vec<bb's that dominate src in order of their depth in the CFG>
+    std::unordered_map<const BasicBlock*,
+                      std::vector<const BasicBlock*>> dominators;
+    void buildDominators();
+  public:
+    DomTree(Function &f, CFG& cfg) : f(f), cfg(cfg) { buildDominators(); }
+    void printDot(std::ostream &os) const;
+};
+
 }

--- a/ir/function.h
+++ b/ir/function.h
@@ -179,7 +179,7 @@ class DomTree final {
     public:
       const BasicBlock &bb;
       std::vector<DomTreeNode*> preds; // predecessors
-      DomTreeNode *dominator; // dominator of bb
+      DomTreeNode *dominator; // dominator of bb 
       unsigned order;
 
       DomTreeNode(const BasicBlock &bb) : bb(bb) {}

--- a/ir/function.h
+++ b/ir/function.h
@@ -171,16 +171,29 @@ public:
   void printDot(std::ostream &os) const;
 };
 
-// Does not support loops
 class DomTree final {
     Function &f;
     CFG &cfg;
-    // bb -> vec<dominator bb's ordered by depth in the CFG lowest first>.
-    std::unordered_map<const BasicBlock*,
-                      std::vector<const BasicBlock*>> dominators;
+
+    class DomTreeNode final {
+    public:
+      const BasicBlock &bb;
+      std::vector<DomTreeNode*> preds; // predecessors
+      DomTreeNode *dominator; // dominator of bb
+      unsigned order;
+
+      DomTreeNode();
+      DomTreeNode(const BasicBlock &bb) : bb(bb) {}
+      DomTreeNode(const BasicBlock &bb, int order) : bb(bb), order(order) {}
+    };
+
+    std::unordered_map<const BasicBlock*,std::unique_ptr<DomTreeNode>> doms;
+
     void buildDominators();
+    DomTreeNode* intersect(DomTreeNode *b1, DomTreeNode *b2);
   public:
     DomTree(Function &f, CFG &cfg) : f(f), cfg(cfg) { buildDominators(); }
+    auto getIDominator(const BasicBlock &bb) const;
     void printDot(std::ostream &os) const;
 };
 

--- a/ir/function.h
+++ b/ir/function.h
@@ -180,7 +180,7 @@ class DomTree final {
                       std::vector<const BasicBlock*>> dominators;
     void buildDominators();
   public:
-    DomTree(Function &f, CFG& cfg) : f(f), cfg(cfg) { buildDominators(); }
+    DomTree(Function &f, CFG &cfg) : f(f), cfg(cfg) { buildDominators(); }
     void printDot(std::ostream &os) const;
 };
 

--- a/ir/function.h
+++ b/ir/function.h
@@ -179,6 +179,7 @@ class DomTree final {
     public:
       const BasicBlock &bb;
       std::vector<DomTreeNode*> preds; // predecessors
+      std::vector<DomTreeNode*> children;
       DomTreeNode *dominator; // dominator of bb
       unsigned order;
 

--- a/tv/tv.cpp
+++ b/tv/tv.cpp
@@ -143,7 +143,11 @@ struct TVPass final : public llvm::FunctionPass {
     if (opt_print_dot) {
       auto &f = I->second.first;
       ofstream file(f.getName() + '.' + to_string(I->second.second++) + ".dot");
-      CFG(f).printDot(file);
+      CFG cfg(f);
+      cfg.printDot(file);
+      ofstream fileDom(f.getName() + '.' + to_string(I->second.second++) +
+                       ".dom.dot");
+      DomTree(f, cfg).printDot(fileDom);
     }
 
     if (first)


### PR DESCRIPTION
This should correctly build dominator trees and print them as .dot files. The main use is to be able to lookup for the dominators or immediate dominator of a given node in O(1). I experimented with building an edge_iterator for it but that would require creating a second map with the relationship dominator->dominated nodes just for iterating over edges. At the moment i don't see any use for this other than quick immediate dominator lookup.