### PR TITLE
add memory model tests; these are parameterized by block size, not bitwidth

### DIFF
--- a/scripts/perf-testing/negative/memcpy1.ll
+++ b/scripts/perf-testing/negative/memcpy1.ll
@@ -1,0 +1,17 @@
+declare void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
+declare i32 @memcmp(i8* nocapture, i8* nocapture, i64)
+
+define i32 @src(i8*) {
+  %p1 = alloca [X x i8]
+  %p2 = bitcast [X x i8]* %p1 to i8*
+  call void @llvm.memcpy.p0i8.p0i8.i32(i8* %p2, i8* %0, i32 X, i1 0)
+  %p3 = getelementptr inbounds i8, i8* %p2, i32 2
+  store i8 0, i8* %p3
+  %r = call i32 @memcmp(i8* %p2, i8* %0, i64 X)
+  ret i32 %r
+}
+
+define i32 @tgt(i8*) {
+  ret i32 0
+}
+

--- a/scripts/perf-testing/negative/memcpy2.ll
+++ b/scripts/perf-testing/negative/memcpy2.ll
@@ -1,0 +1,20 @@
+declare void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
+declare i32 @memcmp(i8* nocapture, i8* nocapture, i64)
+
+define i32 @src(i8*) {
+  %p1 = alloca [X x i8]
+  %p2 = bitcast [X x i8]* %p1 to i8*
+  %p3 = alloca [X x i8]
+  %p4 = bitcast [X x i8]* %p3 to i8*
+  %sub = sub i32 X, 1
+  call void @llvm.memcpy.p0i8.p0i8.i32(i8* %p2, i8* %0, i32 X, i1 0)
+  %p5 = getelementptr inbounds i8, i8* %p4, i32 1
+  call void @llvm.memcpy.p0i8.p0i8.i32(i8* %p5, i8* %0, i32 %sub, i1 0)
+  %r = call i32 @memcmp(i8* %p2, i8* %p4, i64 X)
+  ret i32 %r
+}
+
+define i32 @tgt(i8*) {
+  ret i32 0
+}
+

--- a/scripts/perf-testing/negative/memcpy3.ll
+++ b/scripts/perf-testing/negative/memcpy3.ll
@@ -1,0 +1,20 @@
+declare void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
+declare i32 @memcmp(i8* nocapture, i8* nocapture, i64)
+
+define i32 @src(i8*) {
+  %p2 = alloca i8, i32 X
+  %p4 = alloca i8, i32 X
+  %p5 = getelementptr inbounds i8, i8* %p2, i32 2
+  %p6 = getelementptr inbounds i8, i8* %p4, i32 2
+  call void @llvm.memcpy.p0i8.p0i8.i32(i8* %p2, i8* %0, i32 X, i1 0)
+  call void @llvm.memcpy.p0i8.p0i8.i32(i8* %p4, i8* %0, i32 X, i1 0)
+  store i8 77, i8* %p5
+  store i8 55, i8* %p6
+  %r = call i32 @memcmp(i8* %p2, i8* %p4, i64 X)
+  ret i32 %r
+}
+
+define i32 @tgt(i8*) {
+  ret i32 0
+}
+

--- a/scripts/perf-testing/negative/memcpy4.ll
+++ b/scripts/perf-testing/negative/memcpy4.ll
@@ -1,0 +1,21 @@
+declare void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
+declare i32 @memcmp(i8* nocapture, i8* nocapture, i64)
+
+define i32 @src(i8*) {
+  %p1 = alloca [X x i8]
+  %p2 = bitcast [X x i8]* %p1 to i8*
+  %p3 = alloca [X x i8]
+  %p4 = bitcast [X x i8]* %p3 to i8*
+  %p5 = getelementptr inbounds i8, i8* %p2, i32 2
+  %p6 = getelementptr inbounds i8, i8* %p4, i32 2
+  call void @llvm.memcpy.p0i8.p0i8.i32(i8* %p2, i8* %0, i32 X, i1 0)
+  call void @llvm.memcpy.p0i8.p0i8.i32(i8* %p4, i8* %0, i32 X, i1 0)
+  store i8 77, i8* %p6
+  %r = call i32 @memcmp(i8* %p2, i8* %p4, i64 X)
+  ret i32 %r
+}
+
+define i32 @tgt(i8*) {
+  ret i32 0
+}
+

