### PR TITLE
it was a mistake to redirect stderr using the -o flag, so undo that

### DIFF
--- a/tools/alive-tv.cpp
+++ b/tools/alive-tv.cpp
@@ -362,7 +362,6 @@ int main(int argc, char **argv) {
   if (!opt_outputfile.empty()) {
     OutFile.open(opt_outputfile);
     std::cout.rdbuf(OutFile.rdbuf());
-    std::cerr.rdbuf(OutFile.rdbuf());
   }
   
   auto M1 = openInputFile(Context, opt_file1);


### PR DESCRIPTION
I had thought it was a good idea to send stderr to the -o file, but this prevents compiler explorer from showing these error messages to users. this change seems to give the desired behavior.