### PR TITLE
Let memcpy -> load/store i8 raise memory mismatch

### DIFF
--- a/tests/alive-tv/memory/memcpy-3-loadstore.srctgt.ll
+++ b/tests/alive-tv/memory/memcpy-3-loadstore.srctgt.ll
@@ -1,7 +1,7 @@
 ; ERROR: Mismatch in memory
 
 define void @src(i8* %p, i8* %q) {
-  tail call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 4 %q, i8* align 4 %p, i64 1, i1 false)
+  tail call void @llvm.memcpy.p0i8.p0i8.i64(i8* %q, i8* %p, i64 1, i1 false)
   ret void
 }
 

--- a/tests/alive-tv/memory/memcpy-3-loadstore.srctgt.ll
+++ b/tests/alive-tv/memory/memcpy-3-loadstore.srctgt.ll
@@ -1,0 +1,14 @@
+; ERROR: Mismatch in memory
+
+define void @src(i8* %p, i8* %q) {
+  tail call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 4 %q, i8* align 4 %p, i64 1, i1 false)
+  ret void
+}
+
+define void @tgt(i8* %p, i8* %q) {
+  %v = load i8, i8* %p
+  store i8 %v, i8* %q
+  ret void
+}
+
+declare void @llvm.memcpy.p0i8.p0i8.i64(i8*, i8*, i64, i1)

--- a/tools/transform.cpp
+++ b/tools/transform.cpp
@@ -612,6 +612,7 @@ static uint64_t get_access_size(const Instr &inst) {
 #endif
     // FIXME: memcpy doesn't have multi-byte support
     (void)i;
+    does_ptr_mem_access = true;
     return 1;
   }
 


### PR DESCRIPTION
.. because load i8 yields poison if it was a pointer byte.
This implies that we don't have 'unsigned char' type in the twin memory model right now.
To recap: making i8 as unsigned char again causes all arithmetic optimizations on i8  unsound/controversial again, so this was our design choice.