--- a/scripts/perf-testing/negative/memcpy5.ll
+++ b/scripts/perf-testing/negative/memcpy5.ll
@@ -1,0 +1,22 @@
+declare void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
+declare i32 @memcmp(i8* nocapture, i8* nocapture, i64)
+
+@a = external global [X x i8]
+@b = external global [X x i8]
+
+define i32 @src() {
+  %p1 = bitcast [X x i8]* @a to i8*
+  %p2 = bitcast [X x i8]* @b to i8*
+  call void @llvm.memcpy.p0i8.p0i8.i32(i8* %p1, i8* %p2, i32 X, i1 0)
+  %r = call i32 @memcmp(i8* %p1, i8* %p2, i64 X)
+  ret i32 %r
+}
+
+define i32 @tgt() {
+  %p1 = bitcast [X x i8]* @a to i8*
+  %p2 = bitcast [X x i8]* @b to i8*
+  %sub = sub i32 X, 1
+  call void @llvm.memcpy.p0i8.p0i8.i32(i8* %p1, i8* %p2, i32 %sub, i1 0)
+  ret i32 0
+}
+

--- a/scripts/perf-testing/negative/memcpy6.ll
+++ b/scripts/perf-testing/negative/memcpy6.ll
@@ -1,0 +1,15 @@
+declare void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
+declare i32 @memcmp(i8* nocapture, i8* nocapture, i64)
+
+define i32 @src(i8*, i8*) {
+  %sub = sub i32 X, 2
+  call void @llvm.memcpy.p0i8.p0i8.i32(i8* %0, i8* %1, i32 %sub, i1 0)
+  %r = call i32 @memcmp(i8* %1, i8* %0, i64 X)
+  ret i32 %r
+}
+
+define i32 @tgt(i8*, i8*) {
+  call void @llvm.memcpy.p0i8.p0i8.i32(i8* %0, i8* %1, i32 X, i1 0)
+  ret i32 0
+}
+

--- a/scripts/perf-testing/positive/memcpy1.ll
+++ b/scripts/perf-testing/positive/memcpy1.ll
@@ -1,0 +1,15 @@
+declare void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
+declare i32 @memcmp(i8* nocapture, i8* nocapture, i64)
+
+define i32 @src(i8*) {
+  %p1 = alloca [X x i8]
+  %p2 = bitcast [X x i8]* %p1 to i8*
+  call void @llvm.memcpy.p0i8.p0i8.i32(i8* %p2, i8* %0, i32 X, i1 0)
+  %r = call i32 @memcmp(i8* %p2, i8* %0, i64 X)
+  ret i32 %r
+}
+
+define i32 @tgt(i8*) {
+  ret i32 0
+}
+

--- a/scripts/perf-testing/positive/memcpy2.ll
+++ b/scripts/perf-testing/positive/memcpy2.ll
@@ -1,0 +1,18 @@
+declare void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
+declare i32 @memcmp(i8* nocapture, i8* nocapture, i64)
+
+define i32 @src(i8*) {
+  %p1 = alloca [X x i8]
+  %p2 = bitcast [X x i8]* %p1 to i8*
+  %p3 = alloca [X x i8]
+  %p4 = bitcast [X x i8]* %p3 to i8*
+  call void @llvm.memcpy.p0i8.p0i8.i32(i8* %p2, i8* %0, i32 X, i1 0)
+  call void @llvm.memcpy.p0i8.p0i8.i32(i8* %p4, i8* %0, i32 X, i1 0)
+  %r = call i32 @memcmp(i8* %p2, i8* %p4, i64 X)
+  ret i32 %r
+}
+
+define i32 @tgt(i8*) {
+  ret i32 0
+}
+

--- a/scripts/perf-testing/positive/memcpy3.ll
+++ b/scripts/perf-testing/positive/memcpy3.ll
@@ -1,0 +1,20 @@
+declare void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
+declare i32 @memcmp(i8* nocapture, i8* nocapture, i64)
+
+define i32 @src(i8*) {
+  %p2 = alloca i8, i32 X
+  %p4 = alloca i8, i32 X
+  %p5 = getelementptr inbounds i8, i8* %p2, i32 2
+  %p6 = getelementptr inbounds i8, i8* %p4, i32 2
+  call void @llvm.memcpy.p0i8.p0i8.i32(i8* %p2, i8* %0, i32 X, i1 0)
+  call void @llvm.memcpy.p0i8.p0i8.i32(i8* %p4, i8* %0, i32 X, i1 0)
+  store i8 77, i8* %p5
+  store i8 77, i8* %p6
+  %r = call i32 @memcmp(i8* %p2, i8* %p4, i64 X)
+  ret i32 %r
+}
+
+define i32 @tgt(i8*) {
+  ret i32 0
+}
+

