### PR TITLE
Let ptr cmp ule/ult/.. with difference provenance return nondet value

### DIFF
--- a/ir/memory.cpp
+++ b/ir/memory.cpp
@@ -490,7 +490,10 @@ expr Pointer::operator!=(const Pointer &rhs) const {
 #define DEFINE_CMP(op)                                                      \
 StateValue Pointer::op(const Pointer &rhs) const {                          \
   /* Note that attrs are not compared. */                                   \
-  return { get_offset().op(rhs.get_offset()), get_bid() == rhs.get_bid() }; \
+  expr nondet = expr::mkFreshVar("nondet", true);                           \
+  m.state->addQuantVar(nondet);                                             \
+  return { expr::mkIf(get_bid() == rhs.get_bid(),                           \
+                      get_offset().op(rhs.get_offset()), nondet), true };   \
 }
 
 DEFINE_CMP(sle)

--- a/tests/alive-tv/memory/ptr-cmp.src.ll
+++ b/tests/alive-tv/memory/ptr-cmp.src.ll
@@ -1,4 +1,4 @@
-; ERROR: Target is more poisonous
+; ERROR: Value mismatch
 
 define i1 @f(i32** %a) {
   %load = load i32*, i32** %a


### PR DESCRIPTION
According to the twin memory sem, it returns a nondeterministic value.

This patch resolves 3 failures from LLVM unit tests:
```
Transforms/LoopLoadElim/forward.ll
Transforms/LoopLoadElim/memcheck.ll
Transforms/LoopLoadElim/opt-size.ll
```