### PR TITLE
ptr_deref_within does not need nondeterministic comparison

### DIFF
--- a/ir/memory.cpp
+++ b/ir/memory.cpp
@@ -1552,10 +1552,10 @@ Byte Memory::load(const Pointer &p) const {
 static expr ptr_deref_within(const Pointer &idx, const Pointer &ptr,
                              const expr &size) {
   expr ret = idx.getShortBid() == ptr.getShortBid();
-  ret &= idx.uge(ptr).value;
+  ret &= idx.getOffset().uge(ptr.getOffset());
 
   if (!size.zextOrTrunc(bits_size_t).uge(ptr.blockSize()).isTrue())
-    ret &= idx.ult(ptr + size).value;
+    ret &= idx.getOffset().ult((ptr + size).getOffset());
 
   return ret;
 }


### PR DESCRIPTION
https://github.com/AliveToolkit/alive2/pull/313 changed Pointer::slt/sle/.. to return nondeterministic result when pointers to different blocks are given.

This affected how ptr_deref_within works, which only needs the comparison between offsets because equality of block ids are compared separately.

This patch brings performance improvement by not using the Pointer::slt/slt/.., hence not introducing a quantified variable.

LLVM unit tests timeout: 1083 -> 1073