### PR TITLE
Let blockValRefined's expr::load stop looking into const initializer mem

### DIFF
--- a/ir/memory.h
+++ b/ir/memory.h
@@ -194,6 +194,7 @@ class Memory {
   State *state;
 
   smt::expr non_local_block_val;  // array: (bid, offset) -> Byte
+  smt::expr non_local_block_val_var;
   smt::expr local_block_val;
   smt::expr initial_non_local_block_val;
 
@@ -226,6 +227,7 @@ public:
   class CallState {
     smt::expr non_local_block_val;
     smt::expr block_val_var;
+    smt::expr initial_non_local_block_val;
     smt::expr non_local_block_liveness;
     smt::expr liveness_var;
     bool empty = true;

--- a/smt/expr.cpp
+++ b/smt/expr.cpp
@@ -1488,8 +1488,11 @@ expr expr::store(const expr &idx, const expr &val) const {
   return Z3_mk_store(ctx(), ast(), idx(), val());
 }
 
-expr expr::load(const expr &idx) const {
+expr expr::load(const expr &idx, const expr *stop_simplifying_if) const {
   C(idx);
+
+  if (stop_simplifying_if && stop_simplifying_if->eq(*this))
+    return Z3_mk_select(ctx(), ast(), idx());
 
   // TODO: add support for alias analysis plugin
   expr array, str_idx, val;
@@ -1498,7 +1501,7 @@ expr expr::load(const expr &idx) const {
     if (cmp.isTrue())
       return val;
     if (cmp.isFalse())
-      return array.load(idx);
+      return array.load(idx, stop_simplifying_if);
 
   } else if (isConstArray(val)) {
     return val;

--- a/smt/expr.h
+++ b/smt/expr.h
@@ -291,7 +291,7 @@ public:
   static expr mkConstArray(const expr &domain, const expr &value);
 
   expr store(const expr &idx, const expr &val) const;
-  expr load(const expr &idx) const;
+  expr load(const expr &idx, const expr *stop_simplifying_if = nullptr) const;
 
   static expr mkIf(const expr &cond, const expr &then, const expr &els);
   static expr mkForAll(const std::set<expr> &vars, expr &&val);


### PR DESCRIPTION
I remember that this issue was mentioned before: this is my suggested solution.

expr::load can recursively call a load on a subexpression if it is store and known that the key does not match.
But, if there are many stores nested inside, the calls can go deep, causing long preprocessing time.
This can especially happen when there are many constant initializers such as string literals.

This PR adds an argument to expr::load so it stops simplification if the expression is structurally equivalent to it. This can be used at Memory:: blockValRefined, as this PR does.
When Memory::refined is called with skip_constants = true, looking through constant initializers is not necessary.

[bzip2-slow2.zip](https://github.com/AliveToolkit/alive2/files/4737974/bzip2-slow2.zip)
