### PR TITLE
cmake: search for additional subdirs for z3 include file

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,6 @@ cmake -GNinja -DCMAKE_BUILD_TYPE=Release ..
 ninja
 ```
 
-If CMake cannot find the Z3 include directory (or finds the wrong one) pass
-the ``-DZ3_INCLUDE_DIR=/path/to/z3/include`` argument to CMake
-
 
 Building and Running Translation Validation
 --------

--- a/cmake/FindZ3.cmake
+++ b/cmake/FindZ3.cmake
@@ -1,4 +1,4 @@
-find_path(Z3_INCLUDE_DIR NAMES z3.h)
+find_path(Z3_INCLUDE_DIR NAMES z3.h PATH_SUFFIXES z3)
 find_library(Z3_LIBRARIES NAMES z3)
 
 message(STATUS "Z3: ${Z3_INCLUDE_DIR} ${Z3_LIBRARIES}")


### PR DESCRIPTION
this should prevent the need to specify z3_include_dir 