### PR TITLE
Fix build with llvm trunk - llvm::Type::VectorTyID is now FixedVectorTyID

### DIFF
--- a/llvm_util/utils.cpp
+++ b/llvm_util/utils.cpp
@@ -152,14 +152,11 @@ Type* llvm_type2alive(const llvm::Type *ty) {
     }
     return cache.get();
   }
-  case llvm::Type::VectorTyID: {
+  // TODO: non-fixed sized vectors
+  case llvm::Type::FixedVectorTyID: {
     auto &cache = type_cache[ty];
     if (!cache) {
       auto vty = cast<llvm::VectorType>(ty);
-      // TODO: non-fixed sized vectors
-      if (vty->isScalable())
-        goto err;
-
       auto elems = vty->getElementCount().Min;
       auto ety = llvm_type2alive(vty->getElementType());
       if (!ety || elems > 128)
@@ -192,7 +189,6 @@ Type* llvm_type2alive(const llvm::Type *ty) {
     return cache.get();
   }
   default:
-err:
     *out << "ERROR: Unsupported type: " << *ty << '\n';
     return nullptr;
   }

--- a/tools/alive-tv.cpp
+++ b/tools/alive-tv.cpp
@@ -213,7 +213,7 @@ static int cmpTypes(llvm::Type *TyL, llvm::Type *TyR,
       return cmpNumbers(STyL->getNumElements(), STyR->getNumElements());
     return cmpTypes(STyL->getElementType(), STyR->getElementType(), FnL, FnR);
   }
-  case llvm::Type::VectorTyID: {
+  case llvm::Type::FixedVectorTyID: {
     auto *STyL = llvm::cast<llvm::VectorType>(TyL);
     auto *STyR = llvm::cast<llvm::VectorType>(TyR);
     if (STyL->getElementCount().Scalable != STyR->getElementCount().Scalable)


### PR DESCRIPTION
Since https://reviews.llvm.org/D77587 / https://github.com/llvm/llvm-project/commit/2dea3f129878e929e5d1f00b91a622eb1ec8be4e
Do we need to somehow uglify this to make building with older LLVM still possible?