### PR TITLE
Fix a build error by using isa<llvm::ScalableVectorType> instead of isScalable()

### DIFF
--- a/llvm_util/llvm2alive.cpp
+++ b/llvm_util/llvm2alive.cpp
@@ -489,7 +489,7 @@ public:
         auto ofs_ty = llvm::IntegerType::get(i.getContext(), 64);
 
         if (auto opvty = dyn_cast<llvm::VectorType>(opty)) {
-          assert(!opvty->isScalable());
+          assert(!isa<llvm::ScalableVectorType>(opvty));
           vector<llvm::Constant *> offsets;
 
           for (unsigned i = 0; i < opvty->getElementCount().Min; ++i) {


### PR DESCRIPTION
Vector related API is rapidly changing.. :/
Fixes a build error that was introduced after https://reviews.llvm.org/D77690 landed