### PR TITLE
AggregateType maintains padding elements, and *_overflow should consider this too

### DIFF
--- a/ir/instr.cpp
+++ b/ir/instr.cpp
@@ -540,7 +540,7 @@ StateValue BinOp::toSMT(State &s) const {
                                     bi->non_poison));
       }
     }
-    return ty->aggregateVals(vals);
+    return ty->aggregateVals(vals, true);
   }
 
   if (vertical_zip) {
@@ -548,7 +548,7 @@ StateValue BinOp::toSMT(State &s) const {
     auto [v1, v2] = zip_op(a.value, a.non_poison, b.value, b.non_poison);
     vals.emplace_back(move(v1));
     vals.emplace_back(move(v2));
-    return getType().getAsAggregateType()->aggregateVals(vals);
+    return getType().getAsAggregateType()->aggregateVals(vals, true);
   }
   return scalar_op(a.value, a.non_poison, b.value, b.non_poison);
 }
@@ -567,8 +567,8 @@ expr BinOp::getTypeConstraints(const Function &f) const {
                   lhs->getType() == rhs->getType();
 
     if (auto ty = getType().getAsStructType()) {
-      instrconstr &= ty->numElements() == 2 &&
-                     ty->getChild(0) == lhs->getType() &&
+      // Note that ty->numElements() may not be 2 due to paddings
+      instrconstr &= ty->getChild(0) == lhs->getType() &&
                      ty->getChild(1).enforceIntOrVectorType(1) &&
                      ty->getChild(1).enforceVectorTypeEquiv(lhs->getType());
     }

--- a/ir/instr.cpp
+++ b/ir/instr.cpp
@@ -567,8 +567,9 @@ expr BinOp::getTypeConstraints(const Function &f) const {
                   lhs->getType() == rhs->getType();
 
     if (auto ty = getType().getAsStructType()) {
-      // Note that ty->numElements() may not be 2 due to paddings
-      instrconstr &= ty->getChild(0) == lhs->getType() &&
+      auto cnt = ty->numElements();
+      instrconstr &= cnt - expr::mkInt(ty->numPaddingsConst(), cnt) == 2 &&
+                     ty->getChild(0) == lhs->getType() &&
                      ty->getChild(1).enforceIntOrVectorType(1) &&
                      ty->getChild(1).enforceVectorTypeEquiv(lhs->getType());
     }

--- a/ir/instr.cpp
+++ b/ir/instr.cpp
@@ -567,8 +567,7 @@ expr BinOp::getTypeConstraints(const Function &f) const {
                   lhs->getType() == rhs->getType();
 
     if (auto ty = getType().getAsStructType()) {
-      auto cnt = ty->numElements();
-      instrconstr &= cnt - expr::mkInt(ty->numPaddingsConst(), cnt) == 2 &&
+      instrconstr &= ty->numElementsExcludingPadding() == 2 &&
                      ty->getChild(0) == lhs->getType() &&
                      ty->getChild(1).enforceIntOrVectorType(1) &&
                      ty->getChild(1).enforceVectorTypeEquiv(lhs->getType());

--- a/ir/type.cpp
+++ b/ir/type.cpp
@@ -727,7 +727,7 @@ StateValue AggregateType::aggregateVals(const vector<StateValue> &vals,
 
     StateValue vv;
     if (needsPadding && isPadding(idx))
-      vv = children[idx]->getDummyValue(true);
+      vv = children[idx]->getDummyValue(false);
     else
       vv = vals[val_idx++];
     vv = children[idx]->toBV(move(vv));

--- a/ir/type.cpp
+++ b/ir/type.cpp
@@ -730,7 +730,7 @@ StateValue AggregateType::aggregateVals(const vector<StateValue> &vals,
       vv = children[idx]->getDummyValue(true);
     else
       vv = vals[val_idx++];
-    vv = children[idx]->toBV(vv);
+    vv = children[idx]->toBV(move(vv));
     v = first ? move(vv) : v.concat(vv);
     first = false;
   }

--- a/ir/type.cpp
+++ b/ir/type.cpp
@@ -708,6 +708,11 @@ unsigned AggregateType::numPaddingsConst() const {
   return count;
 }
 
+expr AggregateType::numElementsExcludingPadding() const {
+  auto elems = numElements();
+  return numElements() - expr::mkInt(numPaddingsConst(), elems);
+}
+
 StateValue AggregateType::aggregateVals(const vector<StateValue> &vals,
                                         bool needsPadding) const {
   assert(vals.size() + (needsPadding ? numPaddingsConst() : 0) == elements);

--- a/ir/type.h
+++ b/ir/type.h
@@ -265,8 +265,10 @@ protected:
 public:
   smt::expr numElements() const;
   unsigned numElementsConst() const { return elements; }
+  unsigned numPaddingsConst() const;
 
-  StateValue aggregateVals(const std::vector<StateValue> &vals) const;
+  StateValue aggregateVals(const std::vector<StateValue> &vals,
+                           bool needsPadding = false) const;
   IR::StateValue extract(const IR::StateValue &val, unsigned index,
                          bool fromInt = false) const;
   Type& getChild(unsigned index) const { return *children[index]; }

--- a/ir/type.h
+++ b/ir/type.h
@@ -264,6 +264,7 @@ protected:
 
 public:
   smt::expr numElements() const;
+  smt::expr numElementsExcludingPadding() const;
   unsigned numElementsConst() const { return elements; }
   unsigned numPaddingsConst() const;
 

--- a/tests/alive-tv/memory/umul_overflow-fail.srctgt.ll
+++ b/tests/alive-tv/memory/umul_overflow-fail.srctgt.ll
@@ -1,4 +1,4 @@
-; TEST-ARGS: -disable-undef-input
+; TEST-ARGS: -disable-undef-input -smt-to=5000
 define void @src(i32 %a, i32 %b, {i32, i1}* %p) {
   %mul = call { i32, i1 } @llvm.umul.with.overflow.i32(i32 %a, i32 %b)
   store {i32, i1} %mul, {i32, i1}* %p

--- a/tests/alive-tv/memory/umul_overflow-fail.srctgt.ll
+++ b/tests/alive-tv/memory/umul_overflow-fail.srctgt.ll
@@ -1,0 +1,16 @@
+; TEST-ARGS: -disable-undef-input
+define void @src(i32 %a, i32 %b, {i32, i1}* %p) {
+  %mul = call { i32, i1 } @llvm.umul.with.overflow.i32(i32 %a, i32 %b)
+  store {i32, i1} %mul, {i32, i1}* %p
+  ret void
+}
+
+define void @tgt(i32 %a, i32 %b, {i32, i1}* %p) {
+  %mul = call { i32, i1 } @llvm.smul.with.overflow.i32(i32 %a, i32 %b)
+  store {i32, i1} %mul, {i32, i1}* %p
+  ret void
+}
+
+; ERROR: Mismatch in memory
+declare { i32, i1 } @llvm.umul.with.overflow.i32(i32, i32) nounwind readnone speculatable willreturn
+declare { i32, i1 } @llvm.smul.with.overflow.i32(i32, i32) nounwind readnone speculatable willreturn

--- a/tests/alive-tv/memory/umul_overflow.srctgt.ll
+++ b/tests/alive-tv/memory/umul_overflow.srctgt.ll
@@ -1,0 +1,14 @@
+; TEST-ARGS: -disable-undef-input
+define void @src(i32 %a, i32 %b, {i32, i1}* %p) {
+  %mul = call { i32, i1 } @llvm.umul.with.overflow.i32(i32 %a, i32 %b)
+  store {i32, i1} %mul, {i32, i1}* %p
+  ret void
+}
+
+define void @tgt(i32 %a, i32 %b, {i32, i1}* %p) {
+  %mul = call { i32, i1 } @llvm.umul.with.overflow.i32(i32 %a, i32 %b)
+  store {i32, i1} %mul, {i32, i1}* %p
+  ret void
+}
+
+declare { i32, i1 } @llvm.umul.with.overflow.i32(i32, i32) nounwind readnone speculatable willreturn

--- a/tests/alive-tv/sadd_overflow.srctgt.ll
+++ b/tests/alive-tv/sadd_overflow.srctgt.ll
@@ -1,0 +1,17 @@
+declare { i32, i1 } @llvm.sadd.with.overflow.i32(i32, i32) nounwind readnone
+
+define { i32, i1 } @src(i8 %a, i8 %b) {
+  %aa = sext i8 %a to i32
+  %bb = sext i8 %b to i32
+  %x = call { i32, i1 } @llvm.sadd.with.overflow.i32(i32 %aa, i32 %bb)
+  ret { i32, i1 } %x
+}
+
+
+define { i32, i1 } @tgt(i8 %a, i8 %b) {
+  %aa = sext i8 %a to i32
+  %bb = sext i8 %b to i32
+  %x = add nsw i32 %aa, %bb
+  %tmp = insertvalue {i32, i1} {i32 undef, i1 false}, i32 %x, 0
+  ret {i32, i1} %tmp
+}

--- a/tests/alive-tv/sadd_overflow_vec.srctgt.ll
+++ b/tests/alive-tv/sadd_overflow_vec.srctgt.ll
@@ -1,0 +1,11 @@
+define <2 x i1> @src() {
+	%t = call { <2 x i32>, <2 x i1> } @llvm.sadd.with.overflow.v2i32(<2 x i32> <i32 2147483647, i32 2147483647>, <2 x i32> <i32 1, i32 1>)
+	%v = extractvalue { <2 x i32>, <2 x i1> } %t, 1
+	ret <2 x i1> %v
+}
+
+define <2 x i1> @tgt() {
+	ret <2 x i1> <i1 1, i1 1>
+}
+
+declare { <2 x i32>, <2 x i1> } @llvm.sadd.with.overflow.v2i32(<2 x i32>, <2 x i32>)

--- a/tests/alive-tv/umul_overflow.srctgt.ll
+++ b/tests/alive-tv/umul_overflow.srctgt.ll
@@ -1,0 +1,11 @@
+define void @src(i32 %a, i32 %b) {
+  %mul = call { i32, i1 } @llvm.umul.with.overflow.i32(i32 %a, i32 %b)
+  ret void
+}
+
+define void @tgt(i32 %a, i32 %b) {
+  %mul = call { i32, i1 } @llvm.umul.with.overflow.i32(i32 %a, i32 %b)
+  ret void
+}
+
+declare { i32, i1 } @llvm.umul.with.overflow.i32(i32, i32) nounwind readnone speculatable willreturn


### PR DESCRIPTION
`tests/alive-tv/umul_overflow.srctgt.ll` raises type checking failure, and the reason is that in Alive2 umul_overflow's return type is not {i32, i1}, but {i32, i1, i24} because llvm2alive automatically inserts paddings.
This resolves this issue by inserting dummy values at such padding when encoding the result of umul_overflow.

This resolves type checking failures at LLVM unit tests & gzip single file benchmarks.
Exact numbers for LLVM unit tests - I'm running the tests