### PR TITLE
Encode call site refinement without using quantified variables

### DIFF
--- a/ir/state.cpp
+++ b/ir/state.cpp
@@ -397,8 +397,11 @@ void State::mkAxioms(State &tgt) {
 
         expr refines(true);
         for (unsigned i = 0, e = ins.size(); i != e; ++i) {
-          refines &= ins[i].non_poison.implies(ins[i].value == ins2[i].value &&
-                                               ins2[i].non_poison);
+          string used = fn + "#arg" + to_string(i) + "used";
+          refines &=
+            expr::mkBoolVar(used.c_str()).implies(
+              ins[i].non_poison.implies(ins[i].value == ins2[i].value &&
+                                        ins2[i].non_poison));
         }
 
         if (refines.isFalse())

--- a/ir/state.cpp
+++ b/ir/state.cpp
@@ -420,7 +420,7 @@ void State::mkAxioms(State &tgt) {
           expr eq_val = Pointer(mem, ptr_in.value)
                       .fninputRefined(Pointer(mem2, ptr_in2.value), is_byval2);
           refines &= ptr_in.non_poison
-                       .implies(move(eq_val) && ptr_in2.non_poison);
+                       .implies(eq_val && ptr_in2.non_poison);
         }
 
         if (reads2) {

--- a/tests/alive-tv/call.src.ll
+++ b/tests/alive-tv/call.src.ll
@@ -68,9 +68,17 @@ define void @f8() {
   ret void
 }
 
+define void @f9() {
+  %poison = sub nuw i32 0, 1
+  call void @j(i32 %poison)
+  call void @j(i32 %poison)
+  ret void
+}
+
 declare i8 @g(i8*)
 declare i8 @g2(i8* byval)
 declare i8 @h(i8*) readnone
+declare void @j(i32)
 declare i8* @k()
 
 declare void @llvm.memcpy.p0i8.p0i8.i64(i8*, i8*, i64, i1)

--- a/tests/alive-tv/call.tgt.ll
+++ b/tests/alive-tv/call.tgt.ll
@@ -61,9 +61,16 @@ define void @f8() {
   ret void
 }
 
+define void @f9() {
+  call void @j(i32 3)
+  call void @j(i32 4)
+  ret void
+}
+
 declare i8 @g(i8*)
 declare i8 @g2(i8* byval)
 declare i8 @h(i8*) readnone
+declare void @j(i32)
 declare i8* @k()
 
 declare void @llvm.memcpy.p0i8.p0i8.i64(i8*, i8*, i64, i1)

--- a/tests/unit/call-error5.opt
+++ b/tests/unit/call-error5.opt
@@ -5,4 +5,4 @@ ret i8 %d
   =>
 ret i8 1
 
-; FIXME: this test should fail!
+; ERROR: Source is more defined than target

--- a/tests/unit/call-error5.opt
+++ b/tests/unit/call-error5.opt
@@ -5,4 +5,4 @@ ret i8 %d
   =>
 ret i8 1
 
-; ERROR: Source is more defined than target
+; ERROR: Value mismatch

--- a/tests/unit/call-error6.opt
+++ b/tests/unit/call-error6.opt
@@ -18,4 +18,4 @@ ret i8 %d
 assume(false)
 ret i8 0
 
-; FIXME: this test should fail!
+; ERROR: Source is more defined than target


### PR DESCRIPTION
This patch removes introduction of quantified variables that were created for encoding the return values of functions when poisons were given as inputs. 

No regressions in Alive2 unit tests & LLVM unit tests
LLVM unit tests' timeout #: 836 -> 817
