### PR TITLE
Add support for nonnull attribute

### DIFF
--- a/ir/attrs.cpp
+++ b/ir/attrs.cpp
@@ -36,6 +36,8 @@ ostream& operator<<(ostream &os, const FnAttrs &attr) {
     os << " noreturn";
   if (attr.has(FnAttrs::Dereferenceable))
     os << " dereferenceable(" << attr.derefBytes << ")";
+  if (attr.has(FnAttrs::NonNull))
+    os << " nonnull";
   return os;
 }
 

--- a/ir/attrs.h
+++ b/ir/attrs.h
@@ -33,7 +33,7 @@ class FnAttrs final {
 public:
   enum Attribute { None = 0, NoRead = 1 << 0, NoWrite = 1 << 1,
                    ArgMemOnly = 1 << 2, NNaN = 1 << 3, NoReturn = 1 << 4,
-                   Dereferenceable = 1 << 5 };
+                   Dereferenceable = 1 << 5, NonNull = 1 << 6 };
 
   FnAttrs(unsigned bits = None) : bits(bits) {}
 

--- a/llvm_util/llvm2alive.cpp
+++ b/llvm_util/llvm2alive.cpp
@@ -272,6 +272,8 @@ public:
       attrs.set(FnAttrs::Dereferenceable);
       attrs.setDerefBytes(b);
     }
+    if (i.hasRetAttr(llvm::Attribute::NonNull))
+      attrs.set(FnAttrs::NonNull);
 
     string fn_name = '@' + fn->getName().str();
     auto call =
@@ -303,6 +305,9 @@ public:
 
       if (i.paramHasAttr(argidx, llvm::Attribute::ByVal))
         attr.set(ParamAttrs::ByVal);
+
+      if (i.paramHasAttr(argidx, llvm::Attribute::NonNull))
+        attr.set(ParamAttrs::NonNull);
 
       if (i.paramHasAttr(argidx, llvm::Attribute::Returned)) {
         auto call2
@@ -917,6 +922,8 @@ public:
       attrs.set(FnAttrs::Dereferenceable);
       attrs.setDerefBytes(b);
     }
+    if (f.hasAttribute(ridx, llvm::Attribute::NonNull))
+      attrs.set(FnAttrs::NonNull);
 
     // create all BBs upfront in topological order
     vector<pair<BasicBlock*, llvm::BasicBlock*>> sorted_bbs;

--- a/tests/alive-tv/attrs/nonnull-callsite.srctgt.ll
+++ b/tests/alive-tv/attrs/nonnull-callsite.srctgt.ll
@@ -1,0 +1,12 @@
+define i1 @src(i8* %p) {
+  call void @f(i8* nonnull %p)
+  %c = icmp eq i8* %p, null
+  ret i1 %c
+}
+
+define i1 @tgt(i8* %p) {
+  call void @f(i8* nonnull %p)
+  ret i1 0
+}
+
+declare void @f(i8*)

--- a/tests/alive-tv/attrs/nonnull-callsite2.srctgt.ll
+++ b/tests/alive-tv/attrs/nonnull-callsite2.srctgt.ll
@@ -1,0 +1,12 @@
+define i1 @src(i8* %p) {
+  call void @f(i8* %p)
+  %c = icmp eq i8* %p, null
+  ret i1 %c
+}
+
+define i1 @tgt(i8* %p) {
+  call void @f(i8* %p)
+  ret i1 0
+}
+
+declare void @f(i8* nonnull)

--- a/tests/alive-tv/attrs/nonnull-callsite3.srctgt.ll
+++ b/tests/alive-tv/attrs/nonnull-callsite3.srctgt.ll
@@ -1,0 +1,21 @@
+define void @src(i8* %p) {
+  %c = icmp ne i8* %p, null
+  br i1 %c, label %A, label %B
+A:
+  call void @f(i8* %p)
+  ret void
+B:
+  ret void
+}
+
+define void @tgt(i8* %p) {
+  %c = icmp ne i8* %p, null
+  br i1 %c, label %A, label %B
+A:
+  call void @f(i8* nonnull %p)
+  ret void
+B:
+  ret void
+}
+
+declare void @f(i8*)

--- a/tests/alive-tv/attrs/nonnull-callsite4.srctgt.ll
+++ b/tests/alive-tv/attrs/nonnull-callsite4.srctgt.ll
@@ -1,0 +1,10 @@
+define void @src(i8* %p) {
+  call void @f(i8* null)
+  ret void
+}
+
+define void @tgt(i8* %p) {
+  unreachable
+}
+
+declare void @f(i8* nonnull)

--- a/tests/alive-tv/attrs/nonnull-callsite5.srctgt.ll
+++ b/tests/alive-tv/attrs/nonnull-callsite5.srctgt.ll
@@ -1,0 +1,10 @@
+define void @src(i8* %p) {
+  call void @f(i8* undef)
+  ret void
+}
+
+define void @tgt(i8* %p) {
+  unreachable
+}
+
+declare void @f(i8* nonnull)

--- a/tests/alive-tv/attrs/nonnull-fndef.srctgt.ll
+++ b/tests/alive-tv/attrs/nonnull-fndef.srctgt.ll
@@ -1,0 +1,9 @@
+define nonnull i8* @src(i8* nonnull %p) {
+  ret i8* %p
+}
+
+define nonnull i8* @tgt(i8* nonnull %p) {
+  unreachable
+}
+
+; ERROR: Source is more defined than target

--- a/tests/alive-tv/attrs/nonnull-fndef2.srctgt.ll
+++ b/tests/alive-tv/attrs/nonnull-fndef2.srctgt.ll
@@ -1,0 +1,7 @@
+define nonnull i8* @src(i8* %p) {
+  ret i8* null
+}
+
+define nonnull i8* @tgt(i8* %p) {
+  unreachable
+}

--- a/tests/alive-tv/attrs/nonnull-ret-callsite.srctgt.ll
+++ b/tests/alive-tv/attrs/nonnull-ret-callsite.srctgt.ll
@@ -1,0 +1,12 @@
+define nonnull i8* @src() {
+  %p = call i8* @f()
+  ret i8* %p
+}
+
+define nonnull i8* @tgt() {
+  unreachable
+}
+
+; ERROR: Source is more defined than target
+
+declare nonnull i8* @f()


### PR DESCRIPTION
This adds support for nonnull attribute.

Resolves two failures:
```
Transforms/CorrelatedValuePropagation/basic.ll
Transforms/InstSimplify/compare.ll
```

This encodes  f(nonnull poison) as UB, because poison can be folded into null, making f(nonnull null), which is UB. 
Relevant issue: https://github.com/AliveToolkit/alive2/issues/289
There was a relevant thread in llvm-dev in the past, too.

This semantics may not explain a few existing optimizations. For example, we cannot say 'gep inbounds p, 1' is non-null.
But I think it is better to unsupport a few optimizations than breaking the general refinement from poison to a concrete value at this point...