### PR TITLE
Let AggregateType::extract return an empty statevalue if children[idx]'s bit == 0

### DIFF
--- a/ir/type.cpp
+++ b/ir/type.cpp
@@ -723,6 +723,9 @@ StateValue AggregateType::aggregateVals(const vector<StateValue> &vals) const {
 StateValue
 AggregateType::extract(const StateValue &val, unsigned index, bool fromInt)
     const {
+  if (children[index]->bits() == 0)
+    return { expr::mkUInt(0, 1), true };
+
   unsigned total_value = 0, total_np = 0;
   for (unsigned i = 0; i < index; ++i) {
     total_value += children[i]->bits();

--- a/tests/alive-tv/insertvalue-emptyelem.srctgt.ll
+++ b/tests/alive-tv/insertvalue-emptyelem.srctgt.ll
@@ -1,0 +1,9 @@
+define { {}, { float }, [0 x i8] } @src({ float } %unwrap1) {
+  %wrap2 = insertvalue { {}, { float }, [0 x i8] } undef, { float } %unwrap1, 1
+  ret { {}, { float }, [0 x i8] } %wrap2
+}
+
+define { {}, { float }, [0 x i8] } @tgt({ float } %unwrap1) {
+  %wrap2 = insertvalue { {}, { float }, [0 x i8] } undef, { float } %unwrap1, 1
+  ret { {}, { float }, [0 x i8] } %wrap2
+}


### PR DESCRIPTION
This resolves assertion failure from Transforms/SROA/basictest.ll