### PR TITLE
Add tests for bitcast between int and vector

### DIFF
--- a/tests/alive-tv/bitcast/bitcast-vector-bigendian.src.ll
+++ b/tests/alive-tv/bitcast/bitcast-vector-bigendian.src.ll
@@ -1,0 +1,27 @@
+target datalayout="E"
+target triple = "powerpc64-unknown-linux-gnu"
+
+define i4 @f1() {
+  ; returns: 1101
+  %v = bitcast <4 x i1> <i1 1, i1 1, i1 0, i1 1> to i4
+  ret i4 %v
+}
+
+define i8 @f2() {
+  ; returns: 00011011
+  %v = bitcast <4 x i2> <i2 0, i2 1, i2 2, i2 3> to i8
+  ret i8 %v
+}
+
+define i12 @f3() {
+  ; returns: 00000000 01010011
+  %v = bitcast <4 x i3> <i3 0, i3 1, i3 2, i3 3> to i12
+  ret i12 %v
+}
+
+define i16 @f4() {
+  ; returns: 00000001 00100011
+  %v = bitcast <4 x i4> <i4 0, i4 1, i4 2, i4 3> to i16
+  ret i16 %v
+}
+

--- a/tests/alive-tv/bitcast/bitcast-vector-bigendian.tgt.ll
+++ b/tests/alive-tv/bitcast/bitcast-vector-bigendian.tgt.ll
@@ -1,0 +1,18 @@
+target datalayout="E"
+target triple = "powerpc64-unknown-linux-gnu"
+
+define i4 @f1() {
+  ret i4 13
+}
+
+define i8 @f2() {
+  ret i8 27
+}
+
+define i12 @f3() {
+  ret i12 83
+}
+
+define i16 @f4() {
+  ret i16 291
+}

--- a/tests/alive-tv/bitcast/bitcast-vector.src.ll
+++ b/tests/alive-tv/bitcast/bitcast-vector.src.ll
@@ -1,0 +1,26 @@
+target datalayout="e"
+
+define i4 @f1() {
+  ; returns: 1011
+  %v = bitcast <4 x i1> <i1 1, i1 1, i1 0, i1 1> to i4
+  ret i4 %v
+}
+
+define i8 @f2() {
+  ; returns: 11100100
+  %v = bitcast <4 x i2> <i2 0, i2 1, i2 2, i2 3> to i8
+  ret i8 %v
+}
+
+define i12 @f3() {
+  ; returns: 00000110 10001000
+  %v = bitcast <4 x i3> <i3 0, i3 1, i3 2, i3 3> to i12
+  ret i12 %v
+}
+
+define i16 @f4() {
+  ; returns: 00110010 00010000
+  %v = bitcast <4 x i4> <i4 0, i4 1, i4 2, i4 3> to i16
+  ret i16 %v
+}
+

--- a/tests/alive-tv/bitcast/bitcast-vector.tgt.ll
+++ b/tests/alive-tv/bitcast/bitcast-vector.tgt.ll
@@ -1,0 +1,17 @@
+target datalayout="e"
+
+define i4 @f1() {
+  ret i4 11
+}
+
+define i8 @f2() {
+  ret i8 -28
+}
+
+define i12 @f3() {
+  ret i12 1672
+}
+
+define i16 @f4() {
+  ret i16 12816
+}

--- a/tests/alive-tv/bitcast/cast-vec-roundtrip-bigendian.srctgt.ll
+++ b/tests/alive-tv/bitcast/cast-vec-roundtrip-bigendian.srctgt.ll
@@ -1,0 +1,12 @@
+target datalayout="E"
+target triple = "powerpc64-unknown-linux-gnu"
+
+define i8 @src(i8 %v){
+  %t = bitcast i8 %v to <4 x i2>
+  %v2 = bitcast <4 x i2> %t to i8
+  ret i8 %v2
+}
+
+define i8 @tgt(i8 %v) {
+  ret i8 %v
+}

--- a/tests/alive-tv/bitcast/cast-vec-roundtrip.srctgt.ll
+++ b/tests/alive-tv/bitcast/cast-vec-roundtrip.srctgt.ll
@@ -1,0 +1,9 @@
+define i8 @src(i8 %v){
+  %t = bitcast i8 %v to <4 x i2>
+  %v2 = bitcast <4 x i2> %t to i8
+  ret i8 %v2
+}
+
+define i8 @tgt(i8 %v) {
+  ret i8 %v
+}

--- a/tests/alive-tv/bitcast/vec-cast-roundtrip-bigendian.srctgt.ll
+++ b/tests/alive-tv/bitcast/vec-cast-roundtrip-bigendian.srctgt.ll
@@ -1,0 +1,12 @@
+target datalayout="E"
+target triple = "powerpc64-unknown-linux-gnu"
+
+define <4 x i2> @src(<4 x i2> %t){
+  %v = bitcast <4 x i2> %t to i8
+  %t2 = bitcast i8 %v to <4 x i2>
+  ret <4 x i2> %t2
+}
+
+define <4 x i2> @tgt(<4 x i2> %t){
+  ret <4 x i2> %t
+}

--- a/tests/alive-tv/bitcast/vec-cast-roundtrip.srctgt.ll
+++ b/tests/alive-tv/bitcast/vec-cast-roundtrip.srctgt.ll
@@ -1,0 +1,9 @@
+define <4 x i2> @src(<4 x i2> %t){
+  %v = bitcast <4 x i2> %t to i8
+  %t2 = bitcast i8 %v to <4 x i2>
+  ret <4 x i2> %t2
+}
+
+define <4 x i2> @tgt(<4 x i2> %t){
+  ret <4 x i2> %t
+}


### PR DESCRIPTION
I'm attacking #277 now, and these are sanity checks for correct semantics of bitcasts