### PR TITLE
Dereferenceable attr should update max_access_size

### DIFF
--- a/tests/alive-tv/attrs/dereferenceable2.srctgt.ll
+++ b/tests/alive-tv/attrs/dereferenceable2.srctgt.ll
@@ -1,0 +1,11 @@
+define float @src(<4 x float>* dereferenceable(15) %p) {
+  %bc = bitcast <4 x float>* %p to float*
+  %r = load float, float* %bc, align 16
+  ret float %r
+}
+
+define float @tgt(<4 x float>* dereferenceable(15) %p) {
+  %bc = getelementptr inbounds <4 x float>, <4 x float>* %p, i64 0, i64 0
+  %r = load float, float* %bc, align 16
+  ret float %r
+}

--- a/tools/transform.cpp
+++ b/tools/transform.cpp
@@ -529,8 +529,9 @@ static void calculateAndInitConstants(Transform &t) {
       auto *i = dynamic_cast<const Input *>(&v);
       if (i && i->hasAttribute(ParamAttrs::Dereferenceable)) {
         does_mem_access = true;
-        min_access_size = gcd(min_access_size,
-                              i->getAttributes().getDerefBytes());
+        uint64_t deref_bytes = i->getAttributes().getDerefBytes();
+        min_access_size = gcd(min_access_size, deref_bytes);
+        max_access_size = max(max_access_size, deref_bytes);
       }
     }
 


### PR DESCRIPTION
This is a simple patch that resolves `precondition is false` error that happens when a dereferenceable attribute is used with a big alignment.