### PR TITLE
Support store ptr undef -> memset i8 undef (#345)

### DIFF
--- a/ir/memory.h
+++ b/ir/memory.h
@@ -59,7 +59,7 @@ public:
   smt::expr nonptrNonpoison() const;
   smt::expr nonptrValue() const;
   smt::expr isPoison(bool fullbit = true) const;
-  smt::expr isZero() const; // zero or null
+  bool isValid() const { return p.isValid(); }
 
   const smt::expr& operator()() const { return p; }
 

--- a/ir/memory.h
+++ b/ir/memory.h
@@ -79,7 +79,11 @@ public:
 class Pointer {
   const Memory &m;
 
-  // [bid, offset, attributes (1 bit for each)]
+  // Pointer's representation:
+  //   +----------------+-------------------+---------------------+
+  //   | bid            | offset            | attrs               |
+  //   | (bits_for_bid) | (bits_for_offset) | (bits_for_ptrattrs) |
+  //   +----------------+-------------------+---------------------+
   // The top bit of bid is 1 if the block is local, 0 otherwise.
   // A local memory block is a memory block that is
   // allocated by an instruction during the current function call. This does
@@ -181,7 +185,7 @@ public:
   const Memory& getMemory() const { return m; }
 
   static Pointer mkNullPointer(const Memory &m);
-  smt::expr isNull() const;
+  smt::expr isNull(bool check_offset = true) const;
   smt::expr isNonZero() const;
 
   friend std::ostream& operator<<(std::ostream &os, const Pointer &p);

--- a/tests/alive-tv/memory/memset-undefptr-fail.srctgt.ll
+++ b/tests/alive-tv/memory/memset-undefptr-fail.srctgt.ll
@@ -1,0 +1,17 @@
+; This test shows that our approximation does not support conversion from
+; memset(undef) to store undef, because memset undef is approximated to store
+; all identical undef bits.
+
+define void @src(i32** %ptr) {
+  %p = bitcast i32** %ptr to i8*
+  call void @llvm.memset.p0i8.i32(i8* %p, i8 undef, i32 8, i1 0)
+  ret void
+}
+
+define void @tgt(i32** %ptr) {
+  store i32* undef, i32** %ptr, align 1
+  ret void
+}
+
+; ERROR: Mismatch in memory
+declare void @llvm.memset.p0i8.i32(i8*, i8, i32, i1)

--- a/tests/alive-tv/memory/undefptr-memset.srctgt.ll
+++ b/tests/alive-tv/memory/undefptr-memset.srctgt.ll
@@ -1,0 +1,14 @@
+; TEST-ARGS: -smt-to=10000
+
+define void @src(i32** %ptr) {
+  store i32* undef, i32** %ptr
+  ret void
+}
+
+define void @tgt(i32** %ptr) {
+  %p = bitcast i32** %ptr to i8*
+  call void @llvm.memset.p0i8.i32(i8* %p, i8 undef, i32 8, i1 0)
+  ret void
+}
+
+declare void @llvm.memset.p0i8.i32(i8*, i8, i32, i1)

--- a/tests/alive-tv/refinement/zero-null.src.ll
+++ b/tests/alive-tv/refinement/zero-null.src.ll
@@ -1,8 +1,3 @@
-define void @f(i64* %p) {
-  store i64 0, i64* %p
-  ret void
-}
-
 define void @f2(i64* %p) {
   %p2 = bitcast i64* %p to i8**
   store i8* null, i8** %p2, align 4

--- a/tests/alive-tv/refinement/zero-null.tgt.ll
+++ b/tests/alive-tv/refinement/zero-null.tgt.ll
@@ -1,9 +1,3 @@
-define void @f(i64* %p) {
-  %p2 = bitcast i64* %p to i8**
-  store i8* null, i8** %p2, align 4
-  ret void
-}
-
 define void @f2(i64* %p) {
   store i64 0, i64* %p
   ret void


### PR DESCRIPTION
This resolves issue #345.

Transformations of interest:
```
  //   store ty* null  <-> memset i8 0
  //   store ty* undef  -> memset i8 undef
```

Only extracting the last bits_byte bits from pointer offset & comparing it seemed enough.
Running unit tests..