### PR TITLE
Fix clang-tv build with latest LLVM

### DIFF
--- a/tv/tv.cpp
+++ b/tv/tv.cpp
@@ -353,9 +353,10 @@ llvmGetPassPluginInfo() {
         [](llvm::ModulePassManager &MPM) { MPM.addPass(TVInitPass()); }
       );
       PB.registerOptimizerLastEPCallback(
-        [](llvm::FunctionPassManager &FPM, llvm::PassBuilder::OptimizationLevel)
-        { FPM.addPass(TVFinalizePass()); }
-      );
+          [](llvm::ModulePassManager &MPM,
+             llvm::PassBuilder::OptimizationLevel) {
+            MPM.addPass(createModuleToFunctionPassAdaptor(TVFinalizePass()));
+          });
       auto f = [](llvm::StringRef P, llvm::Any IR) {
         static int count = 0;
         if (!out) {


### PR DESCRIPTION
After https://reviews.llvm.org/D80692 / https://github.com/llvm/llvm-project/commit/1285e8bcac2c54ddd924ffb813b2b187467ac2a6
`registerOptimizerLastEPCallback()` expects `ModulePassManager`,
not `FunctionPassManager`, so a workaround/update is needed.