### PR TITLE
Compare msb + nonpoison bits at once when converting bytes to value

### DIFF
--- a/ir/memory.h
+++ b/ir/memory.h
@@ -59,6 +59,7 @@ public:
   smt::expr ptrByteoffset() const;
   smt::expr nonptrNonpoison() const;
   smt::expr nonptrValue() const;
+  smt::expr isNonptrNonpoison() const;
   smt::expr isPoison(bool fullbit = true) const;
   smt::expr isZero() const; // zero or null
 

--- a/ir/type.cpp
+++ b/ir/type.cpp
@@ -243,11 +243,6 @@ StateValue Type::fromInt(StateValue v) const {
   return { fromInt(move(v.value)), v.non_poison == 0 };
 }
 
-expr Type::combine_poison(const expr &boolean, const expr &orig) const {
-  return
-    expr::mkIf(boolean, expr::mkInt(0, orig), expr::mkInt(-1, orig)) | orig;
-}
-
 pair<expr, vector<expr>>
 Type::mkUndefInput(State &s, const ParamAttrs &attrs) const {
   auto var = expr::mkFreshVar("undef", mkInput(s, "", attrs));

--- a/ir/type.h
+++ b/ir/type.h
@@ -100,10 +100,6 @@ public:
   virtual smt::expr fromInt(smt::expr v) const;
   virtual IR::StateValue fromInt(IR::StateValue v) const;
 
-  // combine existing poison value in BV repr with a new boolean expr
-  smt::expr combine_poison(const smt::expr &boolean,
-                           const smt::expr &orig) const;
-
   // returns pair of refinement constraints for <poison, !poison && value>
   virtual std::pair<smt::expr, smt::expr>
     refines(State &src_s, State &tgt_s, const StateValue &src,


### PR DESCRIPTION
When loading a non-pointer value from bytes, we should check whether there is no poison byte & no pointer byte.
If bits_int_poison is 1, this can be done efficiently by extracting and checking relevant bits from Byte at once 
This can also be applied when bits_int_poison > 1, but requires a bigger change.

[oggenc.srctgt.zip](https://github.com/AliveToolkit/alive2/files/4804601/oggenc.srctgt.zip)
Running -se-verbose from this pair will show the diff.

Moved Type.combine_poison to Memory.cpp's static function because it was only used there.