--- a/scripts/perf-testing/positive/memcpy4.ll
+++ b/scripts/perf-testing/positive/memcpy4.ll
@@ -1,0 +1,22 @@
+declare void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
+declare i32 @memcmp(i8* nocapture, i8* nocapture, i64)
+
+define i32 @src(i8*) {
+  %p1 = alloca [X x i8]
+  %p2 = bitcast [X x i8]* %p1 to i8*
+  %p3 = alloca [X x i8]
+  %p4 = bitcast [X x i8]* %p3 to i8*
+  %p5 = getelementptr inbounds i8, i8* %p2, i32 2
+  %p6 = getelementptr inbounds i8, i8* %p4, i32 2
+  call void @llvm.memcpy.p0i8.p0i8.i32(i8* %p2, i8* %0, i32 X, i1 0)
+  call void @llvm.memcpy.p0i8.p0i8.i32(i8* %p4, i8* %0, i32 X, i1 0)
+  store i8 77, i8* %p5
+  store i8 77, i8* %p6
+  %r = call i32 @memcmp(i8* %p2, i8* %p4, i64 X)
+  ret i32 %r
+}
+
+define i32 @tgt(i8*) {
+  ret i32 0
+}
+

--- a/scripts/perf-testing/positive/memcpy5.ll
+++ b/scripts/perf-testing/positive/memcpy5.ll
@@ -1,0 +1,21 @@
+declare void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
+declare i32 @memcmp(i8* nocapture, i8* nocapture, i64)
+
+@a = external global [X x i8]
+@b = external global [X x i8]
+
+define i32 @src() {
+  %p1 = bitcast [X x i8]* @a to i8*
+  %p2 = bitcast [X x i8]* @b to i8*
+  call void @llvm.memcpy.p0i8.p0i8.i32(i8* %p1, i8* %p2, i32 X, i1 0)
+  %r = call i32 @memcmp(i8* %p1, i8* %p2, i64 X)
+  ret i32 %r
+}
+
+define i32 @tgt() {
+  %p1 = bitcast [X x i8]* @a to i8*
+  %p2 = bitcast [X x i8]* @b to i8*
+  call void @llvm.memcpy.p0i8.p0i8.i32(i8* %p1, i8* %p2, i32 X, i1 0)
+  ret i32 0
+}
+

--- a/scripts/perf-testing/positive/memcpy6.ll
+++ b/scripts/perf-testing/positive/memcpy6.ll
@@ -1,0 +1,14 @@
+declare void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
+declare i32 @memcmp(i8* nocapture, i8* nocapture, i64)
+
+define i32 @src(i8*, i8*) {
+  call void @llvm.memcpy.p0i8.p0i8.i32(i8* %0, i8* %1, i32 X, i1 0)
+  %r = call i32 @memcmp(i8* %1, i8* %0, i64 X)
+  ret i32 %r
+}
+
+define i32 @tgt(i8*, i8*) {
+  call void @llvm.memcpy.p0i8.p0i8.i32(i8* %0, i8* %1, i32 X, i1 0)
+  ret i32 0
+}
+

--- a/scripts/perf-testing/test.pl
+++ b/scripts/perf-testing/test.pl
@@ -10,6 +10,7 @@ use Getopt::Long;
 my $ALIVETV = $ENV{"HOME"}."/alive2/build/alive-tv";
 my $MINW = 4;
 my $MAXW = 256;
+my $SMT_TO = 5000; # milliseconds
 
 #####################################################################
 
@@ -40,12 +41,12 @@ sub check($$$) {
     system "m4 --define=iX=i${x} --define=X=${x} ${f} > ${tmpll}";
     system "cat ${tmpll}" if $DEBUG;
     my $tmpout = File::Temp->new();
-    system "${ALIVETV} ${tmpll} > $tmpout 2>&1";
+    system "${ALIVETV} --smt-to=${SMT_TO} ${tmpll} > $tmpout 2>&1";
     system "cat ${tmpout}" if $DEBUG;
     open my $INF, "<$tmpout" or die;
     while (my $line = <$INF>) {
         return 1 if $positive && $line =~ /Transformation seems to be correct/;
-        return 1 if !$positive && $line =~ /Value mismatch/;
+        return 1 if !$positive && $line =~ /Transformation doesn't verify/;
     }
     close $INF;
     return 0;
@@ -80,6 +81,7 @@ if (scalar(@ARGV) > 0) {
         } elsif ($f =~ /^negative/) {
             test_file($f, 0);
         } else {
+            die;
         }
     }
 } else {


### PR DESCRIPTION
not sure these are great, since mostly the new memory tests either fail at 11 (falling off the unroll limit of 10, I guess) or go all the way to 256. I'd be happy for feedback from Juneyoung or Nuno