### PR TITLE
Implement memcmp/bcmp

### DIFF
--- a/ir/globals.cpp
+++ b/ir/globals.cpp
@@ -21,6 +21,7 @@ unsigned bits_program_pointer;
 unsigned bits_size_t;
 unsigned bits_byte;
 unsigned strlen_unroll_cnt;
+unsigned memcmp_unroll_cnt;
 bool little_endian;
 bool has_int2ptr;
 bool has_ptr2int;

--- a/ir/globals.h
+++ b/ir/globals.h
@@ -38,6 +38,7 @@ extern unsigned bits_size_t;
 extern unsigned bits_byte;
 
 extern unsigned strlen_unroll_cnt;
+extern unsigned memcmp_unroll_cnt;
 
 extern bool little_endian;
 

--- a/ir/instr.cpp
+++ b/ir/instr.cpp
@@ -50,7 +50,8 @@ struct LoopLikeFunctionApproximator {
     auto [res_i, ub_i, continue_i] = ith_exec(i, is_last);
 
     if (is_last) {
-      s.addPre(prefix().implies(!continue_i));
+      prefix.add(ub_i);
+      s.addPre(prefix().implies(!continue_i), true);
       return { move(res_i), ub_i() };
     }
 

--- a/ir/instr.cpp
+++ b/ir/instr.cpp
@@ -33,6 +33,37 @@ struct print_type {
     return str.empty() ? os : (os << s.pre << str << s.post);
   }
 };
+
+struct LoopLikeFunctionApproximator {
+  // input: (i, is the last iter?)
+  // output: (value, UB, continue?)
+  function<tuple<expr, AndExpr, expr>(unsigned, bool)> ith_exec;
+
+  pair<expr, expr> encode(IR::State &s, unsigned unroll_cnt) {
+    AndExpr prefix;
+    return _loop(s, prefix, 0, unroll_cnt);
+  }
+
+  pair<expr, expr> _loop(IR::State &s, AndExpr &prefix, unsigned i,
+                        unsigned unroll_cnt) {
+    bool is_last = i == unroll_cnt - 1;
+    auto [res_i, ub_i, continue_i] = ith_exec(i, is_last);
+
+    if (is_last) {
+      s.addPre(prefix().implies(!continue_i));
+      return { move(res_i), ub_i() };
+    }
+
+    if (continue_i.isFalse() || ub_i().isFalse())
+      return { move(res_i), ub_i() };
+
+    prefix.add(ub_i);
+    prefix.add(continue_i);
+    auto [val_next, ub_next] = _loop(s, prefix, i + 1, unroll_cnt);
+    return { expr::mkIf(continue_i, move(val_next), move(res_i)),
+              ub_i() && continue_i.implies(ub_next) };
+  }
+};
 }
 
 
@@ -2403,65 +2434,6 @@ unique_ptr<Instr> Memcpy::dup(const string &suffix) const {
 }
 
 
