### PR TITLE
Increase timeout of pr43948.srctgt.ll

### DIFF
--- a/tests/alive-tv/bugs/pr43948.srctgt.ll
+++ b/tests/alive-tv/bugs/pr43948.srctgt.ll
@@ -1,3 +1,4 @@
+; TEST-ARGS: -smt-to=8000
 ; https://bugs.llvm.org/show_bug.cgi?id=43948
 @arr = local_unnamed_addr global [32 x i32] zeroinitializer, align 16
 @var = global i32 zeroinitializer, align 8


### PR DESCRIPTION
.. because it raises timeout on my machine. :/
I have a feeling that Z3 in Mac is slower than in Linux machines.