### PR TITLE
Initialize has_alloca/has_dead_allocas, let may_be_nonlocal see select

### DIFF
--- a/ir/instr.h
+++ b/ir/instr.h
@@ -144,6 +144,9 @@ public:
   Select(Type &type, std::string &&name, Value &cond, Value &a, Value &b)
     : Instr(type, std::move(name)), cond(&cond), a(&a), b(&b) {}
 
+  Value *getTrueValue() const { return a; }
+  Value *getFalseValue() const { return b; }
+
   std::vector<Value*> operands() const override;
   void rauw(const Value &what, Value &with) override;
   void print(std::ostream &os) const override;

--- a/tools/transform.cpp
+++ b/tools/transform.cpp
@@ -439,6 +439,12 @@ static bool may_be_nonlocal(Value *ptr) {
         todo.emplace_back(op);
       continue;
     }
+
+    if (auto s = dynamic_cast<Select*>(ptr)) {
+      todo.emplace_back(s->getTrueValue());
+      todo.emplace_back(s->getFalseValue());
+      continue;
+    }
     return true;
 
   } while (!todo.empty());
@@ -497,6 +503,8 @@ static void calculateAndInitConstants(Transform &t) {
   bool nullptr_is_used = false;
   has_int2ptr      = false;
   has_ptr2int      = false;
+  has_alloca       = false;
+  has_dead_allocas = false;
   has_malloc       = false;
   has_free         = false;
   has_fncall       = false;


### PR DESCRIPTION
This is from #392 , with analysis-related part only.
There was a missing initialization for has_alloca/has_dead_allocas.
Also, may_be_nonlocal wasn't looking through select. 