-
-static pair<expr,expr>
-encode_memcmp(State &s, const Pointer &p1, const Pointer &p2, AndExpr &prefix,
-              const expr &max_num, bool is_bcmp, unsigned i) {
-  expr ei = expr::mkUInt(i, max_num.bits());
-  expr zero = expr::mkUInt(0, 32);
-  if (ei.uge(max_num).isTrue())
-    return { move(zero), true };
-
-  // TODO: Pointers?
-  auto [val1, ub1] = s.getMemory().load((p1 + i)(), IntType("i8", 8), 1);
-  auto [val2, ub2] = s.getMemory().load((p2 + i)(), IntType("i8", 8), 1);
-  AndExpr ub_and;
-  ub_and.add(val1.non_poison);
-  ub_and.add(val2.non_poison);
-  ub_and.add(move(ub1));
-  ub_and.add(move(ub2));
-
-  expr val_eq = val1.value == val2.value;
-
-  expr result_neq;
-  if (is_bcmp) {
-    result_neq = expr::mkFreshVar("bcmp_nonzero", zero);
-    s.addQuantVar(result_neq);
-    s.addPre(result_neq != zero);
-  } else {
-    expr pos = expr::mkFreshVar("memcmp_pos", expr::mkUInt(0, 31));
-    expr neg = expr::mkFreshVar("memcmp_neg", expr::mkUInt(0, 31));
-    s.addQuantVar(pos);
-    s.addQuantVar(neg);
-    s.addPre(pos != expr::mkUInt(0u, 31));
-    pos = expr::mkUInt(0, 1).concat(pos);
-    neg = expr::mkUInt(1, 1).concat(neg);
-    result_neq = expr::mkIf(val1.value.ugt(val2.value), move(pos), move(neg));
-  }
-
-  expr ub = ub_and();
-  if (val_eq.isFalse())
-    return { move(result_neq), move(ub) };
-  else if (ub.isFalse())
-    return { zero, false };
-  else if (i == memcmp_unroll_cnt - 1) {
-    // Approximation: assume that the two bytes aren't the same unless they are
-    // same pointers.
-    auto ptr_eq = p1 == p2;
-    s.addPre((ei.ult(max_num) && prefix() && !ptr_eq).implies(!val_eq), true);
-    return { expr::mkIf(move(ptr_eq), move(zero), move(result_neq)), move(ub) };
-  }
-
-  prefix.add(ub_and);
-  prefix.add(val_eq);
-  auto [val_next, ub_next]
-    = encode_memcmp(s, p1, p2, prefix, max_num, is_bcmp, i + 1);
-  return
-    { expr::mkIf(ei.uge(max_num), zero,
-                 expr::mkIf(val_eq, val_next, move(result_neq))),
-      ub && (ei.ult(max_num) && val_eq).implies(ub_next) };
-}
-
 StateValue Memcmp::toSMT(State &s) const {
   auto &[vptr1, np1] = s[*ptr1];
   auto &[vptr2, np2] = s[*ptr2];
@@ -2475,7 +2447,48 @@ StateValue Memcmp::toSMT(State &s) const {
   // dereferenceability check of vnum.
   s.addUB(p1.isDereferenceable(vnum, 1, false));
   s.addUB(p2.isDereferenceable(vnum, 1, false));
-  auto [val, ub] = encode_memcmp(s, p1, p2, prefix, vnum, is_bcmp, 0);
+
+  expr vn = vnum;
+  auto ith_exec =
+      [&, this](unsigned i, bool is_last) -> tuple<expr, AndExpr, expr> {
+    AndExpr ub_and;
+    auto [val1, ub1] = s.getMemory().load((p1 + i)(), IntType("i8", 8), 1);
+    auto [val2, ub2] = s.getMemory().load((p2 + i)(), IntType("i8", 8), 1);
+
+    ub_and.add(val1.non_poison);
+    ub_and.add(val2.non_poison);
+    ub_and.add(move(ub1));
+    ub_and.add(move(ub2));
+
+    expr ei = expr::mkUInt(i, vn.bits());
+    auto val_eq = val1.value == val2.value;
+    expr continue_cond = val_eq && ei.ult(vn);
+    if (is_last)
+      continue_cond &= (p1 != p2);
+
+    expr zero = expr::mkUInt(0, 32);
+    expr result_neq;
+    if (is_bcmp) {
+      result_neq = expr::mkFreshVar("bcmp_nonzero", zero);
+      s.addQuantVar(result_neq);
+      s.addPre(result_neq != zero);
+    } else {
+      expr pos = expr::mkFreshVar("memcmp_pos", expr::mkUInt(0, 31));
+      expr neg = expr::mkFreshVar("memcmp_neg", expr::mkUInt(0, 31));
+      s.addQuantVar(pos);
+      s.addQuantVar(neg);
+      s.addPre(pos != expr::mkUInt(0u, 31));
+      pos = expr::mkUInt(0, 1).concat(pos);
+      neg = expr::mkUInt(1, 1).concat(neg);
+      result_neq = expr::mkIf(val1.value.ugt(val2.value), move(pos), move(neg));
+    }
+    auto result = expr::mkIf(val_eq, zero, result_neq);
+
+    return { move(result), move(ub_and), move(continue_cond) };
+  };
+  LoopLikeFunctionApproximator apprx;
+  apprx.ith_exec = ith_exec;
+  auto [val, ub] = apprx.encode(s, memcmp_unroll_cnt);
   s.addUB(move(ub));
   return { move(val), true };
 }
@@ -2519,36 +2532,26 @@ void Strlen::print(ostream &os) const {
   os << getName() << " = strlen " << *ptr;
 }
 
-static pair<expr,expr>
-find_null(State &s, Type &ty, const Pointer &ptr, AndExpr &prefix, unsigned i) {
-  auto [val, ub0] = s.getMemory().load((ptr + i)(), IntType("i8", 8), 1);
-  auto ub = ub0() && val.non_poison;
-
-  auto is_zero = val.value == 0;
-  auto result = expr::mkUInt(i, ty.bits());
-
-  if (i == strlen_unroll_cnt - 1) {
-    s.addPre(prefix().implies(is_zero), true);
-    return { move(result), move(ub) };
-  }
-
-  if (is_zero.isTrue() || ub.isFalse())
-    return { move(result), move(ub) };
-
-  prefix.add(ub0);
-  prefix.add(val.non_poison);
-  prefix.add(!is_zero);
-  auto [val2, ub2] = find_null(s, ty, ptr, prefix, i + 1);
-  return { expr::mkIf(is_zero, result, val2),
-           ub && (is_zero || ub2) };
-}
-
 StateValue Strlen::toSMT(State &s) const {
   auto &[eptr, np_ptr] = s[*ptr];
   s.addUB(np_ptr);
-  AndExpr prefix;
-  auto [val, ub]
-    = find_null(s, getType(), Pointer(s.getMemory(), eptr), prefix, 0);
+
+  LoopLikeFunctionApproximator apprx;
+  Pointer p(s.getMemory(), eptr);
+  Type &ty = getType();
+
+  auto ith_exec =
+      [&s, &p, &ty](unsigned i, bool _) -> tuple<expr, AndExpr, expr> {
+    AndExpr ub;
+    auto [val, ub_load] = s.getMemory().load((p + i)(), IntType("i8", 8), 1);
+    ub.add(ub_load);
+    ub.add(val.non_poison);
+    auto nonnull = val.value != 0;
+    auto result = expr::mkUInt(i, ty.bits());
+    return { move(result), move(ub), move(nonnull) };
+  };
+  apprx.ith_exec = ith_exec;
+  auto [val, ub] = apprx.encode(s, strlen_unroll_cnt);
   s.addUB(move(ub));
   return { move(val), true };
 }

--- a/ir/instr.h
+++ b/ir/instr.h
@@ -606,6 +606,24 @@ public:
 };
 
 
