### PR TITLE
Use pattern-match to simplify at DisjointExpr for faster vcgen

### DIFF
--- a/smt/exprs.cpp
+++ b/smt/exprs.cpp
@@ -95,8 +95,8 @@ static expr subst_for_ptr(const expr &e, const expr &from, const expr &to) {
   if (e.isAdd(a, b))
     return subst_for_ptr(a, from, to) + subst_for_ptr(b, from, to);
   else if (e.isIf(cond, then, els) && cond.eq(from))
-    // Don't look further
-    return expr::mkIf(to, then, els);
+    return expr::mkIf(to, subst_for_ptr(then, from, to),
+                          subst_for_ptr(els, from, to));
   else if (e.isExtract(a, hi, lo))
     return subst_for_ptr(a, from, to).extract(hi, lo);
 


### PR DESCRIPTION
When DisjointExpr explodes an expression, it uses expr::subst() to simplify a subexpression using domain. But, as we're exploding SMT formula for pointers only, a simple pattern-match for the expression and making simplified expressions works too.

Has a nice speedup of vcgen time at oggenc, no regression in # correct and other benchmarks' vcgen time.
Result of bzip2/gzip/oggenc: [result.txt](https://github.com/AliveToolkit/alive2/files/4809321/result.txt)
