### PR TITLE
Another fix to dominators to ensure progress in some cases

### DIFF
--- a/ir/function.cpp
+++ b/ir/function.cpp
@@ -356,9 +356,9 @@ DomTree::DomTreeNode* DomTree::intersect(DomTreeNode *f1, DomTreeNode *f2) {
     // cases, dom trees for subtrees not rooted at entry will be wrong
     if (f1 == f1->dominator && f2 == f2->dominator)
       return &f1->bb == &f.getFirstBB() ? f1_start : f2_start;
-    while (f1->order < f2->order && f1 != f1->dominator)
+    if (f1->order < f2->order || f2 == f2->dominator)
       f1 = f1->dominator;
-    while (f2->order < f1->order && f2 != f2->dominator)
+    if (f2->order < f1->order || f1 == f1->dominator)
       f2 = f2->dominator;
   }
   return f1;


### PR DESCRIPTION
One of the functions in the oggenc benchmark resulted in an infinite loop in the intersect function with:

``` 
(gdb) p f1->order
$2 = 21
(gdb) p f2->order
$3 = 19
(gdb) p f1->dominator->order
$4 = 22
(gdb) p f2->dominator->order
$5 = 19
(gdb) p f1->dominator->dominator->order
$6 = 22
```
Because `f2->order < f1->order` and `f2->dominator == f2` nothing will change in each iteration. It is another side effect of multiple root CFG's where the order here loses meaning. This change should ensure that progress is made in these cases. Tested with my ub implementation and everything looks correct.