### PR TITLE
Let fcmp correctly print its operand type

### DIFF
--- a/ir/instr.cpp
+++ b/ir/instr.cpp
@@ -1527,8 +1527,8 @@ void FCmp::print(ostream &os) const {
   case UNE:   condtxt = "une "; break;
   case UNO:   condtxt = "uno "; break;
   }
-  os << getName() << " = fcmp " << fmath << condtxt << print_type(getType())
-     << a->getName() << ", " << b->getName();
+  os << getName() << " = fcmp " << fmath << condtxt << *a << ", "
+     << b->getName();
 }
 
 StateValue FCmp::toSMT(State &s) const {


### PR DESCRIPTION
Alive2 is printing the return type of fcmp at the place where operand type should be printed:
```
%c = fcmp oeq i1 %x, %x
```
This patch fixes it.