+class Memcmp final : public Instr {
+  Value *ptr1, *ptr2, *num;
+  bool is_bcmp;
+public:
+  Memcmp(Type &type, std::string &&name, Value &ptr1, Value &ptr2, Value &num,
+        bool is_bcmp): Instr(type, std::move(name)), ptr1(&ptr1), ptr2(&ptr2),
+                        num(&num), is_bcmp(is_bcmp) {}
+
+  Value &getBytes() const { return *num; }
+  std::vector<Value*> operands() const override;
+  void rauw(const Value &what, Value &with) override;
+  void print(std::ostream &os) const override;
+  StateValue toSMT(State &s) const override;
+  smt::expr getTypeConstraints(const Function &f) const override;
+  std::unique_ptr<Instr> dup(const std::string &suffix) const override;
+};
+
+
 class ExtractElement final : public Instr {
   Value *v, *idx;
 public:

--- a/llvm_util/known_fns.cpp
+++ b/llvm_util/known_fns.cpp
@@ -60,6 +60,12 @@ known_call(llvm::CallInst &i, const llvm::TargetLibraryInfo &TLI,
       }
     }
     RETURN_KNOWN(make_unique<Strlen>(*ty, value_name(i), *args[0]));
+  case llvm::LibFunc_memcmp:
+  case llvm::LibFunc_bcmp: {
+    RETURN_KNOWN(
+      make_unique<Memcmp>(*ty, value_name(i), *args[0], *args[1], *args[2],
+                          libfn == llvm::LibFunc_bcmp));
+  }
   default:
     RETURN_FAIL_KNOWN();
   }

