### PR TITLE
Check hit_half_memory_limit while substituting qvars

### DIFF
--- a/tools/transform.cpp
+++ b/tools/transform.cpp
@@ -203,6 +203,9 @@ static expr preprocess(Transform &t, const set<expr> &qvars0,
     e = e.subst(var, true).simplify() &&
         e.subst(var, false).simplify();
     qvars.erase(var);
+
+    if (hit_half_memory_limit())
+      break;
   }
 
   // TODO: maybe try to instantiate undet_xx vars?

--- a/tools/transform.cpp
+++ b/tools/transform.cpp
@@ -200,12 +200,12 @@ static expr preprocess(Transform &t, const set<expr> &qvars0,
   for (auto &var : qvars0) {
     if (!var.isBool())
       continue;
+    if (hit_half_memory_limit())
+      break;
+
     e = e.subst(var, true).simplify() &&
         e.subst(var, false).simplify();
     qvars.erase(var);
-
-    if (hit_half_memory_limit())
-      break;
   }
 
   // TODO: maybe try to instantiate undet_xx vars?


### PR DESCRIPTION
I see that oggenc takes pretty long time (> 10hrs when run in parallel) in preprocessing only, and for some pairs substituting boolean qvars with true + false was the place .
I put hit_half_memory_limit() so the loop stops if the expression gets too large.