### PR TITLE
alive2test.py should check absence of 'ERROR: ..' too

### DIFF
--- a/tests/alive-tv/failcheck.src.ll
+++ b/tests/alive-tv/failcheck.src.ll
@@ -1,0 +1,9 @@
+define i8 @src() {
+ret i8 0
+}
+
+define i8 @tgt() {
+ret i8 1
+}
+
+; XFAIL: Value mismatch

--- a/tests/alive-tv/failcheck.tgt.ll
+++ b/tests/alive-tv/failcheck.tgt.ll
@@ -1,0 +1,7 @@
+define i8 @src() {
+ret i8 0
+}
+
+define i8 @tgt() {
+ret i8 2
+}

--- a/tests/lit/lit/formats/alive2test.py
+++ b/tests/lit/lit/formats/alive2test.py
@@ -6,6 +6,7 @@ import lit.util
 from .base import TestFormat
 import os, re, signal, string, subprocess
 
+
 def executeCommand(command):
   p = subprocess.Popen(command,
                        stdout=subprocess.PIPE,


### PR DESCRIPTION
This also updates XFAIL to check stdout too.

Realized that we were missing several fails, including alive-tv/memory/lifetime-1.src.ll ; it was raising `Precondition is false` error.