### PR TITLE
Add undef vars that are registered to the stored value only

### DIFF
--- a/ir/instr.cpp
+++ b/ir/instr.cpp
@@ -2517,7 +2517,8 @@ void Store::print(std::ostream &os) const {
 StateValue Store::toSMT(State &s) const {
   auto &[p, np] = s[*ptr];
   s.addUB(np);
-  s.getMemory().store(p, s[*val], val->getType(), align, s.getUndefVars());
+  auto &sv = s[*val];
+  s.getMemory().store(p, sv, val->getType(), align, s.getUndefVars(*val));
   return {};
 }
 
@@ -2564,8 +2565,9 @@ StateValue Memset::toSMT(State &s) const {
   auto &[vbytes, np_bytes] = s[*bytes];
   s.addUB((vbytes != 0).implies(np_ptr));
   s.addUB(np_bytes);
-  s.getMemory().memset(vptr, s[*val].zextOrTrunc(8), vbytes, align,
-                       s.getUndefVars());
+  auto &sv = s[*val];
+  s.getMemory().memset(vptr, sv.zextOrTrunc(8), vbytes, align,
+                       s.getUndefVars(*val));
   return {};
 }
 

--- a/ir/state.cpp
+++ b/ir/state.cpp
@@ -287,6 +287,10 @@ void State::addUndefVar(expr &&var) {
   undef_vars.emplace(move(var));
 }
 
+const std::set<smt::expr>& State::getUndefVars(const Value &val) const {
+  return std::get<1>(values[values_map.at(&val)]).second;
+}
+
 void State::resetUndefVars() {
   quantified_vars.insert(undef_vars.begin(), undef_vars.end());
   undef_vars.clear();

--- a/ir/state.h
+++ b/ir/state.h
@@ -147,6 +147,7 @@ public:
   void addQuantVar(const smt::expr &var);
   void addUndefVar(smt::expr &&var);
   auto& getUndefVars() const { return undef_vars; }
+  const std::set<smt::expr>& getUndefVars(const Value &val) const;
   void resetUndefVars();
 
   StateValue rewriteUndef(StateValue &&val,


### PR DESCRIPTION
IIUC Memory::store's `undef_vars` argument takes undef variables that are used by the stored value only.

This PR makes it explicit.

Reduces preprocessing time of a few function pairs including [bzip2-slow.zip](https://github.com/AliveToolkit/alive2/files/4734074/bzip2-slow.zip)