--- a/tests/alive-tv/memory/bcmp-identity.srctgt.ll
+++ b/tests/alive-tv/memory/bcmp-identity.srctgt.ll
@@ -1,0 +1,13 @@
+target datalayout = "e-p:64:64:64"
+target triple = "x86_64-unknown-linux-gnu"
+
+define i32 @src(i8 *%p, i64 %n) {
+  %res = call i32 @bcmp(i8* %p, i8* %p, i64 %n)
+  ret i32 %res
+}
+
+define i32 @tgt(i8 *%p, i64 %n) {
+  ret i32 0
+}
+
+declare i32 @bcmp(i8* nocapture, i8* nocapture, i64)

--- a/tests/alive-tv/memory/memcmp-basic-fail-2.srctgt.ll
+++ b/tests/alive-tv/memory/memcmp-basic-fail-2.srctgt.ll
@@ -1,0 +1,20 @@
+target datalayout = "e-m:o-i64:64-f80:128-n8:16:32:64-S128"
+
+define i32 @src() {
+  %p = alloca i32
+  %q = alloca i32
+  store i32 1, i32* %p ; 01 00 00 00
+  store i32 2, i32* %q ; 02 00 00 00
+  %p8 = bitcast i32* %p to i8*
+  %q8 = bitcast i32* %q to i8*
+  %res = call i32 @memcmp(i8* %p8, i8* %q8, i64 4)
+  ret i32 %res
+}
+
+define i32 @tgt() {
+	ret i32 1
+}
+
+; ERROR: Value mismatch
+
+declare i32 @memcmp(i8* nocapture, i8* nocapture, i64)

--- a/tests/alive-tv/memory/memcmp-basic-fail-3.srctgt.ll
+++ b/tests/alive-tv/memory/memcmp-basic-fail-3.srctgt.ll
@@ -1,0 +1,20 @@
+target datalayout = "e-m:o-i64:64-f80:128-n8:16:32:64-S128"
+
+define i32 @src() {
+  %p = alloca i32
+  %q = alloca i32
+  store i32 2, i32* %p ; 02 00 00 00
+  store i32 1, i32* %q ; 01 00 00 00
+  %p8 = bitcast i32* %p to i8*
+  %q8 = bitcast i32* %q to i8*
+  %res = call i32 @memcmp(i8* %p8, i8* %q8, i64 4)
+  ret i32 %res
+}
+
+define i32 @tgt() {
+  ret i32 0
+}
+
+; ERROR: Value mismatch
+
+declare i32 @memcmp(i8* nocapture, i8* nocapture, i64)

--- a/tests/alive-tv/memory/memcmp-basic-fail.srctgt.ll
+++ b/tests/alive-tv/memory/memcmp-basic-fail.srctgt.ll
@@ -1,0 +1,19 @@
+target datalayout = "e-m:o-i64:64-f80:128-n8:16:32:64-S128"
+
+define i32 @src() {
+  %p = alloca i8
+  %q = alloca i8
+  store i8 1, i8* %p
+  store i8 2, i8* %q
+  %res = call i32 @memcmp(i8* %p, i8* %q, i64 1)
+  ret i32 %res
+}
+
+define i32 @tgt() {
+	ret i32 0;
+}
+
+; ERROR: Value mismatch
+
+declare i32 @memcmp(i8* nocapture, i8* nocapture, i64)
+

