### PR TITLE
Fix and extend dominators algorithm in function.h to support multi-root CFGs

### DIFF
--- a/ir/function.cpp
+++ b/ir/function.cpp
@@ -306,7 +306,7 @@ void DomTree::buildDominators() {
     (void)instr;
     // skip back-edges
     visited_src.insert(&src);
-    if (visited_src.find(&tgt) == visited_src.end())
+    if (!visited_src.count(&tgt))
       doms.at(&tgt).preds.push_back(&doms.at(&src));
   }
 

--- a/ir/function.h
+++ b/ir/function.h
@@ -198,7 +198,7 @@ class DomTree final {
     std::unordered_map<const BasicBlock*, DomTreeNode> doms;
 
     void buildDominators();
-    static DomTreeNode* intersect(DomTreeNode *b1, DomTreeNode *b2);
+    DomTreeNode* intersect(DomTreeNode *b1, DomTreeNode *b2);
 
   public:
     DomTree(Function &f, CFG &cfg) : f(f), cfg(cfg) { buildDominators(); }


### PR DESCRIPTION
The algorithm originally implemented by Cooper, Keith D.; Harvey, Timothy J.; and Kennedy, Ken (2001) in the paper http://www.cs.rice.edu/~keith/EMBED/dom.pdf had a flaw in which they assumed that two different basic blocks always have a common parent which is not the case when dead code exists.
I only made a couple of changes to the algorithm added in the pull request https://github.com/AliveToolkit/alive2/pull/304 such that dominator trees for bb's that have paths to them from program entry are correct, however it is not possible to guarantee the same for the bbs that are not reachable from program entry. This should not affect the ub algorithm in https://github.com/AliveToolkit/alive2/pull/369.

The main changes are ignoring back-edges, making sure that every block without predecessors is its own dominator, and prioritise returning the predecessor on the tree with root on program entry when intersect is called on two subtrees of BB's with no common root.  
I tested this together with the changes in https://github.com/AliveToolkit/alive2/pull/369 and everything is working correctly.
