### PR TITLE
Support vector load/store with element size not a multiple of 8

### DIFF
--- a/ir/memory.cpp
+++ b/ir/memory.cpp
@@ -273,7 +273,7 @@ static vector<Byte> valueToBytes(const StateValue &val, const Type &fromType,
     for (unsigned i = 0; i < bytesize; ++i)
       bytes.emplace_back(p, i, val.non_poison);
   } else {
-    assert(!fromType.isAggregateType() || isIntVector(fromType));
+    assert(!fromType.isAggregateType() || isNonPtrVector(fromType));
     StateValue bvval = fromType.toInt(*s, val);
     unsigned bitsize = bvval.bits();
     unsigned bytesize = divide_up(bitsize, bits_byte);
@@ -326,7 +326,7 @@ static StateValue bytesToValue(const Memory &m, const vector<Byte> &bytes,
              move(non_poison) };
 
   } else {
-    assert(!toType.isAggregateType() || isIntVector(toType));
+    assert(!toType.isAggregateType() || isNonPtrVector(toType));
     auto bitsize = toType.bits();
     assert(divide_up(bitsize, bits_byte) == bytes.size());
 
@@ -1457,7 +1457,7 @@ unsigned Memory::getStoreByteSize(const Type &ty) {
     return divide_up(bits_program_pointer, 8);
 
   auto aty = ty.getAsAggregateType();
-  if (aty && !isIntVector(ty)) {
+  if (aty && !isNonPtrVector(ty)) {
     unsigned sz = 0;
     for (unsigned i = 0; i < aty->numElementsConst(); ++i)
       sz += getStoreByteSize(aty->getChild(i));
@@ -1480,7 +1480,7 @@ void Memory::store(const expr &p, const StateValue &v, const Type &type,
                                         !state->isInitializationPhase()));
 
   auto aty = type.getAsAggregateType();
-  if (aty && !isIntVector(type)) {
+  if (aty && !isNonPtrVector(type)) {
     unsigned byteofs = 0;
     for (unsigned i = 0, e = aty->numElementsConst(); i < e; ++i) {
       auto &child = aty->getChild(i);
@@ -1517,7 +1517,7 @@ Memory::load(const expr &p, const Type &type, unsigned align) {
 
   StateValue ret;
   auto aty = type.getAsAggregateType();
-  if (aty && !isIntVector(type)) {
+  if (aty && !isNonPtrVector(type)) {
     vector<StateValue> member_vals;
     unsigned byteofs = 0;
     for (unsigned i = 0, e = aty->numElementsConst(); i < e; ++i) {

--- a/ir/memory.cpp
+++ b/ir/memory.cpp
@@ -273,7 +273,7 @@ static vector<Byte> valueToBytes(const StateValue &val, const Type &fromType,
     for (unsigned i = 0; i < bytesize; ++i)
       bytes.emplace_back(p, i, val.non_poison);
   } else {
-    assert(!fromType.isAggregateType() || isVectorWithNonByteInts(fromType));
+    assert(!fromType.isAggregateType() || isIntVector(fromType));
     StateValue bvval = fromType.toInt(*s, val);
     unsigned bitsize = bvval.bits();
     unsigned bytesize = divide_up(bitsize, bits_byte);
@@ -326,7 +326,7 @@ static StateValue bytesToValue(const Memory &m, const vector<Byte> &bytes,
              move(non_poison) };
 
   } else {
-    assert(!toType.isAggregateType() || isVectorWithNonByteInts(toType));
+    assert(!toType.isAggregateType() || isIntVector(toType));
     auto bitsize = toType.bits();
     assert(divide_up(bitsize, bits_byte) == bytes.size());
 
@@ -1457,7 +1457,7 @@ unsigned Memory::getStoreByteSize(const Type &ty) {
     return divide_up(bits_program_pointer, 8);
 
   auto aty = ty.getAsAggregateType();
-  if (aty && !isVectorWithNonByteInts(ty)) {
+  if (aty && !isIntVector(ty)) {
     unsigned sz = 0;
     for (unsigned i = 0; i < aty->numElementsConst(); ++i)
       sz += getStoreByteSize(aty->getChild(i));
@@ -1480,7 +1480,7 @@ void Memory::store(const expr &p, const StateValue &v, const Type &type,
                                         !state->isInitializationPhase()));
 
   auto aty = type.getAsAggregateType();
-  if (aty && !isVectorWithNonByteInts(type)) {
+  if (aty && !isIntVector(type)) {
     unsigned byteofs = 0;
     for (unsigned i = 0, e = aty->numElementsConst(); i < e; ++i) {
       auto &child = aty->getChild(i);
@@ -1517,7 +1517,7 @@ Memory::load(const expr &p, const Type &type, unsigned align) {
 
   StateValue ret;
   auto aty = type.getAsAggregateType();
-  if (aty && !isVectorWithNonByteInts(type)) {
+  if (aty && !isIntVector(type)) {
     vector<StateValue> member_vals;
     unsigned byteofs = 0;
     for (unsigned i = 0, e = aty->numElementsConst(); i < e; ++i) {

--- a/ir/memory.cpp
+++ b/ir/memory.cpp
@@ -273,6 +273,7 @@ static vector<Byte> valueToBytes(const StateValue &val, const Type &fromType,
     for (unsigned i = 0; i < bytesize; ++i)
       bytes.emplace_back(p, i, val.non_poison);
   } else {
+    assert(!fromType.isAggregateType() || isVectorWithNonByteInts(fromType));
     StateValue bvval = fromType.toInt(*s, val);
     unsigned bitsize = bvval.bits();
     unsigned bytesize = divide_up(bitsize, bits_byte);
@@ -325,6 +326,7 @@ static StateValue bytesToValue(const Memory &m, const vector<Byte> &bytes,
              move(non_poison) };
 
   } else {
+    assert(!toType.isAggregateType() || isVectorWithNonByteInts(toType));
     auto bitsize = toType.bits();
     assert(divide_up(bitsize, bits_byte) == bytes.size());
 
@@ -1454,7 +1456,8 @@ unsigned Memory::getStoreByteSize(const Type &ty) {
   if (ty.isPtrType())
     return divide_up(bits_program_pointer, 8);
 
-  if (auto aty = ty.getAsAggregateType()) {
+  auto aty = ty.getAsAggregateType();
+  if (aty && !isVectorWithNonByteInts(ty)) {
     unsigned sz = 0;
     for (unsigned i = 0; i < aty->numElementsConst(); ++i)
       sz += getStoreByteSize(aty->getChild(i));
@@ -1476,7 +1479,8 @@ void Memory::store(const expr &p, const StateValue &v, const Type &type,
     state->addUB(ptr.is_dereferenceable(getStoreByteSize(type), align,
                                         !state->isInitializationPhase()));
 
-  if (auto aty = type.getAsAggregateType()) {
+  auto aty = type.getAsAggregateType();
+  if (aty && !isVectorWithNonByteInts(type)) {
     unsigned byteofs = 0;
     for (unsigned i = 0, e = aty->numElementsConst(); i < e; ++i) {
       auto &child = aty->getChild(i);
@@ -1512,7 +1516,8 @@ Memory::load(const expr &p, const Type &type, unsigned align) {
   auto ubs = ptr.is_dereferenceable(bytecount, align, false);
 
   StateValue ret;
-  if (auto aty = type.getAsAggregateType()) {
+  auto aty = type.getAsAggregateType();
+  if (aty && !isVectorWithNonByteInts(type)) {
     vector<StateValue> member_vals;
     unsigned byteofs = 0;
     for (unsigned i = 0, e = aty->numElementsConst(); i < e; ++i) {

--- a/ir/type.cpp
+++ b/ir/type.cpp
@@ -1367,12 +1367,12 @@ bool hasPtr(const Type &t) {
   return false;
 }
 
-bool isVectorWithNonByteInts(const Type &t) {
+bool isIntVector(const Type &t) {
   auto vty = dynamic_cast<const VectorType *>(&t);
   if (!vty || vty->numElementsConst() == 0)
     return false;
   auto &child = vty->getChild(0);
-  return child.isIntType() && child.bits() % 8 != 0;
+  return child.isIntType();
 }
 
 }

--- a/ir/type.h
+++ b/ir/type.h
@@ -408,6 +408,6 @@ public:
 
 
 bool hasPtr(const Type &t);
-bool isVectorWithNonByteInts(const Type &t);
+bool isIntVector(const Type &t);
 
 }

--- a/ir/type.h
+++ b/ir/type.h
@@ -267,7 +267,8 @@ public:
   unsigned numElementsConst() const { return elements; }
 
   StateValue aggregateVals(const std::vector<StateValue> &vals) const;
-  IR::StateValue extract(const IR::StateValue &val, unsigned index) const;
+  IR::StateValue extract(const IR::StateValue &val, unsigned index,
+                         bool fromInt = false) const;
   Type& getChild(unsigned index) const { return *children[index]; }
   bool isPadding(unsigned i) const { return is_padding[i]; }
 
@@ -408,6 +409,6 @@ public:
 
 
 bool hasPtr(const Type &t);
-bool isIntVector(const Type &t);
+bool isNonPtrVector(const Type &t);
 
 }

--- a/ir/type.h
+++ b/ir/type.h
@@ -408,5 +408,6 @@ public:
 
 
 bool hasPtr(const Type &t);
+bool isVectorWithNonByteInts(const Type &t);
 
 }

--- a/tests/alive-tv/memory/vectors-float.srctgt.ll
+++ b/tests/alive-tv/memory/vectors-float.srctgt.ll
@@ -1,0 +1,13 @@
+target datalayout="e"
+
+define i64 @src(<2 x float>* %p) {
+  store <2 x float> <float 1.0, float 2.0>, <2 x float>* %p
+  %p2 = bitcast <2 x float>* %p to i64*
+  %i = load i64, i64* %p2
+  ret i64 %i
+}
+
+define i64 @tgt(<2 x float>* %p) {
+	store <2 x float> <float 1.0, float 2.0>, <2 x float>* %p
+	ret i64 4611686019492741120
+}

--- a/tests/alive-tv/memory/vectors-i12.srctgt.ll
+++ b/tests/alive-tv/memory/vectors-i12.srctgt.ll
@@ -1,0 +1,15 @@
+; TEST-ARGS: -bidirectional
+target datalayout="e"
+
+define i24 @src(<2 x i12>* %p) {
+  store <2 x i12> <i12 4094, i12 2050>, <2 x i12>* %p
+  %p2 = bitcast <2 x i12>* %p to i24*
+  %v = load i24, i24* %p2
+  ret i24 %v
+}
+
+define i24 @tgt(<2 x i12>* %p) {
+  store <2 x i12> <i12 4094, i12 2050>, <2 x i12>* %p
+  ret i24 8400894
+}
+

--- a/tests/alive-tv/memory/vectors-small-bigendian-fail.srctgt.ll
+++ b/tests/alive-tv/memory/vectors-small-bigendian-fail.srctgt.ll
@@ -1,0 +1,15 @@
+target datalayout="E"
+target triple = "powerpc64-unknown-linux-gnu"
+
+define void @src(<3 x i2>* %p) {
+  ; 00011011 = 27
+  store <3 x i2> <i2 1, i2 2, i2 3>, <3 x i2>* %p
+  ret void
+}
+
+define void @tgt(<3 x i2>* %p) {
+  store <3 x i2> <i2 1, i2 2, i2 2>, <3 x i2>* %p
+  ret void
+}
+
+; ERROR: Mismatch in memory

--- a/tests/alive-tv/memory/vectors-small-bigendian.src.ll
+++ b/tests/alive-tv/memory/vectors-small-bigendian.src.ll
@@ -1,0 +1,19 @@
+target datalayout="E"
+target triple = "powerpc64-unknown-linux-gnu"
+
+define i8 @f(<3 x i2>* %p) {
+  ; 00011011 = 27
+  store <3 x i2> <i2 1, i2 2, i2 3>, <3 x i2>* %p
+  %q = load <3 x i2>, <3 x i2>* %p
+  %w = bitcast <3 x i2> %q to i6
+  %v = zext i6 %w to i8
+  ret i8 %v
+}
+
+define i8 @f2(<3 x i2>* %p) {
+  store <3 x i2> <i2 1, i2 2, i2 3>, <3 x i2>* %p
+  %p2 = bitcast <3 x i2>* %p to i8*
+  %v = load i8, i8* %p2
+  ret i8 %v
+}
+

--- a/tests/alive-tv/memory/vectors-small-bigendian.tgt.ll
+++ b/tests/alive-tv/memory/vectors-small-bigendian.tgt.ll
@@ -1,0 +1,14 @@
+target datalayout="E"
+target triple = "powerpc64-unknown-linux-gnu"
+
+define i8 @f(<3 x i2>* %p) {
+  %p2 = bitcast <3 x i2>* %p to i8*
+  store i8 27, i8* %p2
+  ret i8 27
+}
+
+define i8 @f2(<3 x i2>* %p) {
+  %p2 = bitcast <3 x i2>* %p to i8*
+  store i8 27, i8* %p2
+  ret i8 27
+}

--- a/tests/alive-tv/memory/vectors-small-fail.srctgt.ll
+++ b/tests/alive-tv/memory/vectors-small-fail.srctgt.ll
@@ -1,0 +1,13 @@
+target datalayout="e"
+
+define void @src(<3 x i2>* %p) {
+  store <3 x i2> <i2 1, i2 2, i2 3>, <3 x i2>* %p
+  ret void
+}
+
+define void @tgt(<3 x i2>* %p) {
+  store <3 x i2> <i2 1, i2 2, i2 2>, <3 x i2>* %p
+  ret void
+}
+
+; ERROR: Mismatch in memory

--- a/tests/alive-tv/memory/vectors-small.src.ll
+++ b/tests/alive-tv/memory/vectors-small.src.ll
@@ -1,0 +1,18 @@
+target datalayout="e"
+
+define i8 @f(<3 x i2>* %p) {
+  ; 00111001 = 57
+  store <3 x i2> <i2 1, i2 2, i2 3>, <3 x i2>* %p
+  %q = load <3 x i2>, <3 x i2>* %p
+  %w = bitcast <3 x i2> %q to i6
+  %v = zext i6 %w to i8
+  ret i8 %v
+}
+
+define i8 @f2(<3 x i2>* %p) {
+  store <3 x i2> <i2 1, i2 2, i2 3>, <3 x i2>* %p
+  %p2 = bitcast <3 x i2>* %p to i8*
+  %v = load i8, i8* %p2
+  ret i8 %v
+}
+

--- a/tests/alive-tv/memory/vectors-small.tgt.ll
+++ b/tests/alive-tv/memory/vectors-small.tgt.ll
@@ -1,0 +1,13 @@
+target datalayout="e"
+
+define i8 @f(<3 x i2>* %p) {
+  %p2 = bitcast <3 x i2>* %p to i8*
+  store i8 57, i8* %p2
+  ret i8 57
+}
+
+define i8 @f2(<3 x i2>* %p) {
+  %p2 = bitcast <3 x i2>* %p to i8*
+  store i8 57, i8* %p2
+  ret i8 57
+}


### PR DESCRIPTION
This resolves #277 by making int vectors be encoded as primitive values at valueToBytes / bytesToValue.
For structs (e.g. {i1, ..}), this doesn't work, because each element occupy its own byte.
Fixes one failure (Transforms/SROA/vector-promotion-different-size.ll).