### PR TITLE
set build RPATH so we can find z3 in non-standard locations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,9 @@ endif()
 
 message(STATUS "Build type: ${CMAKE_BUILD_TYPE}")
 
+set(CMAKE_INSTALL_RPATH_USE_LINK_PATH ON)
+set(CMAKE_BUILD_WITH_INSTALL_RPATH ON)
+
 if (MSVC)
   set(CMAKE_CXX_FLAGS                "/GL /EHsc /W2 ${CMAKE_CXX_FLAGS}")
   set(CMAKE_CXX_FLAGS_DEBUG          "/Od /Zi ${CMAKE_CXX_FLAGS_DEBUG}")


### PR DESCRIPTION
so forever I have not been able to get alive2 to find libz3.so (at runtime, not cmake time) unless that library is in a standard location like /usr/lib. recently I had to fix similar issues in souper, so figured I'd fix them here as well. this tells CMake to set the RPATH of build products so that libraries can be found at runtime.