--- a/tests/alive-tv/memory/memcmp-basic.src.ll
+++ b/tests/alive-tv/memory/memcmp-basic.src.ll
@@ -1,0 +1,81 @@
+target datalayout = "e-p:64:64:64"
+
+define i32 @lt() {
+  %p = alloca i32
+  %q = alloca i32
+  store i32 1, i32* %p ; 01 00 00 00
+  store i32 2, i32* %q ; 02 00 00 00
+  %p8 = bitcast i32* %p to i8*
+  %q8 = bitcast i32* %q to i8*
+  %res = call i32 @memcmp(i8* %p8, i8* %q8, i64 4)
+  ret i32 %res
+}
+
+define i32 @lt2() {
+  %p = alloca i32
+  %q = alloca i32
+  store i32 1, i32* %p   ; 01 00 00 00
+  store i32 513, i32* %q ; 01 02 00 00
+  %p8 = bitcast i32* %p to i8*
+  %q8 = bitcast i32* %q to i8*
+  %res = call i32 @memcmp(i8* %p8, i8* %q8, i64 4)
+  ret i32 %res
+}
+
+define i32 @lt3() {
+  %p = alloca i32
+  %q = alloca i32
+  store i32 513, i32* %p    ; 01 02 00 00
+  store i32 197121, i32* %q ; 01 02 03 00
+  %p8 = bitcast i32* %p to i8*
+  %q8 = bitcast i32* %q to i8*
+  %res = call i32 @memcmp(i8* %p8, i8* %q8, i64 4)
+  ret i32 %res
+}
+
+define i32 @lt4() {
+  %p = alloca i32
+  %q = alloca i32
+  store i32 197121, i32* %p   ; 01 02 03 00
+  store i32 67305985, i32* %q ; 01 02 03 04
+  %p8 = bitcast i32* %p to i8*
+  %q8 = bitcast i32* %q to i8*
+  %res = call i32 @memcmp(i8* %p8, i8* %q8, i64 4)
+  ret i32 %res
+}
+
+define i32 @eq() {
+  %p = alloca i32
+  %q = alloca i32
+  store i32 10, i32* %p
+  store i32 10, i32* %q
+  %p8 = bitcast i32* %p to i8*
+  %q8 = bitcast i32* %q to i8*
+  %res = call i32 @memcmp(i8* %p8, i8* %q8, i64 4)
+  ret i32 %res
+}
+
+define i32 @gt() {
+  %p = alloca i32
+  %q = alloca i32
+  store i32 2, i32* %p ; 02 00 00 00
+  store i32 1, i32* %q ; 01 00 00 00
+  %p8 = bitcast i32* %p to i8*
+  %q8 = bitcast i32* %q to i8*
+  %res = call i32 @memcmp(i8* %p8, i8* %q8, i64 4)
+  ret i32 %res
+}
+
+define i32 @gt2() {
+  %p = alloca i32
+  %q = alloca i32
+  store i32 67305985, i32* %p ; 01 02 03 04
+  store i32 197121, i32* %q   ; 01 02 03 00
+  %p8 = bitcast i32* %p to i8*
+  %q8 = bitcast i32* %q to i8*
+  %res = call i32 @memcmp(i8* %p8, i8* %q8, i64 4)
+  ret i32 %res
+}
+
+declare i32 @memcmp(i8* nocapture, i8* nocapture, i64)
+

--- a/tests/alive-tv/memory/memcmp-basic.tgt.ll
+++ b/tests/alive-tv/memory/memcmp-basic.tgt.ll
@@ -1,0 +1,29 @@
+target datalayout = "e-p:64:64:64"
+
+define i32 @lt() {
+  ret i32 -11 ; any negative number is fine
+}
+
+define i32 @lt2() {
+  ret i32 -99
+}
+
+define i32 @lt3() {
+  ret i32 -2553
+}
+
+define i32 @lt4() {
+  ret i32 -1
+}
+
+define i32 @eq() {
+  ret i32 0
+}
+
+define i32 @gt() {
+  ret i32 101
+}
+
+define i32 @gt2() {
+  ret i32 2147483647
+}

