### PR TITLE
Memory and value refinement should be checked together if there's nondet. exec.

### DIFF
--- a/tests/alive-tv/refinement/nondet-fail.srctgt.ll
+++ b/tests/alive-tv/refinement/nondet-fail.srctgt.ll
@@ -1,0 +1,26 @@
+define i1 @src() {
+	%guard = freeze i1 undef
+	br i1 %guard, label %COMPARE, label %EXIT
+
+COMPARE:
+	call void @g()
+	ret i1 1
+
+EXIT:
+	ret i1 0
+}
+
+define i1 @tgt() {
+	%guard = freeze i1 undef
+	br i1 %guard, label %COMPARE, label %EXIT
+
+COMPARE:
+	ret i1 1
+
+EXIT:
+	ret i1 0
+}
+
+declare void @g()
+
+; ERROR: Mismatch in memory

--- a/tests/alive-tv/refinement/nondet-fail2.srctgt.ll
+++ b/tests/alive-tv/refinement/nondet-fail2.srctgt.ll
@@ -1,0 +1,27 @@
+define i1 @src() {
+	%guard = freeze i1 undef
+	br i1 %guard, label %COMPARE, label %EXIT
+
+COMPARE:
+	call void @g()
+	ret i1 1
+
+EXIT:
+	ret i1 0
+}
+
+define i1 @tgt() {
+	%guard = freeze i1 undef
+	br i1 %guard, label %COMPARE, label %EXIT
+
+COMPARE:
+	call void @g()
+	ret i1 0
+
+EXIT:
+	ret i1 1
+}
+
+declare void @g()
+
+; ERROR: Mismatch in memory

--- a/tools/transform.cpp
+++ b/tools/transform.cpp
@@ -328,8 +328,9 @@ check_refinement(Errors &errs, Transform &t, State &src_state, State &tgt_state,
 
   auto src_mem = src_state.returnMemory();
   auto tgt_mem = tgt_state.returnMemory();
-  auto [memory_cnstr, ptr_refinement0] = src_mem.refined(tgt_mem, false);
+  auto [memory_cnstr0, ptr_refinement0] = src_mem.refined(tgt_mem, false);
   auto &ptr_refinement = ptr_refinement0;
+  auto memory_cnstr = value_cnstr && memory_cnstr0;
 
   if (check_expr(axioms_expr && (pre_src && pre_tgt)).isUnsat()) {
     errs.add("Precondition is always false", false);


### PR DESCRIPTION
This resolves issue #385 , which happened because there was no entanglement between refinement of return value and refinement of final memory.
As the refinement formula becomes more complex, this causes slowdown in some cases; I added has_nondet_op which checks whether there is an operation that returns a nondeterministic value. If there is no nondet op, there is only a single execution given an input, so entanglement between the return value and final memory isn't needed.

Running LLVM unit tests...