### PR TITLE
mk_nonlocal_val_axioms should do nothing when num_nonlocals == 0

### DIFF
--- a/ir/memory.cpp
+++ b/ir/memory.cpp
@@ -1026,6 +1026,8 @@ static expr mk_liveness_array() {
 static void mk_nonlocal_val_axioms(State &s, Memory &m, expr &val) {
   if (!does_ptr_mem_access)
     return;
+  else if (m.num_nonlocals() == 0)
+    return;
 
   auto idx = Pointer(m, "#idx", false, false).short_ptr();
 #if 0


### PR DESCRIPTION
There was a bug at mk_nonlocal_val_axioms() that makes axiom to be always false when num_nonlocals == 0, causing some unit tests to raise `precondition is false` error

```
  Byte byte(m, val.load(idx));
  Pointer loadedptr = byte.ptr();
  expr bid = loadedptr.get_short_bid();
  s.addAxiom(
    expr::mkForAll({ idx },
      byte.is_ptr().implies(
                            !loadedptr.is_local() && // << this was always false
                            !loadedptr.is_nocapture() &&
                            bid.ule(m.num_nonlocals() - 1))));
```