--- a/tests/alive-tv/memory/memcmp-bcmp.srctgt.ll
+++ b/tests/alive-tv/memory/memcmp-bcmp.srctgt.ll
@@ -1,0 +1,31 @@
+target datalayout = "e-p:64:64:64"
+target triple = "x86_64-unknown-linux-gnu"
+; TEST-ARGS: -smt-to=10000 -disable-undef-input
+; allowing undef as inputs causes timeout, so it is disabled.
+
+define i1 @src(i64 %x, i64 %y, i64 %n) {
+  %p = alloca i64
+  %q = alloca i64
+  store i64 %x, i64* %p
+  store i64 %y, i64* %q
+  %p8 = bitcast i64* %p to i8*
+  %q8 = bitcast i64* %q to i8*
+  %res = call i32 @memcmp(i8* %p8, i8* %q8, i64 %n)
+  %c = icmp eq i32 %res, 0
+  ret i1 %c
+}
+
+define i1 @tgt(i64 %x, i64 %y, i64 %n) {
+  %p = alloca i64
+  %q = alloca i64
+  store i64 %x, i64* %p
+  store i64 %y, i64* %q
+  %p8 = bitcast i64* %p to i8*
+  %q8 = bitcast i64* %q to i8*
+  %res = call i32 @bcmp(i8* %p8, i8* %q8, i64 %n)
+  %c = icmp eq i32 %res, 0
+  ret i1 %c
+}
+
+declare i32 @bcmp(i8* nocapture, i8* nocapture, i64)
+declare i32 @memcmp(i8* nocapture, i8* nocapture, i64)

--- a/tests/alive-tv/memory/memcmp-identity.srctgt.ll
+++ b/tests/alive-tv/memory/memcmp-identity.srctgt.ll
@@ -1,0 +1,13 @@
+target datalayout = "e-p:64:64:64"
+target triple = "x86_64-unknown-linux-gnu"
+
+define i32 @src(i8 *%p, i64 %n) {
+  %res = call i32 @memcmp(i8* %p, i8* %p, i64 %n)
+  ret i32 %res
+}
+
+define i32 @tgt(i8 *%p, i64 %n) {
+  ret i32 0
+}
+
+declare i32 @memcmp(i8* nocapture, i8* nocapture, i64)

--- a/tests/alive-tv/memory/memcmp-noub.srctgt.ll
+++ b/tests/alive-tv/memory/memcmp-noub.srctgt.ll
@@ -7,7 +7,7 @@ define i32 @src() {
   %p8_3 = getelementptr i8, i8* %p8, i64 3
   store i8 1, i8* %p8_3
   %q = getelementptr i8, i8* %p8, i64 1
-  %res = call i32 @memcmp(i8* %p8, i8* %q, i64 4) ; noub
+  %res = call i32 @memcmp(i8* %p8, i8* %q, i64 3) ; noub
 	ret i32 %res
 }
 

--- a/tests/alive-tv/memory/memcmp-noub.srctgt.ll
+++ b/tests/alive-tv/memory/memcmp-noub.srctgt.ll
@@ -1,0 +1,20 @@
+target datalayout = "e-p:64:64:64"
+
+define i32 @src() {
+  %p = alloca i32
+	store i32 0, i32* %p
+  %p8 = bitcast i32* %p to i8*
+  %p8_3 = getelementptr i8, i8* %p8, i64 3
+  store i8 1, i8* %p8_3
+  %q = getelementptr i8, i8* %p8, i64 1
+  %res = call i32 @memcmp(i8* %p8, i8* %q, i64 4) ; noub
+	ret i32 %res
+}
+
+define i32 @tgt() {
+  unreachable
+}
+
+; ERROR: Source is more defined than target
+
+declare i32 @memcmp(i8* nocapture, i8* nocapture, i64)

