### PR TITLE
Raise Unsupported constant error if glbvar's initializer cannot be translated

### DIFF
--- a/llvm_util/llvm2alive.cpp
+++ b/llvm_util/llvm2alive.cpp
@@ -918,8 +918,11 @@ public:
         continue;
 
       auto storedval = get_operand(gv->getInitializer());
-      if (!storedval)
+      if (!storedval) {
+        *out << "ERROR: Unsupported constant: " << *gv->getInitializer()
+             << "\n";
         return {};
+      }
 
       stores.emplace(GV->getName(),
                      make_unique<Store>(*GV, *storedval, GV->getAlignment()));

--- a/scripts/stats.php
+++ b/scripts/stats.php
@@ -25,7 +25,7 @@ foreach (glob("$logs/*.txt") as $f) {
     @$stats[$stat[1]] += (int)$stat[2];
   }
 
-  preg_match_all('/Unsupported (?:instruction|type|attribute):\s*(.+)/S', $txt, $m);
+  preg_match_all('/Unsupported (?:instruction|type|attribute|constant):\s*(.+)/S', $txt, $m);
   foreach ($m[1] as $str) {
     if (preg_match('/%\S+ = ([^%[(]+)/S', $str, $m2)) {
       @++$unsupported[trim($m2[1])];


### PR DESCRIPTION
This is especially helpful when e.g. a long string constant is used