### PR TITLE
Let pointer comparison compare absolute addresses

### DIFF
--- a/ir/globals.cpp
+++ b/ir/globals.cpp
@@ -25,6 +25,7 @@ unsigned memcmp_unroll_cnt;
 bool little_endian;
 bool has_int2ptr;
 bool has_ptr2int;
+bool has_ptrcmp;
 bool has_malloc;
 bool has_free;
 bool has_fncall;

--- a/ir/globals.h
+++ b/ir/globals.h
@@ -46,6 +46,9 @@ extern bool little_endian;
 extern bool has_int2ptr;
 extern bool has_ptr2int;
 
+/// Whether an icmp with pointers is used in either function
+extern bool has_ptrcmp;
+
 /// Whether malloc or free/delete is used in either function
 extern bool has_malloc;
 extern bool has_free;

--- a/ir/instr.cpp
+++ b/ir/instr.cpp
@@ -1482,8 +1482,8 @@ StateValue ICmp::toSMT(State &s) const {
       Pointer lhs(s.getMemory(), av);
       Pointer rhs(s.getMemory(), bv);
       switch (cond) {
-      case EQ:  return StateValue(lhs == rhs, true);
-      case NE:  return StateValue(lhs != rhs, true);
+      case EQ:  return lhs.eq(rhs);
+      case NE:  return lhs.ne(rhs);
       case SLE: return lhs.sle(rhs);
       case SLT: return lhs.slt(rhs);
       case SGE: return lhs.sge(rhs);

--- a/ir/instr.h
+++ b/ir/instr.h
@@ -227,6 +227,7 @@ private:
 public:
   ICmp(Type &type, std::string &&name, Cond cond, Value &a, Value &b);
 
+  Type &getOperandType() const { return a->getType(); }
   std::vector<Value*> operands() const override;
   void rauw(const Value &what, Value &with) override;
   void print(std::ostream &os) const override;

--- a/ir/memory.cpp
+++ b/ir/memory.cpp
@@ -763,7 +763,11 @@ expr Pointer::refined(const Pointer &other) const {
   // TODO: this induces an infinite loop
   //local &= block_refined(other);
 
-  return isBlockAlive().implies(
+  // In twin memory model, null refines any other pointer with address 0.
+  expr null_refines(false);
+  if (observes_addresses())
+    null_refines = other.isNull() && getAddress() == 0;
+  return null_refines || isBlockAlive().implies(
            other.isBlockAlive() &&
              expr::mkIf(isLocal(), isHeapAllocated().implies(local),
                         *this == other));
@@ -792,8 +796,11 @@ expr Pointer::fninputRefined(const Pointer &other, bool is_byval_arg) const {
 
   // TODO: this induces an infinite loop
   // block_refined(other);
-
-  return isBlockAlive().implies(
+  // In twin memory model, null refines any other pointer with address 0.
+  expr null_refines(false);
+  if (observes_addresses())
+    null_refines = other.isNull() && getAddress() == 0;
+  return null_refines || isBlockAlive().implies(
            other.isBlockAlive() &&
              expr::mkIf(isLocal(), local, *this == other));
 }

--- a/ir/memory.cpp
+++ b/ir/memory.cpp
@@ -927,12 +927,6 @@ expr Pointer::isNull() const {
   return *this == mkNullPointer(m);
 }
 
-expr Pointer::isNullBlock() const {
-  if (!has_null_block)
-    return false;
-  return getBid() == mkNullPointer(m).getBid();
-}
-
 expr Pointer::isNonZero() const {
   if (observes_addresses())
     return getAddress() != 0;

--- a/ir/memory.h
+++ b/ir/memory.h
@@ -137,6 +137,8 @@ public:
   smt::expr operator==(const Pointer &rhs) const;
   smt::expr operator!=(const Pointer &rhs) const;
 
+  StateValue eq(const Pointer &rhs) const;
+  StateValue ne(const Pointer &rhs) const;
   StateValue sle(const Pointer &rhs) const;
   StateValue slt(const Pointer &rhs) const;
   StateValue sge(const Pointer &rhs) const;
@@ -182,6 +184,7 @@ public:
 
   static Pointer mkNullPointer(const Memory &m);
   smt::expr isNull() const;
+  smt::expr isNullBlock() const;
   smt::expr isNonZero() const;
 
   friend std::ostream& operator<<(std::ostream &os, const Pointer &p);

--- a/ir/memory.h
+++ b/ir/memory.h
@@ -184,7 +184,6 @@ public:
 
   static Pointer mkNullPointer(const Memory &m);
   smt::expr isNull() const;
-  smt::expr isNullBlock() const;
   smt::expr isNonZero() const;
 
   friend std::ostream& operator<<(std::ostream &os, const Pointer &p);

--- a/tests/alive-tv/attrs/nocapture-noundef.srctgt.ll
+++ b/tests/alive-tv/attrs/nocapture-noundef.srctgt.ll
@@ -1,4 +1,4 @@
-; this is needed for correctness, since the cmn+branch needs to be strong
+; This test should fail because % and %b may point to different blocks
 ; TEST-ARGS: -disable-undef-input
 
 define i8* @src(i8* %a, i8* nocapture %b) {
@@ -25,5 +25,6 @@ f:
   ret i8* null
 }
 
+; ERROR: Source is more defined than target
 
 declare i8* @g(i8*)

--- a/tests/alive-tv/attrs/readnone-fail.srctgt.ll
+++ b/tests/alive-tv/attrs/readnone-fail.srctgt.ll
@@ -1,3 +1,4 @@
+; TEST-ARGS: -disable-undef-input
 ; This test checks LangRef's following statement:
 ; """
 ; this attribute indicates that the function does not dereference that pointer

--- a/tests/alive-tv/memory/free-null2.srctgt.ll
+++ b/tests/alive-tv/memory/free-null2.srctgt.ll
@@ -1,0 +1,16 @@
+define void @src(i8* %p) {
+  %c = icmp ne i8* %p, null
+  br i1 %c, label %A, label %B
+A:
+  call void @free(i8* %p)
+  br label %B
+B:
+  ret void
+}
+
+define void @tgt(i8* %p) {
+  call void @free(i8* %p)
+  ret void
+}
+
+declare void @free(i8*)

--- a/tests/alive-tv/memory/ptr-cmp.src.ll
+++ b/tests/alive-tv/memory/ptr-cmp.src.ll
@@ -1,8 +1,0 @@
-; ERROR: Value mismatch
-
-define i1 @f(i32** %a) {
-  %load = load i32*, i32** %a
-  %integral = ptrtoint i32* %load to i64
-  %cmp = icmp slt i64 %integral, 0
-  ret i1 %cmp
-}

--- a/tests/alive-tv/memory/ptr-cmp.tgt.ll
+++ b/tests/alive-tv/memory/ptr-cmp.tgt.ll
@@ -1,6 +1,0 @@
-define i1 @f(i32** %a) {
-  %load = load i32*, i32** %a, align 8
-  %cmp = icmp slt i32* %load, null
-  ret i1 %cmp
-}
-

--- a/tests/alive-tv/ptrcmp/alloca-cmp.srctgt.ll
+++ b/tests/alive-tv/ptrcmp/alloca-cmp.srctgt.ll
@@ -1,0 +1,10 @@
+define i1 @src() {
+  %a = alloca i64
+  %b = alloca i64
+  %cmp = icmp eq i64* %a, %b
+  ret i1 %cmp
+}
+define i1 @tgt() {
+  ret i1 0
+}
+

--- a/tests/alive-tv/ptrcmp/and-or-null.srctgt.ll
+++ b/tests/alive-tv/ptrcmp/and-or-null.srctgt.ll
@@ -1,0 +1,11 @@
+define i1 @src(i8* %a, i8* %b) {
+  %c1 = icmp ule i8* %a, %b
+  %c2 = icmp eq i8* %a, null
+  %c = or i1 %c1, %c2
+  ret i1 %c
+}
+
+define i1 @tgt(i8* %a, i8* %b) {
+  %c1 = icmp ule i8* %a, %b
+  ret i1 %c1
+}

--- a/tests/alive-tv/ptrcmp/gep.srctgt.ll
+++ b/tests/alive-tv/ptrcmp/gep.srctgt.ll
@@ -1,0 +1,13 @@
+; TEST-ARGS: -disable-undef-input
+
+define i1 @src(i8* %a, i8* %b, i64 %ofs) {
+  %a2 = getelementptr i8, i8* %a, i64 %ofs
+  %b2 = getelementptr i8, i8* %b, i64 %ofs
+  %c = icmp eq i8* %a2, %b2
+  ret i1 %c
+}
+
+define i1 @tgt(i8* %a, i8* %b, i64 %ofs) {
+  %c = icmp eq i8* %a, %b
+  ret i1 %c
+}

--- a/tests/alive-tv/ptrcmp/icmp-pcmp.srctgt.ll
+++ b/tests/alive-tv/ptrcmp/icmp-pcmp.srctgt.ll
@@ -1,0 +1,11 @@
+define i1 @src(i8* %a, i8* %b) {
+  %ia = ptrtoint i8* %a to i64
+  %ib = ptrtoint i8* %b to i64
+  %c = icmp eq i64 %ia, %ib
+  ret i1 %c
+}
+
+define i1 @tgt(i8* %a, i8* %b) {
+  %c = icmp eq i8* %a, %b
+  ret i1 %c
+}

--- a/tests/alive-tv/ptrcmp/icmp-to-ptrcmp-slt.srctgt.ll
+++ b/tests/alive-tv/ptrcmp/icmp-to-ptrcmp-slt.srctgt.ll
@@ -1,0 +1,13 @@
+define i1 @src(i32** %a) {
+  %load = load i32*, i32** %a
+  %integral = ptrtoint i32* %load to i64
+  %cmp = icmp slt i64 %integral, 0
+  ret i1 %cmp
+}
+
+define i1 @tgt(i32** %a) {
+  %load = load i32*, i32** %a, align 8
+  %cmp = icmp slt i32* %load, null
+  ret i1 %cmp
+}
+

--- a/tests/alive-tv/ptrcmp/lifetime-cmp.srctgt.ll
+++ b/tests/alive-tv/ptrcmp/lifetime-cmp.srctgt.ll
@@ -1,0 +1,58 @@
+define void @src() {
+	%p = alloca i32
+	%p8 = bitcast i32* %p to i8*
+	%q = alloca i32
+	%q8 = bitcast i32* %q to i8*
+	call void @llvm.lifetime.start.p0i8(i64 4, i8* %p8)
+	call void @llvm.lifetime.end.p0i8(i64 4, i8* %p8)
+
+	call void @llvm.lifetime.start.p0i8(i64 4, i8* %q8)
+
+	%ip = ptrtoint i32* %p to i64
+	%iq = ptrtoint i32* %q to i64
+	%guard = icmp eq i64 %ip, %iq
+	br i1 %guard, label %COMPARE, label %EXIT
+
+COMPARE:
+	%c0 = icmp eq i8* %p8, %q8
+	%qgep1 = getelementptr inbounds i8, i8* %q8, i64 1
+	%c1 = icmp eq i8* %p8, %qgep1
+	call void @g(i1 %c0) ; false
+	call void @g(i1 %c1) ; false
+	br label %EXIT
+
+EXIT:
+	call void @llvm.lifetime.end.p0i8(i64 4, i8* %q8)
+	ret void
+}
+
+define void @tgt() {
+	%p = alloca i32
+	%p8 = bitcast i32* %p to i8*
+	%q = alloca i32
+	%q8 = bitcast i32* %q to i8*
+	call void @llvm.lifetime.start.p0i8(i64 4, i8* %p8)
+	call void @llvm.lifetime.end.p0i8(i64 4, i8* %p8)
+
+	call void @llvm.lifetime.start.p0i8(i64 4, i8* %q8)
+
+	%ip = ptrtoint i32* %p to i64
+	%iq = ptrtoint i32* %q to i64
+	%guard = icmp eq i64 %ip, %iq
+	br i1 %guard, label %COMPARE, label %EXIT
+
+COMPARE:
+	call void @g(i1 false)
+	call void @g(i1 false)
+	br label %EXIT
+
+EXIT:
+	call void @llvm.lifetime.end.p0i8(i64 4, i8* %q8)
+	ret void
+}
+
+declare i1 @check(i32*, i32*)
+declare void @g(i1)
+
+declare void @llvm.lifetime.start.p0i8(i64, i8*)
+declare void @llvm.lifetime.end.p0i8(i64, i8*)

--- a/tests/alive-tv/ptrcmp/null-fninput.srctgt.ll
+++ b/tests/alive-tv/ptrcmp/null-fninput.srctgt.ll
@@ -1,0 +1,21 @@
+declare void @f(i8*)
+
+define void @src(i8* %p) {
+  %c = icmp eq i8* %p, null
+  br i1 %c, label %A, label %B
+A:
+  call void @f(i8* %p)
+  ret void
+B:
+  ret void
+}
+
+define void @tgt(i8* %p) {
+  %c = icmp eq i8* %p, null
+  br i1 %c, label %A, label %B
+A:
+  call void @f(i8* null)
+  ret void
+B:
+  ret void
+}

--- a/tests/alive-tv/ptrcmp/null-return.srctgt.ll
+++ b/tests/alive-tv/ptrcmp/null-return.srctgt.ll
@@ -1,0 +1,12 @@
+define i8* @src(i8* %p) {
+  %c = icmp eq i8* %p, null
+  br i1 %c, label %A, label %B
+A:
+  ret i8* %p
+B:
+  ret i8* null
+}
+
+define i8* @tgt(i8* %p) {
+  ret i8* null
+}

--- a/tests/alive-tv/refinement/null-fninput.srctgt.ll
+++ b/tests/alive-tv/refinement/null-fninput.srctgt.ll
@@ -1,0 +1,21 @@
+declare void @f(i8*)
+
+define void @src(i8* %p) {
+  %c = icmp eq i8* %p, null
+  br i1 %c, label %A, label %B
+A:
+  call void @f(i8* %p)
+  ret void
+B:
+  ret void
+}
+
+define void @tgt(i8* %p) {
+  %c = icmp eq i8* %p, null
+  br i1 %c, label %A, label %B
+A:
+  call void @f(i8* null)
+  ret void
+B:
+  ret void
+}

--- a/tests/alive-tv/refinement/null-return.srctgt.ll
+++ b/tests/alive-tv/refinement/null-return.srctgt.ll
@@ -1,0 +1,12 @@
+define i8* @src(i8* %p) {
+  %c = icmp eq i8* %p, null
+  br i1 %c, label %A, label %B
+A:
+  ret i8* %p
+B:
+  ret i8* null
+}
+
+define i8* @tgt(i8* %p) {
+  ret i8* null
+}

--- a/tools/transform.cpp
+++ b/tools/transform.cpp
@@ -573,6 +573,12 @@ static void calculateAndInitConstants(Transform &t) {
           auto &t = bc->getType();
           does_sub_byte_access |= hasSubByte(t);
           min_access_size = gcd(min_access_size, getCommonAccessSize(t));
+
+        } else if (auto *ic = dynamic_cast<const ICmp *>(&i)) {
+          if (hasPtr(ic->getOperandType())) {
+            has_ptrcmp = true;
+            cur_max_gep = UINT64_MAX;
+          }
         }
       }
     }


### PR DESCRIPTION
*NOTE: This description is out-of-date; see the comments below

---

This has two changes:

- Let icmp ptr1, ptr2 compare their absolute addresses if either points to the null block.

- Add refinement between ptr and null if ptr.getAddress() == 0. This allows
```
if (ptr == null) use(ptr);
=>
if (ptr == null) use(null);
```

Both are based on the twin memory semantics.

Unfortunately, this patch isn't sufficient to support Transforms/InstSimplify/and-or-icmp-nullptr.ll that was reported by @LebedevRI ... :( Currently icmp ult/ugt... does not consider block sizes, so it still says it's wrong.

BTW, It is amazing that precisely defining pointer comparison is a pretty hard job.

---