### PR TITLE
Factor out Memory::PtrInput class, put assertions in State's methods

### DIFF
--- a/ir/instr.cpp
+++ b/ir/instr.cpp
@@ -1327,7 +1327,7 @@ void FnCall::print(ostream &os) const {
 
 static void unpack_inputs(State&s, Type &ty, const ParamAttrs &argflag,
                           const StateValue &value, vector<StateValue> &inputs,
-                          vector<pair<StateValue, bool>> &ptr_inputs) {
+                          vector<Memory::PtrInput> &ptr_inputs) {
   if (auto agg = ty.getAsAggregateType()) {
     for (unsigned i = 0, e = agg->numElementsConst(); i != e; ++i) {
       unpack_inputs(s, agg->getChild(i), argflag, agg->extract(value, i),
@@ -1400,7 +1400,7 @@ StateValue FnCall::toSMT(State &s) const {
   }
 
   vector<StateValue> inputs;
-  vector<pair<StateValue, bool>> ptr_inputs;
+  vector<Memory::PtrInput> ptr_inputs;
   vector<Type*> out_types;
 
   ostringstream fnName_mangled;

--- a/ir/memory.h
+++ b/ir/memory.h
@@ -247,11 +247,21 @@ public:
   smt::expr mkInput(const char *name, const ParamAttrs &attrs) const;
   std::pair<smt::expr, smt::expr> mkUndefInput(const ParamAttrs &attrs) const;
 
+  struct PtrInput {
+    StateValue val;
+    bool byval;
+
+    PtrInput(StateValue &&v, bool byval) : val(std::move(v)), byval(byval) {}
+    bool operator<(const PtrInput &rhs) const {
+      return std::tie(val, byval) < std::tie(rhs.val, rhs.byval);
+    }
+  };
+
   std::pair<smt::expr, smt::expr>
     mkFnRet(const char *name,
-            const std::vector<std::pair<StateValue, bool>> &ptr_inputs) const;
+            const std::vector<PtrInput> &ptr_inputs) const;
   CallState
-    mkCallState(const std::vector<std::pair<StateValue, bool>> *ptr_inputs)
+    mkCallState(const std::vector<PtrInput> *ptr_inputs)
       const;
   void setState(const CallState &st);
 
@@ -296,7 +306,7 @@ public:
   std::pair<smt::expr,Pointer>
     refined(const Memory &other,
             bool skip_constants,
-            const std::vector<std::pair<StateValue, bool>> *set_ptrs = nullptr)
+            const std::vector<PtrInput> *set_ptrs = nullptr)
       const;
 
   // Returns true if a nocapture pointer byte is not in the memory.

--- a/ir/state.cpp
+++ b/ir/state.cpp
@@ -179,7 +179,6 @@ void State::addCondJump(const expr &cond, const BasicBlock &dst_true,
 }
 
 void State::addReturn(const StateValue &val) {
-  assert(current_bb);
   return_val.add(val, domain.path);
   return_memory.add(memory, domain.path);
   return_domain.add(domain());
@@ -191,27 +190,23 @@ void State::addReturn(const StateValue &val) {
 }
 
 void State::addUB(expr &&ub) {
-  assert(current_bb);
   domain.UB.add(move(ub));
   if (!ub.isConst())
     domain.undef_vars.insert(undef_vars.begin(), undef_vars.end());
 }
 
 void State::addUB(const expr &ub) {
-  assert(current_bb);
   domain.UB.add(ub);
   if (!ub.isConst())
     domain.undef_vars.insert(undef_vars.begin(), undef_vars.end());
 }
 
 void State::addUB(AndExpr &&ubs) {
-  assert(current_bb);
   domain.UB.add(ubs);
   domain.undef_vars.insert(undef_vars.begin(), undef_vars.end());
 }
 
 void State::addNoReturn() {
-  assert(current_bb);
   function_domain.add(domain());
   return_undef_vars.insert(undef_vars.begin(), undef_vars.end());
   return_undef_vars.insert(domain.undef_vars.begin(), domain.undef_vars.end());

--- a/ir/state.h
+++ b/ir/state.h
@@ -56,7 +56,7 @@ private:
   smt::AndExpr axioms;
   smt::AndExpr ooms;
 
-  const BasicBlock *current_bb;
+  const BasicBlock *current_bb = nullptr;
   std::set<smt::expr> quantified_vars;
 
   // var -> ((value, not_poison), undef_vars, already_used?)
@@ -91,8 +91,7 @@ private:
 
   struct FnCallInput {
     std::vector<StateValue> args_nonptr;
-    // (ptr arguments, is by_val arg?)
-    std::vector<std::pair<StateValue, bool>> args_ptr;
+    std::vector<Memory::PtrInput> args_ptr;
     Memory m;
     bool readsmem, argmemonly;
     bool operator<(const FnCallInput &rhs) const {
@@ -142,7 +141,7 @@ public:
 
   const std::vector<StateValue>
     addFnCall(const std::string &name, std::vector<StateValue> &&inputs,
-              std::vector<std::pair<StateValue, bool>> &&ptr_inputs,
+              std::vector<Memory::PtrInput> &&ptr_inputs,
               const std::vector<Type*> &out_types, const FnAttrs &attrs);
 
   void addQuantVar(const smt::expr &var);


### PR DESCRIPTION
To resolve https://web.ist.utl.pt/nuno.lopes/alive2/index.php?hash=4beb2b117e2fdd2c&test=Transforms%2FSink%2Fcall.ll in the future, ptr_inputs should have readonly flag too (currently it only has byval, and ptr_input is represented as a pair of StateValue and bool).
This PR factors out it as a Memory::PtrInput so it will have more fields like byval, readonly, etc.

Also, I put a few assertions into State's methods which should fail if current_bb was not set.