### PR TITLE
Support dereferenceable attribute

### DIFF
--- a/ir/attrs.cpp
+++ b/ir/attrs.cpp
@@ -18,7 +18,7 @@ ostream& operator<<(ostream &os, const ParamAttrs &attr) {
   if (attr.has(ParamAttrs::ReadNone))
     os << "readnone ";
   if (attr.has(ParamAttrs::Dereferenceable))
-    os << "dereferenceable(" + to_string(attr.derefBytes) + ") ";
+    os << "dereferenceable(" << attr.derefBytes << ") ";
   return os;
 }
 

--- a/ir/attrs.cpp
+++ b/ir/attrs.cpp
@@ -17,6 +17,8 @@ ostream& operator<<(ostream &os, const ParamAttrs &attr) {
     os << "readonly ";
   if (attr.has(ParamAttrs::ReadNone))
     os << "readnone ";
+  if (attr.has(ParamAttrs::Dereferenceable))
+    os << "dereferenceable(" + to_string(attr.derefBytes) + ") ";
   return os;
 }
 

--- a/ir/attrs.h
+++ b/ir/attrs.h
@@ -9,15 +9,18 @@ namespace IR {
 
 class ParamAttrs final {
   unsigned bits;
+  uint64_t derefBytes;
 
 public:
   enum Attribute { None = 0, NonNull = 1<<0, ByVal = 1<<1, NoCapture = 1<<2,
-                   ReadOnly = 1<<3, ReadNone = 1<<4 };
+                   ReadOnly = 1<<3, ReadNone = 1<<4, Dereferenceable = 1<<5 };
 
   ParamAttrs(unsigned bits = None) : bits(bits) {}
 
   bool has(Attribute a) const { return (bits & a) != 0; }
   void set(Attribute a) { bits |= (unsigned)a; }
+  uint64_t getDerefBytes() const { return derefBytes; }
+  void setDerefBytes(uint64_t bytes) { derefBytes = bytes; }
 
   friend std::ostream& operator<<(std::ostream &os, const ParamAttrs &attr);
 };