--- a/tests/alive-tv/memory/memcmp-opt-bigendian.srctgt.ll
+++ b/tests/alive-tv/memory/memcmp-opt-bigendian.srctgt.ll
@@ -1,0 +1,26 @@
+target datalayout = "E-p:64:64:64"
+; TEST-ARGS: -disable-undef-input
+; This optimization is incorrect if x == 0 and y == undef!
+; In src, %res cannot be 1 because y cannot be smaller than 0.
+; In tgt, %lt and %eq can both be false because y is undef, so %res can be 1.
+
+define i32 @src(i16 %x, i16 %y) {
+  %p = alloca i16
+  %q = alloca i16
+  store i16 %x, i16* %p, align 1
+  store i16 %y, i16* %q, align 1
+  %p8 = bitcast i16* %p to i8*
+  %q8 = bitcast i16* %q to i8*
+  %res = call i32 @memcmp(i8* %p8, i8* %q8, i64 2)
+  ret i32 %res
+}
+
+define i32 @tgt(i16 %x, i16 %y) {
+  %lt = icmp ult i16 %x, %y
+  %eq = icmp eq i16 %x, %y
+  %r = select i1 %eq, i32 0, i32 1
+  %res = select i1 %lt, i32 -1, i32 %r
+  ret i32 %res
+}
+
+declare i32 @memcmp(i8* nocapture, i8* nocapture, i64)	

--- a/tests/alive-tv/memory/memcmp-opt-littleendian-fail.srctgt.ll
+++ b/tests/alive-tv/memory/memcmp-opt-littleendian-fail.srctgt.ll
@@ -1,0 +1,26 @@
+target datalayout = "e-p:64:64:64"
+
+; ex) %x = 0x1020, %y = 0x30
+; Note that %x > %y
+define i32 @src(i64 %x, i64 %y) {
+  %p = alloca i64
+  %q = alloca i64
+  store i64 %x, i64* %p, align 1 ; 20 10 00 00 ..
+  store i64 %y, i64* %q, align 1 ; 30 00 00 00 ..
+  %p8 = bitcast i64* %p to i8*
+  %q8 = bitcast i64* %q to i8*
+  %res = call i32 @memcmp(i8* %p8, i8* %q8, i64 8) ; %res < 0
+  ret i32 %res
+}
+
+define i32 @tgt(i64 %x, i64 %y) {
+  %lt = icmp ult i64 %x, %y
+  %eq = icmp eq i64 %x, %y
+  %r = select i1 %eq, i32 0, i32 1
+  %res = select i1 %lt, i32 -1, i32 %r
+  ret i32 %res
+}
+
+; ERROR: Value mismatch
+
+declare i32 @memcmp(i8* nocapture, i8* nocapture, i64)

