### PR TITLE
Add --succinct param to alive-tv, add CHECK-NOT directive

### DIFF
--- a/tests/alive-tv/params/succinct-correct.srctgt.ll
+++ b/tests/alive-tv/params/succinct-correct.srctgt.ll
@@ -1,0 +1,13 @@
+; TEST-ARGS: -succinct
+
+define i32 @src(i32 %x) {
+  ret i32 %x
+}
+
+define i32 @tgt(i32 %x) {
+  %y = add i32 %x, 0
+  ret i32 %y
+}
+
+; CHECK: Transformation seems to be correct!
+; CHECK-NOT: define i32 @src

--- a/tests/alive-tv/params/succinct-incorrect.srctgt.ll
+++ b/tests/alive-tv/params/succinct-incorrect.srctgt.ll
@@ -1,0 +1,14 @@
+; TEST-ARGS: -succinct
+
+define i32 @src(i32 %x) {
+  ret i32 %x
+}
+
+define i32 @tgt(i32 %x) {
+  %y = add i32 %x, 1
+  ret i32 %y
+}
+
+; CHECK: Transformation doesn't verify!
+; CHECK-NOT: define i32 @src
+; CHECK-NOT: ERROR:

--- a/tests/lit/lit/formats/alive2test.py
+++ b/tests/lit/lit/formats/alive2test.py
@@ -41,6 +41,7 @@ class Alive2Test(TestFormat):
     self.regex_xfail = re.compile(r";\s*XFAIL:\s*(.*)")
     self.regex_args = re.compile(r";\s*TEST-ARGS:(.*)")
     self.regex_check = re.compile(r";\s*CHECK:(.*)")
+    self.regex_check_not = re.compile(r";\s*CHECK-NOT:(.*)")
     self.regex_errs_out = re.compile("ERROR:.*")
 
   def getTestsInDirectory(self, testSuite, path_in_suite,
@@ -107,20 +108,27 @@ class Alive2Test(TestFormat):
     expect_err = self.regex_errs.search(input)
     xfail = self.regex_xfail.search(input)
     chk = self.regex_check.search(input)
+    chk_not = self.regex_check_not.search(input)
+
+    # Check XFAIL early.
+    if xfail != None and (out + err).find(xfail.group(1)) != -1:
+      return lit.Test.XFAIL, ''
 
     if chk != None and (out + err).find(chk.group(1).strip()) == -1:
       return lit.Test.FAIL, out + err
 
-    if expect_err is None and xfail is None:
+    if chk_not != None and (out + err).find(chk_not.group(1).strip()) != -1:
+      return lit.Test.FAIL, out + err
+
+    if expect_err is None and xfail is None and chk is None and chk_not is None:
+      # If there's no other test, correctness of the transformation should be
+      # checked.
       if exitCode == 0 and (out + err).find(ok_string) != -1 and \
           self.regex_errs_out.search(out + err) is None:
         return lit.Test.PASS, ''
       return lit.Test.FAIL, out + err
 
-    if expect_err != None and (out + err).find(expect_err.group(1)) != -1:
-      return lit.Test.PASS, ''
+    if expect_err != None and (out + err).find(expect_err.group(1)) == -1:
+      return lit.Test.FAIL, out + err
 
-    if xfail != None and (out + err).find(xfail.group(1)) != -1:
-      return lit.Test.XFAIL, ''
-
-    return lit.Test.FAIL, out + err
+    return lit.Test.PASS, ''

--- a/tools/alive-tv.cpp
+++ b/tools/alive-tv.cpp
@@ -84,6 +84,10 @@ static llvm::cl::opt<bool> opt_smt_stats(
     "smt-stats", llvm::cl::desc("Show SMT statistics"),
     llvm::cl::cat(opt_alive), llvm::cl::init(false));
 
+static llvm::cl::opt<bool> opt_succinct(
+    "succinct", llvm::cl::desc("Make the output succinct"),
+    llvm::cl::cat(opt_alive), llvm::cl::init(false));
+
 static llvm::cl::opt<unsigned> opt_max_mem(
      "max-mem", llvm::cl::desc("Max memory (approx)"),
      llvm::cl::cat(opt_alive), llvm::cl::init(1024), llvm::cl::value_desc("MB"));
@@ -243,7 +247,8 @@ static void compareFunctions(llvm::Function &F1, llvm::Function &F2,
   t.src = move(*Func1);
   t.tgt = move(*Func2);
   TransformVerify verifier(t, false);
-  t.print(cout, print_opts);
+  if (!opt_succinct)
+    t.print(cout, print_opts);
 
   {
     auto types = verifier.getTypings();
@@ -260,7 +265,9 @@ static void compareFunctions(llvm::Function &F1, llvm::Function &F2,
   bool result(errs);
   if (result) {
     if (errs.isUnsound()) {
-      cout << "Transformation doesn't verify!\n" << errs << endl;
+      cout << "Transformation doesn't verify!\n";
+      if (!opt_succinct)
+        cout << errs << endl;
       ++badCount;
     } else {
       cerr << errs << endl;


### PR DESCRIPTION
This adds --succinct param to alive-tv.
With this flag enabled, alive-tv prints a single line per function.
This helps reduce the size of logs emitted from TV.

To add tests for --succinct, I added CHECK-NOT: predicate.
This required small rewrites to ailve2test.py , because CHECK-NOT should succeed regardless of whether the transformation is correct or not.