### PR TITLE
Let fninputRefined see bytes of local blocks

### DIFF
--- a/ir/memory.h
+++ b/ir/memory.h
@@ -177,7 +177,10 @@ public:
 
   smt::expr refined(const Pointer &other) const;
   smt::expr fninputRefined(const Pointer &other, bool is_byval_arg) const;
-  smt::expr blockValRefined(const Pointer &other) const;
+  // If encode_local is true, assume that this and other can point to local
+  // blocks as well
+  smt::expr blockValRefined(const Pointer &other,
+                            bool encode_local = false) const;
   smt::expr blockRefined(const Pointer &other) const;
 
   const Memory& getMemory() const { return m; }

--- a/tests/alive-tv/bugs/pr11390.srctgt.ll
+++ b/tests/alive-tv/bugs/pr11390.srctgt.ll
@@ -1,5 +1,6 @@
 ; https://bugs.llvm.org/show_bug.cgi?id=11390
 ; To detect this bug, escaped local blocks' bytes should be checked
+; Needs aligning escaped mallocs in src and tgt
 
 target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f32:32:32-f64:64:64-v64:64:64-v128:128:128-a0:0:64-s0:64:64-f80:128:128-n8:16:32:64-S128"
 target triple = "x86_64-unknown-linux-gnu"

--- a/tests/alive-tv/bugs/pr23599.srctgt.ll
+++ b/tests/alive-tv/bugs/pr23599.srctgt.ll
@@ -1,5 +1,4 @@
 ; https://bugs.llvm.org/show_bug.cgi?id=23599
-; To reproduce this, bytes of escaped local blocks should be checked
 
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-unknown-linux-gnu"
@@ -68,3 +67,4 @@ attributes #2 = { "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "
 !3 = !{!"omnipotent char", !4, i64 0}
 !4 = !{!"Simple C/C++ TBAA"}
 
+; ERROR: Source is more defined than target

--- a/tests/alive-tv/bugs/pr41949-2.srctgt.ll
+++ b/tests/alive-tv/bugs/pr41949-2.srctgt.ll
@@ -1,5 +1,4 @@
 ; https://bugs.llvm.org/show_bug.cgi?id=41949
-; To detect a bug from this, bytes of escaped local blocks should be checked
 
 ;source_filename = "41949.ll"
 target datalayout = "E"
@@ -23,3 +22,5 @@ define void @tgt(i32* %p) {
 }
 
 declare void @test1(i32*)
+
+; ERROR: Source is more defined than target

--- a/tests/alive-tv/calls/call-movestr2.src.ll
+++ b/tests/alive-tv/calls/call-movestr2.src.ll
@@ -1,6 +1,3 @@
-; TODO: needs refinement of local blocks working
-; XPASS: Transformation seems to be correct
-
 define i8 @f() {
   %a = alloca i8
   store i8 3, i8* %a
@@ -9,3 +6,5 @@ define i8 @f() {
 }
 
 declare i8 @g(i8*)
+
+; ERROR: Source is more defined than target


### PR DESCRIPTION
This PR makes fninputRefined see bytes of local blocks.
This reproduces two bugzilla reports. Note that `pr41949-2.srctgt.ll` is the original version of `pr41949.srctgt.ll` that used function call to observe the byte contents.

This starts with seeing integer bytes of the escaped blocks.
I believe that this will provide a good baseline metrics; any encoding that is more complex than this should raise more timeouts.
