### PR TITLE
Missing option for CMake

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ ninja
 ```
 
 If CMake cannot find the Z3 include directory (or finds the wrong one) pass
-the ``-DZ3_INCLUDE_DIR=/path/to/z3/include`` argument to CMake
+the ``-DZ3_INCLUDE_DIR=/path/to/z3/include`` and ``-DZ3_LIBRARIES=/path/to/z3/lib/libz3.so`` arguments to CMake.
 
 
 Building and Running Translation Validation


### PR DESCRIPTION
If CMake is not found, `Z3_LIBRARIES` also needs to be set along with `Z3_INCLUDE_DIR`. If not, configure and build fails.