### PR TITLE
PtrType::refines should use returnMemory()

### DIFF
--- a/ir/type.cpp
+++ b/ir/type.cpp
@@ -644,8 +644,9 @@ StateValue PtrType::fromInt(StateValue v) const {
 pair<expr, expr>
 PtrType::refines(State &src_s, State &tgt_s, const StateValue &src,
                  const StateValue &tgt) const {
-  Pointer p(src_s.getMemory(), src.value);
-  Pointer q(tgt_s.getMemory(), tgt.value);
+  auto sm = src_s.returnMemory(), tm = tgt_s.returnMemory();
+  Pointer p(sm, src.value);
+  Pointer q(tm, tgt.value);
 
   return { src.non_poison.implies(tgt.non_poison),
            (src.non_poison && tgt.non_poison).implies(p.refined(q)) };

--- a/tests/alive-tv/refinement/ptr-returnmemory.srctgt.ll
+++ b/tests/alive-tv/refinement/ptr-returnmemory.srctgt.ll
@@ -1,0 +1,30 @@
+define i8* @src(i1 %cond, i8* %a, i8* %b, i8* %dummy) {
+  call void @free(i8* %dummy) ; dummy free
+
+  br i1 %cond, label %A, label %B
+A:
+  %c1 = call i8* @callee2(i8* %a)
+  ret i8* %c1
+B:
+  %c2 = call i8* @callee2(i8* %b)
+  ret i8* %c2
+}
+
+define i8* @tgt(i1 %cond, i8* %a, i8* %b, i8* %dummy) {
+  call void @free(i8* %dummy) ; dummy free
+
+  br i1 %cond, label %A, label %B
+A:
+  %c1 = call i8* @callee2(i8* %a)
+  br label %EXIT
+B:
+  %c2 = call i8* @callee2(i8* %b)
+  br label %EXIT
+EXIT:
+  %cc = phi i8* [%c1, %A], [%c2, %B]
+  ret i8* %cc
+}
+
+
+declare i8* @callee2(i8*)
+declare void @free(i8*)


### PR DESCRIPTION
PtrType::refines should use returnMemory().
Found this bug while investigating https://github.com/AliveToolkit/alive2/issues/412#issuecomment-640274035

Running LLVM unit tests to see its impact