### PR TITLE
Fix the bool flag value given to parse_assume

### DIFF
--- a/tests/unit/call-error6.opt
+++ b/tests/unit/call-error6.opt
@@ -18,4 +18,4 @@ ret i8 %d
 assume(false)
 ret i8 0
 
-; FIXME: this test should fail!
+; ERROR: Source is more defined than target

--- a/tools/alive_parser.cpp
+++ b/tools/alive_parser.cpp
@@ -1146,10 +1146,10 @@ static void parse_fn(Function &f) {
   while (true) {
     switch (auto t = *tokenizer) {
     case ASSUME:
-      bb->addInstr(parse_assume(true));
+      bb->addInstr(parse_assume(false));
       break;
     case ASSUME_NON_POISON:
-      bb->addInstr(parse_assume(false));
+      bb->addInstr(parse_assume(true));
       break;
     case LABEL:
       bb = &f.getBB(yylval.str);


### PR DESCRIPTION
I observed that `tests/unit/call-error6.opt` was printing `assume` and `assume_non_poison` in an inversed way, so I wonder whether the bool flag that is given to parse_assume should have been inversed.
With this fix, call-error6 successfully raises an error. call-error5 still passes silently, but this will be addressed in the other patch.