### PR TITLE
Add nofree attribute

### DIFF
--- a/ir/attrs.cpp
+++ b/ir/attrs.cpp
@@ -38,6 +38,8 @@ ostream& operator<<(ostream &os, const FnAttrs &attr) {
     os << " dereferenceable(" << attr.derefBytes << ")";
   if (attr.has(FnAttrs::NonNull))
     os << " nonnull";
+  if (attr.has(FnAttrs::NoFree))
+    os << " nofree";
   return os;
 }
 

--- a/ir/attrs.h
+++ b/ir/attrs.h
@@ -33,7 +33,8 @@ class FnAttrs final {
 public:
   enum Attribute { None = 0, NoRead = 1 << 0, NoWrite = 1 << 1,
                    ArgMemOnly = 1 << 2, NNaN = 1 << 3, NoReturn = 1 << 4,
-                   Dereferenceable = 1 << 5, NonNull = 1 << 6 };
+                   Dereferenceable = 1 << 5, NonNull = 1 << 6,
+                   NoFree = 1 << 7 };
 
   FnAttrs(unsigned bits = None) : bits(bits) {}
 

--- a/ir/instr.cpp
+++ b/ir/instr.cpp
@@ -2385,6 +2385,10 @@ StateValue Free::toSMT(State &s) const {
   s.addUB(np);
   // If not heaponly, don't encode constraints
   s.getMemory().free(p, !heaponly);
+
+  if (s.getFn().getFnAttrs().has(FnAttrs::NoFree) && heaponly)
+    s.addUB(expr(false));
+
   return {};
 }
 

--- a/ir/memory.cpp
+++ b/ir/memory.cpp
@@ -707,7 +707,7 @@ expr Pointer::isBlockAlive() const {
   // If programs have no free(), we assume all blocks are always live.
   // For non-local blocks, there's enough non-determinism through block size,
   // that can be 0 or non-0
-  if (!has_free && !has_fncall && !has_dead_allocas)
+  if (!has_free && !has_dead_allocas)
     return true;
 
   // globals are always live
@@ -728,7 +728,7 @@ expr Pointer::getAllocType() const {
   // If programs have no malloc & free, we don't need to store this information
   // since it is only used to check if free/delete is ok and
   // for memory refinement of local malloc'ed blocks
-  if (!has_malloc && !has_free && !has_fncall && !has_alloca)
+  if (!has_malloc && !has_free && !has_alloca)
     return expr::mkUInt(GLOBAL, 2);
 
   // if malloc is used, but no free, we can still ignore info for non-locals

--- a/ir/memory.cpp
+++ b/ir/memory.cpp
@@ -1295,7 +1295,6 @@ Memory::mkCallState(const vector<PtrInput> *ptr_inputs, bool nofree) const {
                                   non_local_block_val.load(idx)));
   }
 
-  st.non_local_block_liveness = non_local_block_liveness;
   if (num_nonlocals_src && !nofree) {
     expr one  = expr::mkUInt(1, num_nonlocals);
     expr zero = expr::mkUInt(0, num_nonlocals);
@@ -1316,7 +1315,9 @@ Memory::mkCallState(const vector<PtrInput> *ptr_inputs, bool nofree) const {
                                one << expr::mkUInt(bid, num_nonlocals));
     }
 
