### PR TITLE
Allow a global var to be constant in tgt (reproduces pr43616 again)

### DIFF
--- a/tests/alive-tv/bugs/pr43616.src.ll
+++ b/tests/alive-tv/bugs/pr43616.src.ll
@@ -1,0 +1,22 @@
+declare {}* @llvm.invariant.start.p0i8(i64 %size, i8* nocapture %ptr)
+
+;define void @test1(i8* %ptr) {
+;  call {}* @llvm.invariant.start.p0i8(i64 4, i8* %ptr)
+;  ret void
+;}
+; To reproduce the error, test1's fn body is not needed
+declare void @test1(i8*)
+
+@object1 = global i32 0
+define void @ctor1() {
+  store i32 -1, i32* @object1
+  %A = bitcast i32* @object1 to i8*
+  call void @test1(i8* %A)
+  ret void
+}
+
+@llvm.global_ctors = appending constant
+  [1 x { i32, void ()*, i8* }]
+  [ { i32, void ()*, i8* } { i32 65535, void ()* @ctor1, i8* null } ]
+
+; ERROR: Source is more defined than target

--- a/tests/alive-tv/bugs/pr43616.tgt.ll
+++ b/tests/alive-tv/bugs/pr43616.tgt.ll
@@ -1,0 +1,21 @@
+@object1 = constant i32 -1
+@llvm.global_ctors = appending constant [0 x { i32, void ()*, i8* }] zeroinitializer
+
+; Function Attrs: argmemonly nounwind willreturn
+declare {}* @llvm.invariant.start.p0i8(i64 immarg, i8* nocapture) #0
+
+;define void @test1(i8* %ptr) local_unnamed_addr {
+;  %1 = call {}* @llvm.invariant.start.p0i8(i64 4, i8* %ptr)
+;  ret void
+;}
+; To reproduce the error, test1's fn body is not needed
+declare void @test1(i8*)
+
+define void @ctor1() local_unnamed_addr {
+  store i32 -1, i32* @object1
+  %A = bitcast i32* @object1 to i8*
+  call void @test1(i8* %A)
+  ret void
+}
+
+attributes #0 = { argmemonly nounwind willreturn }

--- a/tests/alive-tv/glbconstchk.src.ll
+++ b/tests/alive-tv/glbconstchk.src.ll
@@ -5,4 +5,4 @@ define i32 @f() {
   ret i32 %v
 }
 
-; ERROR: Unsupported interprocedural transformation: global variable @g is const in target but not in source
+; ERROR: Value mismatch

--- a/tools/transform.cpp
+++ b/tools/transform.cpp
@@ -906,11 +906,6 @@ Errors TransformVerify::verify() const {
       ss << "Transformation is incorrect because global variable "
         << GVS->getName() << " is const in source but not in target";
       return { ss.str(), true };
-    } else if (!GVS->isConst() && GVT->isConst()) {
-      stringstream ss;
-      ss << "Unsupported interprocedural transformation: global variable "
-        << GVS->getName() << " is const in target but not in source";
-      return { ss.str(), false };
     }
   }
 


### PR DESCRIPTION
This PR allows a global var to be constant in tgt again.
This helps Alive2 reproduce https://bugs.llvm.org/show_bug.cgi?id=43616, which was found by Alive2 in the past but became unsupported at some point.