### PR TITLE
non_local_block_liveness should be preserved if nofree exists

### DIFF
--- a/ir/memory.cpp
+++ b/ir/memory.cpp
@@ -1326,6 +1326,8 @@ Memory::mkCallState(const vector<PtrInput> *ptr_inputs, bool nofree) const {
       st.non_local_block_liveness
         = non_local_block_liveness & (st.liveness_var | mask);
     }
+  } else {
+    st.non_local_block_liveness = non_local_block_liveness;
   }
   return st;
 }


### PR DESCRIPTION
This caused invalidexpr errors after #398 and nofree are landed because many io functions are labeled as nofree.