### PR TITLE
Fix calloc's precondition is false error

### DIFF
--- a/ir/memory.cpp
+++ b/ir/memory.cpp
@@ -1394,7 +1394,7 @@ Memory::alloc(const expr &size, unsigned align, BlockKind blockKind,
 
       // addr + size does not overflow
       if (!size.uge(align).isFalse())
-        state->addPre(full_addr.add_no_uoverflow(size_zext));
+        state->addPre(allocated.implies(full_addr.add_no_uoverflow(size_zext)));
 
       // Disjointness of block's address range with other local blocks
       state->addPre(

--- a/tests/alive-tv/memory/calloc-overflow.srctgt.ll
+++ b/tests/alive-tv/memory/calloc-overflow.srctgt.ll
@@ -1,0 +1,19 @@
+target datalayout = "e-m:o-i64:64-f80:128-n8:16:32:64-S128"
+
+define i8 @src(i64 %num) {
+  %ptr = call noalias i8* @calloc(i64 555555555555555, i64 40000000)
+  %cmp = icmp eq i8* %ptr, null
+  br i1 %cmp, label %BB1, label %BB2
+BB1:
+  ret i8 0
+BB2:
+  ret i8 1
+}
+
+define i8 @tgt(i64 %num) {
+  ret i8 1
+}
+
+; ERROR: Value mismatch
+
+declare noalias i8* @calloc(i64, i64)

--- a/tests/alive-tv/memory/calloc-overflow.srctgt2.ll
+++ b/tests/alive-tv/memory/calloc-overflow.srctgt2.ll
@@ -1,12 +1,17 @@
 target datalayout = "e-m:o-i64:64-f80:128-n8:16:32:64-S128"
 
-define i8 @calloc_overflow(i64 %num) {
+define i8 @src(i64 %num) {
   %ptr = call noalias i8* @calloc(i64 555555555555555, i64 40000000)
+  %unused = ptrtoint i8* %ptr to i64
   %cmp = icmp eq i8* %ptr, null
   br i1 %cmp, label %BB1, label %BB2
 BB1:
   ret i8 0
 BB2:
+  ret i8 1
+}
+
+define i8 @tgt(i64 %num) {
   ret i8 1
 }
 

--- a/tests/alive-tv/memory/calloc-overflow.tgt.ll
+++ b/tests/alive-tv/memory/calloc-overflow.tgt.ll
@@ -1,6 +1,0 @@
-target datalayout = "e-m:o-i64:64-f80:128-n8:16:32:64-S128"
-
-define i8 @calloc_overflow(i64 %num) {
-  ret i8 1
-}
-


### PR DESCRIPTION
Without this fix, tests/alive-tv/memory/calloc-overflow.srctgt2.ll  raises precondition is false error.