### PR TITLE
Implement mapping between local blocks escaped via function calls

### DIFF
--- a/ir/instr.cpp
+++ b/ir/instr.cpp
@@ -2044,6 +2044,7 @@ StateValue Return::toSMT(State &s) const {
   auto &retval = s[*val];
   s.addUB(s.getMemory().checkNocapture());
   addUBForNoCaptureRet(s, retval, val->getType());
+  s.getMemory().markAllocasAsDead();
 
   auto &attrs = s.getFn().getFnAttrs();
   bool isDeref = attrs.has(FnAttrs::Dereferenceable);

--- a/ir/memory.cpp
+++ b/ir/memory.cpp
@@ -810,9 +810,11 @@ expr Pointer::fninputRefined(const Pointer &other, bool is_byval_arg) const {
   else
     local = encodeLocalPtrRefinement(other, false);
 
-  return expr::mkIf(isLocal(),
+  return isBlockAlive().implies(
+            other.isBlockAlive() &&
+            expr::mkIf(isLocal(),
                expr::mkIf(is_byval_arg, move(byval_cond), move(local)),
-               *this == other);
+               *this == other));
 }
 
 expr Pointer::blockValRefined(const Pointer &other) const {

--- a/ir/state.h
+++ b/ir/state.h
@@ -103,6 +103,7 @@ private:
   };
   struct FnCallOutput {
     std::vector<StateValue> retvals;
+    std::vector<Type *> retvals_ty;
     smt::expr ub;
     Memory::CallState callstate;
     bool used;

--- a/smt/expr.cpp
+++ b/smt/expr.cpp
@@ -217,7 +217,7 @@ expr expr::mkQuantVar(unsigned i, Z3_sort sort) {
 
 bool expr::isBinOp(expr &a, expr &b, int z3op) const {
   if (auto app = isAppOf(z3op)) {
-    if (Z3_get_domain_size(ctx(), decl()) != 2)
+    if (Z3_get_app_num_args(ctx(), app) != 2)
       return false;
     a = Z3_get_app_arg(ctx(), app, 0);
     b = Z3_get_app_arg(ctx(), app, 1);

--- a/smt/exprs.cpp
+++ b/smt/exprs.cpp
@@ -4,7 +4,7 @@
 #include "smt/exprs.h"
 #include "util/compiler.h"
 #include <vector>
-
+#include <iostream>
 using namespace std;
 
 namespace smt {

--- a/tests/alive-tv/attrs/writeonly.srctgt.ll
+++ b/tests/alive-tv/attrs/writeonly.srctgt.ll
@@ -1,0 +1,15 @@
+declare void @f() writeonly
+@glb = global i8 0
+
+define void @src() {
+  store i8 1, i8* @glb
+  call void @f()
+  store i8 2, i8* @glb
+  ret void
+}
+
+define void @tgt() {
+  call void @f()
+  store i8 2, i8* @glb
+  ret void
+}

--- a/tests/alive-tv/bugs/pr10067.srctgt.ll
+++ b/tests/alive-tv/bugs/pr10067.srctgt.ll
@@ -44,3 +44,5 @@ define i32 @tgt() noinline {
 }
 
 declare void @bar(%struct1* sret)
+
+; ERROR: Source is more defined than target

--- a/tests/alive-tv/bugs/pr23599.srctgt.ll
+++ b/tests/alive-tv/bugs/pr23599.srctgt.ll
@@ -1,5 +1,4 @@
 ; https://bugs.llvm.org/show_bug.cgi?id=23599
-; To reproduce this, bytes of escaped local blocks should be checked
 
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-unknown-linux-gnu"
@@ -68,3 +67,4 @@ attributes #2 = { "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "
 !3 = !{!"omnipotent char", !4, i64 0}
 !4 = !{!"Simple C/C++ TBAA"}
 
+; ERROR: Source is more defined than target

--- a/tests/alive-tv/bugs/pr41949-2.srctgt.ll
+++ b/tests/alive-tv/bugs/pr41949-2.srctgt.ll
@@ -1,5 +1,4 @@
 ; https://bugs.llvm.org/show_bug.cgi?id=41949
-; To detect a bug from this, bytes of escaped local blocks should be checked
 
 ;source_filename = "41949.ll"
 target datalayout = "E"
@@ -23,3 +22,5 @@ define void @tgt(i32* %p) {
 }
 
 declare void @test1(i32*)
+
+; ERROR: Source is more defined than target

--- a/tests/alive-tv/calls/byval-nocopy.srctgt.ll
+++ b/tests/alive-tv/calls/byval-nocopy.srctgt.ll
@@ -1,0 +1,16 @@
+define i8 @src(i8* byval %p) {
+  %a = alloca i8
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* %a, i8* %p, i64 1, i1 false)
+  %b = call i8 @g(i8* %a)
+  ret i8 %b
+}
+
+define i8 @tgt(i8* byval %p) {
+  %b = call i8 @g(i8* %p)
+  ret i8 %b
+}
+
+declare i8 @g(i8*)
+declare void @llvm.memcpy.p0i8.p0i8.i64(i8*, i8*, i64, i1)
+
+; ERROR: Source is more defined than target

--- a/tests/alive-tv/calls/byval.srctgt.ll
+++ b/tests/alive-tv/calls/byval.srctgt.ll
@@ -1,0 +1,13 @@
+@g = global i32 0
+declare void @f(i32*)
+
+define void @src() {
+  %p = alloca i32
+  call void @f(i32* byval %p)
+  ret void
+}
+
+define void @tgt() {
+  call void @f(i32* byval @g)
+  ret void
+}

--- a/tests/alive-tv/calls/call-movestr2.src.ll
+++ b/tests/alive-tv/calls/call-movestr2.src.ll
@@ -1,6 +1,3 @@
-; TODO: needs refinement of local blocks working
-; XPASS: Transformation seems to be correct
-
 define i8 @f() {
   %a = alloca i8
   store i8 3, i8* %a
@@ -9,3 +6,5 @@ define i8 @f() {
 }
 
 declare i8 @g(i8*)
+
+; ERROR: Source is more defined than target

--- a/tests/alive-tv/calls/call.src.ll
+++ b/tests/alive-tv/calls/call.src.ll
@@ -34,13 +34,6 @@ define i8 @f5() {
   ret i8 %b
 }
 
-define i8 @f6(i8* byval %p) {
-  %a = alloca i8
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* %a, i8* %p, i64 1, i1 false)
-  %b = call i8 @g(i8* %a)
-  ret i8 %b
-}
-
 define i8 @f6_2(i8* %p) {
   %a = alloca i8
   call void @llvm.memcpy.p0i8.p0i8.i64(i8* %a, i8* %p, i64 1, i1 false)

--- a/tests/alive-tv/calls/call.tgt.ll
+++ b/tests/alive-tv/calls/call.tgt.ll
@@ -34,11 +34,6 @@ define i8 @f5() {
   ret i8 %b
 }
 
-define i8 @f6(i8* byval %p) {
-  %b = call i8 @g(i8* %p)
-  ret i8 %b
-}
-
 define i8 @f6_2(i8* %p) {
   %b = call i8 @g2(i8* byval %p)
   ret i8 %b

--- a/tests/alive-tv/calls/escape-allocazero.srctgt.ll
+++ b/tests/alive-tv/calls/escape-allocazero.srctgt.ll
@@ -1,0 +1,19 @@
+; from test/Transforms/InstCombine/alloca.ll
+declare void @f([0 x i8]*)
+
+define void @src() {
+  %p = alloca [0 x i8]
+  call void @f([0 x i8]* %p)
+  %q = alloca [0 x i8]
+  call void @f([0 x i8]* %q)
+  ret void
+}
+
+define void @tgt() {
+  %p = alloca [0 x i8]
+  call void @f([0 x i8]* %p)
+  call void @f([0 x i8]* %p)
+  ret void
+}
+
+; XFAIL: Precondition is always false

--- a/tests/alive-tv/calls/escape-lifetime.srctgt.ll
+++ b/tests/alive-tv/calls/escape-lifetime.srctgt.ll
@@ -1,0 +1,19 @@
+; Relevant test: Transforms/InstCombine/lifetime-sanitizer.ll
+declare void @llvm.lifetime.start.p0i8(i64, i8*)
+declare void @llvm.lifetime.end.p0i8(i64, i8*)
+
+declare void @f(i8*)
+
+define void @src() {
+  %p0 = alloca i8
+  call void @llvm.lifetime.start.p0i8(i64 1, i8* %p0)
+  call void @llvm.lifetime.end.p0i8(i64 1, i8* %p0)
+  call void @f(i8* %p0)
+  ret void
+}
+
+define void @tgt() {
+  %p0 = alloca i8
+  call void @f(i8* %p0)
+  ret void
+}

--- a/tests/alive-tv/calls/escape-local-global-fail.srctgt.ll
+++ b/tests/alive-tv/calls/escape-local-global-fail.srctgt.ll
@@ -1,0 +1,15 @@
+@g = global i32 0
+declare void @f(i32*)
+
+define void @src() {
+  %p = alloca i32
+  call void @f(i32* %p)
+  ret void
+}
+
+define void @tgt() {
+  call void @f(i32* @g)
+  ret void
+}
+
+; ERROR: Source is more defined than target

--- a/tests/alive-tv/calls/escape-local-global-fail2.srctgt.ll
+++ b/tests/alive-tv/calls/escape-local-global-fail2.srctgt.ll
@@ -1,0 +1,15 @@
+@g = global i32 0
+declare void @f(i32*)
+
+define void @src() {
+  call void @f(i32* @g)
+  ret void
+}
+
+define void @tgt() {
+  %p = alloca i32
+  call void @f(i32* %p)
+  ret void
+}
+
+; ERROR: Source is more defined than target

--- a/tests/alive-tv/calls/escape-locals-fail.srctgt.ll
+++ b/tests/alive-tv/calls/escape-locals-fail.srctgt.ll
@@ -1,0 +1,21 @@
+declare void @f(i8*, i8*)
+
+define void @src() {
+  %p = alloca i8
+  %q = alloca i8
+  store i8 1, i8* %p
+  store i8 2, i8* %q
+  call void @f(i8* %p, i8* %q)
+  ret void
+}
+
+define void @tgt() {
+  %p = alloca i8
+  %q = alloca i8
+  store i8 2, i8* %p
+  store i8 1, i8* %q
+  call void @f(i8* %p, i8* %q)
+  ret void
+}
+
+; ERROR: Source is more defined than target

--- a/tests/alive-tv/calls/escape-locals.srctgt.ll
+++ b/tests/alive-tv/calls/escape-locals.srctgt.ll
@@ -1,0 +1,19 @@
+declare void @f(i8*, i8*)
+
+define void @src() {
+  %p = alloca i8
+  %q = alloca i8
+  store i8 1, i8* %p
+  store i8 2, i8* %q
+  call void @f(i8* %p, i8* %q)
+  ret void
+}
+
+define void @tgt() {
+  %p = alloca i8
+  %q = alloca i8
+  store i8 2, i8* %p
+  store i8 1, i8* %q
+  call void @f(i8* %q, i8* %p)
+  ret void
+}

--- a/tests/alive-tv/calls/escape-locals2.srctgt.ll
+++ b/tests/alive-tv/calls/escape-locals2.srctgt.ll
@@ -1,0 +1,23 @@
+declare i8* @f(i8*, i8*)
+
+define i8 @src() {
+  %p = alloca i8
+  %q = alloca i8
+  store i8 1, i8* %p
+  store i8 2, i8* %q
+  %r = call i8* @f(i8* %p, i8* %q)
+  store i8 3, i8* %r
+  %v = load i8, i8* %p
+  ret i8 %v
+}
+
+define i8 @tgt() {
+  %p = alloca i8
+  %q = alloca i8
+  store i8 2, i8* %p
+  store i8 1, i8* %q
+  %r = call i8* @f(i8* %q, i8* %p)
+  store i8 3, i8* %r
+  %v = load i8, i8* %q
+  ret i8 %v
+}

--- a/tests/alive-tv/calls/escape-mergealloca.srctgt.ll
+++ b/tests/alive-tv/calls/escape-mergealloca.srctgt.ll
@@ -1,0 +1,19 @@
+; from test/Transforms/InstCombine/alloca.ll
+declare void @f(i32*)
+
+define void @src() {
+  %p = alloca i32
+  call void @f(i32* %p)
+  %q = alloca i32
+  call void @f(i32* %q)
+  ret void
+}
+
+define void @tgt() {
+  %p = alloca i32
+  call void @f(i32* %p)
+  call void @f(i32* %p)
+  ret void
+}
+
+; ERROR: Source is more defined than target

--- a/tests/alive-tv/calls/escape-via-global.srctgt.ll
+++ b/tests/alive-tv/calls/escape-via-global.srctgt.ll
@@ -1,0 +1,14 @@
+declare i8* @malloc(i64)
+@glb = global i8* null
+
+define void @src() {
+  %p = call i8* @malloc(i64 4)
+  store i8* %p, i8** @glb
+  ret void
+}
+
+define void @tgt() {
+  %p = call i8* @malloc(i64 4)
+  store i8* %p, i8** @glb
+  ret void
+}

--- a/tests/alive-tv/calls/escape-via-global2.srctgt.ll
+++ b/tests/alive-tv/calls/escape-via-global2.srctgt.ll
@@ -1,0 +1,16 @@
+@glb = global i8* null
+declare void @f()
+
+define void @src() {
+  %p = alloca i8
+  store i8* %p, i8** @glb
+  call void @f()
+  ret void
+}
+
+define void @tgt() {
+  %p = alloca i8
+  store i8* %p, i8** @glb
+  call void @f()
+  ret void
+}

--- a/tests/alive-tv/calls/escape3.srctgt.ll
+++ b/tests/alive-tv/calls/escape3.srctgt.ll
@@ -1,0 +1,17 @@
+declare void @f(i8*)
+
+define void @src() {
+  %p = alloca i8
+  store i8 1, i8* %p
+  call void @f(i8* %p)
+  ret void
+}
+
+define void @tgt() {
+  %p = alloca i8
+  store i8 2, i8* %p
+  call void @f(i8* %p)
+  ret void
+}
+
+; ERROR: Source is more defined than target

--- a/tests/alive-tv/refinement/alloca-to-heap.srctgt.ll
+++ b/tests/alive-tv/refinement/alloca-to-heap.srctgt.ll
@@ -1,0 +1,12 @@
+declare i8* @malloc(i64)
+
+define i8* @src() {
+  %p = alloca i64
+  %p8 = bitcast i64* %p to i8*
+  ret i8* %p8
+}
+
+define i8* @tgt() {
+  %p = call i8* @malloc(i64 8)
+  ret i8* %p
+}

--- a/tests/alive-tv/refinement/heap-fail.srctgt.ll
+++ b/tests/alive-tv/refinement/heap-fail.srctgt.ll
@@ -1,0 +1,17 @@
+declare i8* @malloc(i64)
+
+define i8* @src() {
+  %p = call i8* @malloc(i64 8)
+  %p8 = bitcast i8* %p to i64*
+  store i64 1, i64* %p8
+  ret i8* %p
+}
+
+define i8* @tgt() {
+  %p = call i8* @malloc(i64 8)
+  %p8 = bitcast i8* %p to i64*
+  store i64 2, i64* %p8
+  ret i8* %p
+}
+
+; ERROR: Value mismatch

--- a/tests/alive-tv/refinement/heap-to-alloca.srctgt.ll
+++ b/tests/alive-tv/refinement/heap-to-alloca.srctgt.ll
@@ -1,0 +1,19 @@
+declare i8* @malloc(i64)
+
+define i8* @src(i64 %x) {
+  %p = call i8* @malloc(i64 8)
+  %c = icmp ne i8* %p, null
+  br i1 %c, label %RET, label %UNREACHABLE
+RET:
+  ret i8* %p
+UNREACHABLE:
+  unreachable
+}
+
+define i8* @tgt(i64 %x) {
+  %p = alloca i64
+  %p8 = bitcast i64* %p to i8*
+  ret i8* %p8
+}
+
+; ERROR: Value mismatch

--- a/tests/alive-tv/refinement/heap.srctgt.ll
+++ b/tests/alive-tv/refinement/heap.srctgt.ll
@@ -1,0 +1,15 @@
+declare i8* @malloc(i64)
+
+define i8* @src(i64 %x) {
+  %p = call i8* @malloc(i64 8)
+  %p8 = bitcast i8* %p to i64*
+  load i64, i64* %p8 ; guarantees dereferenceability
+  ret i8* %p
+}
+
+define i8* @tgt(i64 %x) {
+  %p = call i8* @malloc(i64 8)
+  %p8 = bitcast i8* %p to i64*
+  store i64 %x, i64* %p8
+  ret i8* %p
+}

--- a/tools/transform.cpp
+++ b/tools/transform.cpp
@@ -331,7 +331,9 @@ check_refinement(Errors &errs, Transform &t, State &src_state, State &tgt_state,
 
   auto src_mem = src_state.returnMemory();
   auto tgt_mem = tgt_state.returnMemory();
-  auto [memory_cnstr0, ptr_refinement0] = src_mem.refined(tgt_mem, false);
+  // TODO: all local block's values are simply ignored, but we should check heap
+  auto [memory_cnstr0, ptr_refinement0] =
+      src_mem.refined(tgt_mem, false, false);
   auto &ptr_refinement = ptr_refinement0;
   auto memory_cnstr = memory_cnstr0.isTrue() ? memory_cnstr0
                                              : value_cnstr && memory_cnstr0;


### PR DESCRIPTION
This implements mapping between local blocks escaped via function args.

Mapping is carried as an LocalBlkMap class object, and only target memory maintains it.
- LocalBlkMap uses a bitvector to check whether there is a mapping from target local bid to the source local bid.
- LocalBlkMap uses a lambda function to get the mapped source bid from target bid.
However, mapping should appear as `forall tgt, exists src, mapping, ...` in the refinement, and we cannot quantify lambda. To resolve the issue, each fresh variable that represent the src local bid stored to the lambda function is quantified, and the lambda is expanded by expr::load whenever used.

Using this mapping, the input/output memory of src/tgt function calls are related (as discussed before).
Memory::refined now checks mapped local blocks of src/tgt, if check_local is set. Pointer::blockRefined, Pointer::blockValRefined takes the check_local as arguments as well.
Memory::mkCallState is the place where the mapping is updated.