### PR TITLE
Store to constant global only when it has definitive initializer

### DIFF
--- a/llvm_util/llvm2alive.cpp
+++ b/llvm_util/llvm2alive.cpp
@@ -913,7 +913,7 @@ public:
       if (!GV)
         continue;
       auto gv = getGlobalVariable(GV->getName().substr(1));
-      if (!gv->isConstant() || !gv->hasInitializer())
+      if (!gv->isConstant() || !gv->hasDefinitiveInitializer())
         continue;
 
       auto storedval = get_operand(gv->getInitializer());

--- a/tests/alive-tv/memory/glb-weak-fail.srctgt.ll
+++ b/tests/alive-tv/memory/glb-weak-fail.srctgt.ll
@@ -1,0 +1,12 @@
+@g = weak constant i32 0
+
+define i32 @src() {
+  %x = load i32, i32* @g
+  ret i32 %x
+}
+
+define i32 @tgt() {
+  ret i32 0
+}
+
+; ERROR: Value mismatch


### PR DESCRIPTION
Deal with the case that was mentioned at #311 