-    if (!mask.isAllOnes()) {
+    if (mask.isAllOnes()) {
+      st.non_local_block_liveness = non_local_block_liveness;
+    } else {
       st.liveness_var = expr::mkFreshVar("blk_liveness", mk_liveness_array());
       // functions can free an object, but cannot bring a dead one back to live
       st.non_local_block_liveness

--- a/ir/memory.h
+++ b/ir/memory.h
@@ -260,7 +260,8 @@ public:
   std::pair<smt::expr, smt::expr>
     mkFnRet(const char *name,
             const std::vector<PtrInput> &ptr_inputs) const;
-  CallState mkCallState(const std::vector<PtrInput> *ptr_inputs) const;
+  CallState mkCallState(const std::vector<PtrInput> *ptr_inputs, bool nofree)
+      const;
   void setState(const CallState &st);
 
   // Allocates a new memory block and returns (pointer expr, allocated).
@@ -309,6 +310,7 @@ public:
 
   // Returns true if a nocapture pointer byte is not in the memory.
   smt::expr checkNocapture() const;
+  smt::expr checkNoFree(const CallState &state_after) const;
 
   unsigned numLocals() const;
   unsigned numNonlocals() const;

--- a/llvm_util/llvm2alive.cpp
+++ b/llvm_util/llvm2alive.cpp
@@ -250,11 +250,14 @@ public:
       return error(i);
 
     FnAttrs attrs;
-    if (i.hasFnAttr(llvm::Attribute::ReadOnly))
+    if (i.hasFnAttr(llvm::Attribute::ReadOnly)) {
       attrs.set(FnAttrs::NoWrite);
+      attrs.set(FnAttrs::NoFree);
+    }
     if (i.hasFnAttr(llvm::Attribute::ReadNone)) {
       attrs.set(FnAttrs::NoRead);
       attrs.set(FnAttrs::NoWrite);
+      attrs.set(FnAttrs::NoFree);
     }
     if (i.hasFnAttr(llvm::Attribute::WriteOnly))
       attrs.set(FnAttrs::NoRead);
@@ -262,6 +265,8 @@ public:
       attrs.set(FnAttrs::ArgMemOnly);
     if (i.hasFnAttr(llvm::Attribute::NoReturn))
       attrs.set(FnAttrs::NoReturn);
+    if (i.hasFnAttr(llvm::Attribute::NoFree))
+      attrs.set(FnAttrs::NoFree);
     if (auto op = dyn_cast<llvm::FPMathOperator>(&i)) {
       if (op->hasNoNaNs())
         attrs.set(FnAttrs::NNaN);
@@ -941,6 +946,9 @@ public:
     }
 
     auto &attrs = Fn.getFnAttrs();
+    if (f.hasFnAttribute(llvm::Attribute::NoFree))
+      attrs.set(FnAttrs::NoFree);
+
     const auto &ridx = llvm::AttributeList::ReturnIndex;
     if (uint64_t b = f.getDereferenceableBytes(ridx)) {
       attrs.set(FnAttrs::Dereferenceable);

--- a/tests/alive-tv/attrs/dereferenceable-callsite-fail.srctgt.ll
+++ b/tests/alive-tv/attrs/dereferenceable-callsite-fail.srctgt.ll
@@ -1,20 +1,23 @@
+; dereferenceable attribute does not guarantee that the pointer is unfreed
+
 define i32 @src(i1 %c, i32* %p) {
 ENTRY:
+  call void @f(i32* %p)
   br i1 %c, label %A, label %EXIT
 A:
   %v1 = load i32, i32* %p
   br label %EXIT
 EXIT:
   %val = phi i32 [%v1, %A], [0, %ENTRY]
-  call void @f(i32* dereferenceable(4) %p)
   ret i32 %val
 }
 
 define i32 @tgt(i1 %c, i32* %p) {
+  call void @f(i32* %p)
   %v1 = load i32, i32* %p
   %val = select i1 %c, i32 %v1, i32 0
-  call void @f(i32* dereferenceable(4) %p)
   ret i32 %val
 }
 
-declare void @f(i32* %ptr)
+; ERROR: Source is more defined than target
+declare void @f(i32* dereferenceable(4) %ptr)

--- a/tests/alive-tv/attrs/dereferenceable-callsite-max.srctgt.ll
+++ b/tests/alive-tv/attrs/dereferenceable-callsite-max.srctgt.ll
@@ -1,19 +1,19 @@
 define i32 @src(i1 %c, i32* %p) {
 ENTRY:
-  call void @f(i32* dereferenceable(4) %p)
   br i1 %c, label %A, label %EXIT
 A:
   %v1 = load i32, i32* %p
   br label %EXIT
 EXIT:
   %val = phi i32 [%v1, %A], [0, %ENTRY]
+  call void @f(i32* dereferenceable(4) %p)
   ret i32 %val
 }
 
 define i32 @tgt(i1 %c, i32* %p) {
-  call void @f(i32* dereferenceable(4) %p)
   %v1 = load i32, i32* %p
   %val = select i1 %c, i32 %v1, i32 0
+  call void @f(i32* dereferenceable(4) %p)
   ret i32 %val
 }
 

--- a/tests/alive-tv/attrs/dereferenceable-callsite2.srctgt.ll
+++ b/tests/alive-tv/attrs/dereferenceable-callsite2.srctgt.ll
@@ -1,19 +1,19 @@
 define i32 @src(i1 %c, i32* %p) {
 ENTRY:
-  call void @f(i32* %p)
   br i1 %c, label %A, label %EXIT
 A:
   %v1 = load i32, i32* %p
   br label %EXIT
 EXIT:
   %val = phi i32 [%v1, %A], [0, %ENTRY]
+  call void @f(i32* %p)
   ret i32 %val
 }
 
 define i32 @tgt(i1 %c, i32* %p) {
-  call void @f(i32* %p)
   %v1 = load i32, i32* %p
   %val = select i1 %c, i32 %v1, i32 0
+  call void @f(i32* %p)
   ret i32 %val
 }
 

--- a/tests/alive-tv/attrs/dereferenceable-nofree.srctgt.ll
+++ b/tests/alive-tv/attrs/dereferenceable-nofree.srctgt.ll
@@ -1,20 +1,20 @@
 define i32 @src(i1 %c, i32* %p) {
 ENTRY:
+  call void @f(i32* %p)
   br i1 %c, label %A, label %EXIT
 A:
   %v1 = load i32, i32* %p
   br label %EXIT
 EXIT:
   %val = phi i32 [%v1, %A], [0, %ENTRY]
-  call void @f(i32* dereferenceable(4) %p)
   ret i32 %val
 }
 
 define i32 @tgt(i1 %c, i32* %p) {
+  call void @f(i32* %p)
   %v1 = load i32, i32* %p
   %val = select i1 %c, i32 %v1, i32 0
-  call void @f(i32* dereferenceable(4) %p)
   ret i32 %val
 }
 
-declare void @f(i32* %ptr)
+declare void @f(i32* dereferenceable(4) %ptr) nofree

--- a/tests/alive-tv/attrs/nofree.srctgt.ll
+++ b/tests/alive-tv/attrs/nofree.srctgt.ll
@@ -1,0 +1,20 @@
+define void @src(i1 %c) nofree {
+  %p = call i8* @malloc(i64 4)
+  br i1 %c, label %A, label %EXIT
+A:
+  call void @free(i8* %p)
+  br label %EXIT
+EXIT:
+  ret void
+}
+
+define void @tgt(i1 %c) nofree {
+  %p = call i8* @malloc(i64 4)
+  call void @free(i8* %p)
+  ret void
+}
+
+; ERROR: Source is more defined than target
+
+declare void @free(i8*)
+declare i8* @malloc(i64)

--- a/tools/transform.cpp
+++ b/tools/transform.cpp
@@ -560,7 +560,10 @@ static void calculateAndInitConstants(Transform &t) {
           nullptr_is_used |= has_nullptr(op);
         }
 
-        has_fncall |= dynamic_cast<const FnCall*>(&i) != nullptr;
+        if (auto *fc = dynamic_cast<const FnCall*>(&i)) {
+          has_fncall |= true;
+          has_free   |= !fc->getAttributes().has(FnAttrs::NoFree);
+        }
 
         if (auto *mi = dynamic_cast<const MemInstr *>(&i)) {
           max_alloc_size  = max(max_alloc_size, mi->getMaxAllocSize());


### PR DESCRIPTION
This addresses #412.

Running this with LLVM unit test raises two failures, but this seems to be a pre-existing bug in Alive2. I'll write down the details at #412.