### PR TITLE
Let memcmp return poison when comparing poisonous bytes

### DIFF
--- a/tests/alive-tv/memory/memcmp-noub2.srctgt.ll
+++ b/tests/alive-tv/memory/memcmp-noub2.srctgt.ll
@@ -1,0 +1,23 @@
+target datalayout = "e-p:64:64:64"
+
+define i32 @src() {
+  %p = alloca i32
+  %q = alloca i32
+  %p16 = bitcast i32* %p to i16*
+  %q16 = bitcast i32* %q to i16*
+  store i16 257, i16* %p16 ; 01 01 pp pp
+  store i16 257, i16* %q16 ; 01 01 pp pp
+  %p8 = bitcast i32* %p to i8*
+  %q8 = bitcast i32* %q to i8*
+  %res = call i32 @memcmp(i8* %p8, i8* %q8, i64 4)
+  %res2 = add i32 %res, %res
+  ret i32 %res2
+}
+
+define i32 @tgt() {
+  unreachable
+}
+
+; ERROR: Source is more defined than target
+
+declare i32 @memcmp(i8* nocapture, i8* nocapture, i64)

--- a/tests/alive-tv/memory/memcmp-noub3.srctgt.ll
+++ b/tests/alive-tv/memory/memcmp-noub3.srctgt.ll
@@ -4,7 +4,7 @@ define i32 @src() {
   %p = alloca i32
   %p8 = bitcast i32* %p to i8*
   store i8 0, i8* %p8
-  %res = call i32 @memcmp(i8* %p8, i8* %p8, i64 4) ; ub
+  %res = call i32 @memcmp(i8* %p8, i8* %p8, i64 4) ; poison
   ret i32 %res
 }
 

--- a/tests/alive-tv/memory/memcmp-noub3.srctgt.ll
+++ b/tests/alive-tv/memory/memcmp-noub3.srctgt.ll
@@ -2,16 +2,10 @@ target datalayout = "e-p:64:64:64"
 
 define i32 @src() {
   %p = alloca i32
-  %q = alloca i32
-  %p16 = bitcast i32* %p to i16*
-  %q16 = bitcast i32* %q to i16*
-  store i16 257, i16* %p16 ; 01 01 pp pp
-  store i16 257, i16* %q16 ; 01 01 pp pp
   %p8 = bitcast i32* %p to i8*
-  %q8 = bitcast i32* %q to i8*
-  %res = call i32 @memcmp(i8* %p8, i8* %q8, i64 4)
-  %res2 = add i32 %res, %res
-  ret i32 %res2
+  store i8 0, i8* %p8
+  %res = call i32 @memcmp(i8* %p8, i8* %p8, i64 4) ; ub
+  ret i32 %res
 }
 
 define i32 @tgt() {

--- a/tests/alive-tv/memory/memcmp-noub3.srctgt.ll
+++ b/tests/alive-tv/memory/memcmp-noub3.srctgt.ll
@@ -1,0 +1,23 @@
+target datalayout = "e-p:64:64:64"
+
+define i32 @src() {
+  %p = alloca i32
+  %q = alloca i32
+  %p16 = bitcast i32* %p to i16*
+  %q16 = bitcast i32* %q to i16*
+  store i16 257, i16* %p16 ; 01 01 pp pp
+  store i16 257, i16* %q16 ; 01 01 pp pp
+  %p8 = bitcast i32* %p to i8*
+  %q8 = bitcast i32* %q to i8*
+  %res = call i32 @memcmp(i8* %p8, i8* %q8, i64 4)
+  %res2 = add i32 %res, %res
+  ret i32 %res2
+}
+
+define i32 @tgt() {
+  unreachable
+}
+
+; ERROR: Source is more defined than target
+
+declare i32 @memcmp(i8* nocapture, i8* nocapture, i64)

--- a/tests/alive-tv/memory/memcmp-noub4.srctgt.ll
+++ b/tests/alive-tv/memory/memcmp-noub4.srctgt.ll
@@ -1,0 +1,16 @@
+target datalayout = "e-p:64:64:64"
+
+define i32 @src() {
+  %p = alloca i32
+  %p8 = bitcast i32* %p to i8*
+  %res = call i32 @memcmp(i8* %p8, i8* %p8, i64 4) ; ub
+  ret i32 %res
+}
+
+define i32 @tgt() {
+  unreachable
+}
+
+; ERROR: Source is more defined than target
+
+declare i32 @memcmp(i8* nocapture, i8* nocapture, i64)

--- a/tests/alive-tv/memory/memcmp-ub.src.ll
+++ b/tests/alive-tv/memory/memcmp-ub.src.ll
@@ -1,20 +1,5 @@
 target datalayout = "e-p:64:64:64"
 
-define i32 @ub() {
-  %p = alloca i32
-  %p8 = bitcast i32* %p to i8*
-  %res = call i32 @memcmp(i8* %p8, i8* %p8, i64 4) ; ub
-  ret i32 %res
-}
-
-define i32 @ub2() {
-  %p = alloca i32
-  %p8 = bitcast i32* %p to i8*
-  store i8 0, i8* %p8
-  %res = call i32 @memcmp(i8* %p8, i8* %p8, i64 4) ; ub
-  ret i32 %res
-}
-
 define i32 @ub_null() {
   %p = alloca i32
 	store i32 0, i32* %p
@@ -39,20 +24,6 @@ define i32 @ub_oob2() {
   %q = getelementptr i8, i8* %p8, i64 1
   %res = call i32 @memcmp(i8* %p8, i8* %q, i64 4) ; ub!
 	ret i32 %res
-}
-
-define i32 @ub_diffblocks() {
-  %p = alloca i32
-  %q = alloca i32
-  %p16 = bitcast i32* %p to i16*
-  %q16 = bitcast i32* %q to i16*
-  store i16 257, i16* %p16 ; 01 01 pp pp
-  store i16 257, i16* %q16 ; 01 01 pp pp
-  %p8 = bitcast i32* %p to i8*
-  %q8 = bitcast i32* %q to i8*
-  %res = call i32 @memcmp(i8* %p8, i8* %q8, i64 4)
-  %res2 = add i32 %res, %res
-  ret i32 %res2
 }
 
 declare i32 @memcmp(i8* nocapture, i8* nocapture, i64)

--- a/tests/alive-tv/memory/memcmp-ub.tgt.ll
+++ b/tests/alive-tv/memory/memcmp-ub.tgt.ll
@@ -1,13 +1,5 @@
 target datalayout = "e-p:64:64:64"
 
-define i32 @ub() {
-  unreachable
-}
-
-define i32 @ub2() {
-  unreachable
-}
-
 define i32 @ub_null() {
   unreachable
 }
@@ -17,10 +9,6 @@ define i32 @ub_oob() {
 }
 
 define i32 @ub_oob2() {
-  unreachable
-}
-
-define i32 @ub_diffblocks() {
   unreachable
 }
 


### PR DESCRIPTION
This fixes Transforms/MergeICmps/X86/multiple-blocks-does-work.ll .