--- a/ir/instr.cpp
+++ b/ir/instr.cpp
@@ -1334,6 +1334,11 @@ static void unpack_inputs(State&s, Type &ty, const ParamAttrs &argflag,
     if (ty.isPtrType()) {
       Pointer p(s.getMemory(), value.value);
       p.stripAttrs();
+      if (argflag.has(ParamAttrs::Dereferenceable)) {
+        s.addUB(value.non_poison);
+        s.addUB(
+          p.isDereferenceable(argflag.getDerefBytes(), bits_byte / 8, false));
+      }
       ptr_inputs.emplace_back(StateValue(p.release(), expr(value.non_poison)),
                               argflag.has(ParamAttrs::ByVal));
     } else {

--- a/ir/state.cpp
+++ b/ir/state.cpp
@@ -190,23 +190,27 @@ void State::addReturn(const StateValue &val) {
 }
 
 void State::addUB(expr &&ub) {
+  assert(current_bb);
   domain.UB.add(move(ub));
   if (!ub.isConst())
     domain.undef_vars.insert(undef_vars.begin(), undef_vars.end());
 }
 
 void State::addUB(const expr &ub) {
+  assert(current_bb);
   domain.UB.add(ub);
   if (!ub.isConst())
     domain.undef_vars.insert(undef_vars.begin(), undef_vars.end());
 }
 
 void State::addUB(AndExpr &&ubs) {
+  assert(current_bb);
   domain.UB.add(ubs);
   domain.undef_vars.insert(undef_vars.begin(), undef_vars.end());
 }
 
 void State::addNoReturn() {
+  assert(current_bb);
   function_domain.add(domain());
   return_undef_vars.insert(undef_vars.begin(), undef_vars.end());
   return_undef_vars.insert(domain.undef_vars.begin(), domain.undef_vars.end());

--- a/ir/state.cpp
+++ b/ir/state.cpp
@@ -190,27 +190,23 @@ void State::addReturn(const StateValue &val) {
 }
 
 void State::addUB(expr &&ub) {
-  assert(current_bb);
   domain.UB.add(move(ub));
   if (!ub.isConst())
     domain.undef_vars.insert(undef_vars.begin(), undef_vars.end());
 }
 
 void State::addUB(const expr &ub) {
-  assert(current_bb);
   domain.UB.add(ub);
   if (!ub.isConst())
     domain.undef_vars.insert(undef_vars.begin(), undef_vars.end());
 }
 
 void State::addUB(AndExpr &&ubs) {
-  assert(current_bb);
   domain.UB.add(ubs);
   domain.undef_vars.insert(undef_vars.begin(), undef_vars.end());
 }
 
 void State::addNoReturn() {
-  assert(current_bb);
   function_domain.add(domain());
   return_undef_vars.insert(undef_vars.begin(), undef_vars.end());
   return_undef_vars.insert(domain.undef_vars.begin(), domain.undef_vars.end());

--- a/ir/state.h
+++ b/ir/state.h
@@ -56,7 +56,7 @@ private:
   smt::AndExpr axioms;
   smt::AndExpr ooms;
 
-  const BasicBlock *current_bb = nullptr;
+  const BasicBlock *current_bb;
   std::set<smt::expr> quantified_vars;
 
   // var -> ((value, not_poison), undef_vars, already_used?)

--- a/ir/state.h
+++ b/ir/state.h
@@ -56,7 +56,7 @@ private:
   smt::AndExpr axioms;
   smt::AndExpr ooms;
 
-  const BasicBlock *current_bb;
+  const BasicBlock *current_bb = nullptr;
   std::set<smt::expr> quantified_vars;
 
   // var -> ((value, not_poison), undef_vars, already_used?)
@@ -130,6 +130,7 @@ public:
                    const BasicBlock &dst_false);
   void addReturn(const StateValue &val);
 
+  void addAxiom(smt::AndExpr &&ands) { axioms.add(std::move(ands)); }
   void addAxiom(smt::expr &&axiom) { axioms.add(std::move(axiom)); }
   void addPre(smt::expr &&cond, bool forApprox = false)
   { (forApprox ? preconditionForApprox : precondition).add(std::move(cond)); }

--- a/ir/value.h
+++ b/ir/value.h
@@ -117,6 +117,7 @@ public:
   void copySMTName(const Input &other);
   void print(std::ostream &os) const override;
   bool hasAttribute(ParamAttrs::Attribute a) const { return attrs.has(a); }
+  const ParamAttrs &getAttributes() const { return attrs; }
   StateValue toSMT(State &s) const override;
   smt::expr getTyVar() const;
 };

--- a/llvm_util/llvm2alive.cpp
+++ b/llvm_util/llvm2alive.cpp
@@ -835,9 +835,10 @@ public:
     return true;
   }
 
-  optional<ParamAttrs> handleAttributes(const llvm::AttributeSet &aset) {
+  optional<ParamAttrs> handleAttributes(llvm::Argument &arg) {
     ParamAttrs attrs;
-    for (auto &attr : aset) {
+    for (auto &attr : arg.getParent()->getAttributes()
+                         .getParamAttributes(arg.getArgNo())) {
       switch (attr.getKindAsEnum()) {
       case llvm::Attribute::InReg:
       case llvm::Attribute::SExt:
@@ -893,8 +894,7 @@ public:
 
     for (auto &arg : f.args()) {
       auto ty = llvm_type2alive(arg.getType());
-      auto attrs = handleAttributes(arg.getParent()->getAttributes()
-                                       .getParamAttributes(arg.getArgNo()));
+      auto attrs = handleAttributes(arg);
       if (!ty || !attrs)
         return {};
       auto val = make_unique<Input>(*ty, value_name(arg), move(*attrs));

--- a/llvm_util/llvm2alive.cpp
+++ b/llvm_util/llvm2alive.cpp
@@ -273,7 +273,7 @@ public:
                           !known);
     unique_ptr<Instr> ret_val;
 
-    for (uint64_t argidx = 0; argidx < i.arg_size(); ++argidx) {
+    for (uint64_t argidx = 0, nargs = i.arg_size(); argidx < nargs; ++argidx) {
       auto *arg = args[argidx];
       ParamAttrs attr;
       // TODO: Once attributes at a call site are fully supported, we should

--- a/tests/alive-tv/attrs/dereferenceable-callsite-max.srctgt.ll
+++ b/tests/alive-tv/attrs/dereferenceable-callsite-max.srctgt.ll
@@ -1,0 +1,20 @@
+define i32 @src(i1 %c, i32* %p) {
+ENTRY:
+  call void @f(i32* dereferenceable(4) %p)
+  br i1 %c, label %A, label %EXIT
+A:
+  %v1 = load i32, i32* %p
+  br label %EXIT
+EXIT:
+  %val = phi i32 [%v1, %A], [0, %ENTRY]
+  ret i32 %val
+}
+
+define i32 @tgt(i1 %c, i32* %p) {
+  call void @f(i32* dereferenceable(4) %p)
+  %v1 = load i32, i32* %p
+  %val = select i1 %c, i32 %v1, i32 0
+  ret i32 %val
+}
+
+declare void @f(i32* dereferenceable(2) %ptr)

--- a/tests/alive-tv/attrs/dereferenceable-callsite.srctgt.ll
+++ b/tests/alive-tv/attrs/dereferenceable-callsite.srctgt.ll
@@ -1,0 +1,20 @@
+define i32 @src(i1 %c, i32* %p) {
+ENTRY:
+  call void @f(i32* dereferenceable(4) %p)
+  br i1 %c, label %A, label %EXIT
+A:
+  %v1 = load i32, i32* %p
+  br label %EXIT
+EXIT:
+  %val = phi i32 [%v1, %A], [0, %ENTRY]
+  ret i32 %val
+}
+
+define i32 @tgt(i1 %c, i32* %p) {
+  call void @f(i32* dereferenceable(4) %p)
+  %v1 = load i32, i32* %p
+  %val = select i1 %c, i32 %v1, i32 0
+  ret i32 %val
+}
+
+declare void @f(i32* %ptr)

--- a/tests/alive-tv/attrs/dereferenceable-callsite2.srctgt.ll
+++ b/tests/alive-tv/attrs/dereferenceable-callsite2.srctgt.ll
@@ -1,0 +1,20 @@
+define i32 @src(i1 %c, i32* %p) {
+ENTRY:
+  call void @f(i32* %p)
+  br i1 %c, label %A, label %EXIT
+A:
+  %v1 = load i32, i32* %p
+  br label %EXIT
+EXIT:
+  %val = phi i32 [%v1, %A], [0, %ENTRY]
+  ret i32 %val
+}
+
+define i32 @tgt(i1 %c, i32* %p) {
+  call void @f(i32* %p)
+  %v1 = load i32, i32* %p
+  %val = select i1 %c, i32 %v1, i32 0
+  ret i32 %val
+}
+
+declare void @f(i32* dereferenceable(4) %ptr)

--- a/tests/alive-tv/attrs/dereferenceable-fail.srctgt.ll
+++ b/tests/alive-tv/attrs/dereferenceable-fail.srctgt.ll
@@ -1,0 +1,18 @@
+define i32 @src(i1 %c, i32* dereferenceable(3) %p) {
+ENTRY:
+  br i1 %c, label %A, label %EXIT
+A:
+  %v1 = load i32, i32* %p
+  br label %EXIT
+EXIT:
+  %val = phi i32 [%v1, %A], [0, %ENTRY]
+  ret i32 %val
+}
+
+define i32 @tgt(i1 %c, i32* dereferenceable(3) %p) {
+  %v1 = load i32, i32* %p
+  %val = select i1 %c, i32 %v1, i32 0
+  ret i32 %val
+}
+
+; ERROR: Source is more defined than target

--- a/tests/alive-tv/attrs/dereferenceable.srctgt.ll
+++ b/tests/alive-tv/attrs/dereferenceable.srctgt.ll
@@ -1,0 +1,16 @@
+define i32 @src(i1 %c, i32* dereferenceable(4) %p) {
+ENTRY:
+  br i1 %c, label %A, label %EXIT
+A:
+  %v1 = load i32, i32* %p
+  br label %EXIT
+EXIT:
+  %val = phi i32 [%v1, %A], [0, %ENTRY]
+  ret i32 %val
+}
+
+define i32 @tgt(i1 %c, i32* dereferenceable(4) %p) {
+  %v1 = load i32, i32* %p
+  %val = select i1 %c, i32 %v1, i32 0
+  ret i32 %val
+}

--- a/tests/alive-tv/opt-memory/dereferenceable.srctgt.ll
+++ b/tests/alive-tv/opt-memory/dereferenceable.srctgt.ll
@@ -1,0 +1,14 @@
+; TEST-ARGS: -dbg
+
+define i32 @src(i32* dereferenceable(2) %p) {
+  %v1 = load i32, i32* %p
+  ret i32 %v1
+}
+
+define i32 @tgt(i32* dereferenceable(2) %p) {
+  %v1 = load i32, i32* %p
+  ret i32 %v1
+}
+
+
+; CHECK: min_access_size: 2

--- a/tools/transform.cpp
+++ b/tools/transform.cpp
@@ -511,6 +511,7 @@ static void calculateAndInitConstants(Transform &t) {
   bool has_ptr_load = false;
   does_sub_byte_access = false;
 
+
   for (auto fn : { &t.src, &t.tgt }) {
     unsigned &cur_num_locals = fn == &t.src ? num_locals_src : num_locals_tgt;
     uint64_t &cur_max_gep    = fn == &t.src ? max_gep_src : max_gep_tgt;


### PR DESCRIPTION
This PR adds support for dereferenceable attribute at function parameters.

Dereferenceable for function's return value isn't included because it requires factoring out function attributes as a class, which will make the diff big.

LLVM unit tests: two failures added;
```
Transforms/MergeICmps/X86/entry-block-shuffled.ll
Transforms/MergeICmps/X86/multiple-blocks-does-work.ll
```

The first one does `if (x) { if (y) { ... } }` -> `if (y) { if (x) { ... } }` which is illegal because it may introduce UB.
The second one is related with memcmp's semantics; Currently, memcmp raises UB if poison bytes are compared, but this requires memcmp to return poison...