--- a/tests/alive-tv/memory/memcmp-ub.src.ll
+++ b/tests/alive-tv/memory/memcmp-ub.src.ll
@@ -1,0 +1,58 @@
+target datalayout = "e-p:64:64:64"
+
+define i32 @ub() {
+  %p = alloca i32
+  %p8 = bitcast i32* %p to i8*
+  %res = call i32 @memcmp(i8* %p8, i8* %p8, i64 4) ; ub
+  ret i32 %res
+}
+
+define i32 @ub2() {
+  %p = alloca i32
+  %p8 = bitcast i32* %p to i8*
+  store i8 0, i8* %p8
+  %res = call i32 @memcmp(i8* %p8, i8* %p8, i64 4) ; ub
+  ret i32 %res
+}
+
+define i32 @ub_null() {
+  %p = alloca i32
+	store i32 0, i32* %p
+	%p8 = bitcast i32* %p to i8*
+  %res = call i32 @memcmp(i8* %p8, i8* null, i64 4) ; ub
+	ret i32 %res
+}
+
+define i32 @ub_oob() {
+  %p = alloca i32
+	store i32 0, i32* %p
+  %p8 = bitcast i32* %p to i8*
+  %q = getelementptr i8, i8* %p8, i64 4
+  %res = call i32 @memcmp(i8* %p8, i8* %q, i64 4) ; ub
+	ret i32 %res
+}
+
+define i32 @ub_oob2() {
+  %p = alloca i32
+	store i32 0, i32* %p
+  %p8 = bitcast i32* %p to i8*
+  %q = getelementptr i8, i8* %p8, i64 1
+  %res = call i32 @memcmp(i8* %p8, i8* %q, i64 4) ; ub!
+	ret i32 %res
+}
+
+define i32 @ub_diffblocks() {
+  %p = alloca i32
+  %q = alloca i32
+  %p16 = bitcast i32* %p to i16*
+  %q16 = bitcast i32* %q to i16*
+  store i16 257, i16* %p16 ; 01 01 pp pp
+  store i16 257, i16* %q16 ; 01 01 pp pp
+  %p8 = bitcast i32* %p to i8*
+  %q8 = bitcast i32* %q to i8*
+  %res = call i32 @memcmp(i8* %p8, i8* %q8, i64 4)
+  %res2 = add i32 %res, %res
+  ret i32 %res2
+}
+
+declare i32 @memcmp(i8* nocapture, i8* nocapture, i64)

--- a/tests/alive-tv/memory/memcmp-ub.tgt.ll
+++ b/tests/alive-tv/memory/memcmp-ub.tgt.ll
@@ -1,0 +1,27 @@
+target datalayout = "e-p:64:64:64"
+
+define i32 @ub() {
+  unreachable
+}
+
+define i32 @ub2() {
+  unreachable
+}
+
+define i32 @ub_null() {
+  unreachable
+}
+
+define i32 @ub_oob() {
+  unreachable
+}
+
+define i32 @ub_oob2() {
+  unreachable
+}
+
+define i32 @ub_diffblocks() {
+  unreachable
+}
+
+declare i32 @memcmp(i8* nocapture, i8* nocapture, i64)


### PR DESCRIPTION
This implements memcmp/bcmp by manually unrolling comparisons `memcmp_unroll_cnt` times.

This only considers integer bytes (otherwise poison), but it already seems to work quite well for LLVM unit tests.

Has one regression from unit tests: Transforms/ExpandMemCmp/X86/memcmp.ll due to this kind of transformation:

```
define i32 @cmp2(* nocapture readonly %x, * nocapture readonly %y) {                
%0:                                                                                 
  %call = memcmp * nocapture readonly %x, * nocapture readonly %y, i64 2            
  ret i32 %call                                                                     
}                                                                                   
=>                                                                                  
define i32 @cmp2(* nocapture readonly %x, * nocapture readonly %y) {                
%0:                                                                                 
  %1 = bitcast * nocapture readonly %x to *                                         
  %2 = bitcast * nocapture readonly %y to *                                         
  %3 = load i16, * %1, align 1                                                      
  %4 = load i16, * %2, align 1                                                      
  %5 = bswap i16 %3                                                                 
  %6 = bswap i16 %4                                                                 
  %7 = zext i16 %5 to i32                                                           
  %8 = zext i16 %6 to i32                                                           
  %9 = sub i32 %7, %8                                                               
  ret i32 %9                                                                        
}
```
If x[0] = 0, y[0] = 1, x[1] = y[1] = poison, %3 & %4 in tgt are full-poison whereas src only compares the first non-poison byte and returns non-zero.

This is what is expected & also a ugly part of the current status; bitwise poison will explain this, but it will be a huge pain for checking correctness of all other optimizations because we don't want to redefine all relevant operations bitwisely.

Actually, I think this result also makes sense somehow in perspective of a sanitizer: before transformation, it does not touch x[1]/y[1], but after that it touches it and does arithmetic operation on it.

Fixing these transformations in LLVM doesn't seem trivial; we can introduce notions like 'load with bytes frozen', or use vectorized load (load <2 x i8>), but any of these is likely to effect performance, so it will need some work.