### PR TITLE
Optimize nocapture encoding if only constant ptrs are stored

### DIFF
--- a/ir/globals.cpp
+++ b/ir/globals.cpp
@@ -42,7 +42,7 @@ bool has_null_block;
 bool does_int_mem_access;
 bool does_ptr_mem_access;
 bool does_ptr_store;
-bool does_ptr_store_constantsonly;
+bool does_ptr_store_nonconstant;
 unsigned heap_block_alignment;
 
 

--- a/ir/globals.cpp
+++ b/ir/globals.cpp
@@ -42,6 +42,7 @@ bool has_null_block;
 bool does_int_mem_access;
 bool does_ptr_mem_access;
 bool does_ptr_store;
+bool does_ptr_store_constantsonly;
 unsigned heap_block_alignment;
 
 

--- a/ir/globals.h
+++ b/ir/globals.h
@@ -78,7 +78,9 @@ extern bool has_null_block;
 /// Whether the programs do memory accesses that load/store int/ptrs
 extern bool does_int_mem_access;
 extern bool does_ptr_mem_access;
+
 extern bool does_ptr_store;
+extern bool does_ptr_store_constantsonly; // stores non-constant ptrs only?
 
 extern unsigned heap_block_alignment;
 

--- a/ir/globals.h
+++ b/ir/globals.h
@@ -80,7 +80,7 @@ extern bool does_int_mem_access;
 extern bool does_ptr_mem_access;
 
 extern bool does_ptr_store;
-extern bool does_ptr_store_constantsonly; // stores non-constant ptrs only?
+extern bool does_ptr_store_nonconstant; // may store non-constant ptrs?
 
 extern unsigned heap_block_alignment;
 

--- a/ir/instr.cpp
+++ b/ir/instr.cpp
@@ -2314,11 +2314,11 @@ MemInstr::ByteAccessInfo::get(const Type &t, const Value *storeval,
   bool ptr_access = hasPtr(t);
   ByteAccessInfo info;
   info.hasIntByteAccess = t.enforcePtrOrVectorType().isFalse();
-  info.doesPtrStore = { ptr_access && storeval, false };
+  info.doesPtrStore = { ptr_access && storeval, true };
   if (dynamic_cast<const GlobalVariable *>(storeval) ||
       dynamic_cast<const NullPointerValue *>(storeval) ||
       dynamic_cast<const UndefValue *>(storeval))
-    info.doesPtrStore.constant_ptrs_only = true;
+    info.doesPtrStore.may_store_nonconstptr = false;
   info.doesPtrLoad = ptr_access && !storeval;
   info.byteSize = gcd(align, getCommonAccessSize(t));
   return info;

--- a/ir/instr.h
+++ b/ir/instr.h
@@ -430,9 +430,14 @@ public:
   virtual bool canFree() const = 0;
 
   struct ByteAccessInfo {
+    struct PtrStoreInfo {
+      bool has_store;
+      bool constant_ptrs_only;
+    };
+
     bool hasIntByteAccess = false;
     bool doesPtrLoad = false;
-    bool doesPtrStore = false;
+    PtrStoreInfo doesPtrStore = { false, false };
 
     // The maximum size of a byte that this instruction can support.
     // If zero, this instruction does not read/write bytes.
@@ -443,7 +448,8 @@ public:
 
     static ByteAccessInfo intOnly(unsigned byteSize);
     static ByteAccessInfo anyType(unsigned byteSize);
-    static ByteAccessInfo get(const Type &t, bool store, unsigned align);
+    static ByteAccessInfo get(const Type &t, const Value *storeval,
+                              unsigned align);
     static ByteAccessInfo full(unsigned byteSize);
   };
 

--- a/ir/instr.h
+++ b/ir/instr.h
@@ -432,7 +432,7 @@ public:
   struct ByteAccessInfo {
     struct PtrStoreInfo {
       bool has_store;
-      bool constant_ptrs_only;
+      bool may_store_nonconstptr;
     };
 
     bool hasIntByteAccess = false;

--- a/ir/memory.cpp
+++ b/ir/memory.cpp
@@ -2263,7 +2263,7 @@ Memory::refined(const Memory &other, bool skip_constants,
 }
 
 expr Memory::checkNocapture() const {
-  if (!does_ptr_store || !has_nocapture)
+  if (!does_ptr_store || does_ptr_store_constantsonly || !has_nocapture)
     return true;
 
   auto name = local_name(state, "#offset_nocapture");

--- a/ir/memory.cpp
+++ b/ir/memory.cpp
@@ -2263,7 +2263,7 @@ Memory::refined(const Memory &other, bool skip_constants,
 }
 
 expr Memory::checkNocapture() const {
-  if (!does_ptr_store || does_ptr_store_constantsonly || !has_nocapture)
+  if (!does_ptr_store_nonconstant || !has_nocapture)
     return true;
 
   auto name = local_name(state, "#offset_nocapture");

--- a/tests/alive-tv/opt-memory/store-constptr.srctgt.ll
+++ b/tests/alive-tv/opt-memory/store-constptr.srctgt.ll
@@ -1,0 +1,15 @@
+; TEST-ARGS: -dbg
+@x = global i8* undef
+
+define void @src() {
+  store i8* null, i8** @x
+  ret void
+}
+
+define void @tgt() {
+  store i8* null, i8** @x
+  ret void
+}
+
+; CHECK: does_ptr_store_constantsonly: 1
+

--- a/tests/alive-tv/opt-memory/store-constptr.srctgt.ll
+++ b/tests/alive-tv/opt-memory/store-constptr.srctgt.ll
@@ -11,5 +11,5 @@ define void @tgt() {
   ret void
 }
 
-; CHECK: does_ptr_store_constantsonly: 1
+; CHECK: does_ptr_store_nonconstant: 0
 

--- a/tests/alive-tv/opt-memory/store-constptr2.srctgt.ll
+++ b/tests/alive-tv/opt-memory/store-constptr2.srctgt.ll
@@ -1,0 +1,18 @@
+; TEST-ARGS: -dbg
+@x = global i8* undef
+@y = global i8* undef
+
+define void @src(i8* %a) {
+  store i8* %a, i8** @y
+  store i8* null, i8** @x
+  ret void
+}
+
+define void @tgt(i8* %a) {
+  store i8* %a, i8** @y
+  store i8* null, i8** @x
+  ret void
+}
+
+; CHECK: does_ptr_store_constantsonly: 0
+

--- a/tests/alive-tv/opt-memory/store-constptr2.srctgt.ll
+++ b/tests/alive-tv/opt-memory/store-constptr2.srctgt.ll
@@ -14,5 +14,5 @@ define void @tgt(i8* %a) {
   ret void
 }
 
-; CHECK: does_ptr_store_constantsonly: 0
+; CHECK: does_ptr_store_nonconstant: 1
 

--- a/tools/transform.cpp
+++ b/tools/transform.cpp
@@ -589,6 +589,7 @@ static void calculateAndInitConstants(Transform &t) {
   has_fncall       = false;
   has_null_block   = false;
   does_ptr_store   = false;
+  does_ptr_store_constantsonly = false;
   does_ptr_mem_access = false;
   does_int_mem_access = false;
   bool does_any_byte_access = false;
@@ -659,12 +660,13 @@ static void calculateAndInitConstants(Transform &t) {
 
           auto info = mi->getByteAccessInfo();
           has_ptr_load         |= info.doesPtrLoad;
-          does_ptr_store       |= info.doesPtrStore;
+          does_ptr_store       |= info.doesPtrStore.has_store;
+          does_ptr_store_constantsonly |= info.doesPtrStore.constant_ptrs_only;
           does_int_mem_access  |= info.hasIntByteAccess;
           does_mem_access      |= info.doesMemAccess();
           min_access_size       = gcd(min_access_size, info.byteSize);
           if (info.doesMemAccess() && !info.hasIntByteAccess &&
-              !info.doesPtrLoad && !info.doesPtrStore)
+              !info.doesPtrLoad && !info.doesPtrStore.has_store)
             does_any_byte_access = true;
 
           if (auto alloc = dynamic_cast<const Alloc*>(&i)) {

--- a/tools/transform.cpp
+++ b/tools/transform.cpp
@@ -589,7 +589,7 @@ static void calculateAndInitConstants(Transform &t) {
   has_fncall       = false;
   has_null_block   = false;
   does_ptr_store   = false;
-  does_ptr_store_constantsonly = false;
+  does_ptr_store_constantsonly = true;
   does_ptr_mem_access = false;
   does_int_mem_access = false;
   bool does_any_byte_access = false;
@@ -661,7 +661,7 @@ static void calculateAndInitConstants(Transform &t) {
           auto info = mi->getByteAccessInfo();
           has_ptr_load         |= info.doesPtrLoad;
           does_ptr_store       |= info.doesPtrStore.has_store;
-          does_ptr_store_constantsonly |= info.doesPtrStore.constant_ptrs_only;
+          does_ptr_store_constantsonly &= info.doesPtrStore.constant_ptrs_only;
           does_int_mem_access  |= info.hasIntByteAccess;
           does_mem_access      |= info.doesMemAccess();
           min_access_size       = gcd(min_access_size, info.byteSize);
@@ -692,6 +692,7 @@ static void calculateAndInitConstants(Transform &t) {
     }
   }
 
+  does_ptr_store_constantsonly &= does_ptr_store;
   does_ptr_mem_access = has_ptr_load || does_ptr_store;
   if (does_any_byte_access && !does_int_mem_access && !does_ptr_mem_access)
     // Use int bytes only
@@ -811,6 +812,8 @@ static void calculateAndInitConstants(Transform &t) {
                   << "\nhas_free: " << has_free
                   << "\nhas_null_block: " << has_null_block
                   << "\ndoes_ptr_store: " << does_ptr_store
+                  << "\ndoes_ptr_store_constantsonly: "
+                  << does_ptr_store_constantsonly
                   << "\ndoes_mem_access: " << does_mem_access
                   << "\ndoes_ptr_mem_access: " << does_ptr_mem_access
                   << "\ndoes_int_mem_access: " << does_int_mem_access

--- a/tools/transform.cpp
+++ b/tools/transform.cpp
@@ -589,7 +589,7 @@ static void calculateAndInitConstants(Transform &t) {
   has_fncall       = false;
   has_null_block   = false;
   does_ptr_store   = false;
-  does_ptr_store_constantsonly = true;
+  does_ptr_store_nonconstant = false;
   does_ptr_mem_access = false;
   does_int_mem_access = false;
   bool does_any_byte_access = false;
@@ -661,7 +661,7 @@ static void calculateAndInitConstants(Transform &t) {
           auto info = mi->getByteAccessInfo();
           has_ptr_load         |= info.doesPtrLoad;
           does_ptr_store       |= info.doesPtrStore.has_store;
-          does_ptr_store_constantsonly &= info.doesPtrStore.constant_ptrs_only;
+          does_ptr_store_nonconstant |= info.doesPtrStore.may_store_nonconstptr;
           does_int_mem_access  |= info.hasIntByteAccess;
           does_mem_access      |= info.doesMemAccess();
           min_access_size       = gcd(min_access_size, info.byteSize);
@@ -692,7 +692,6 @@ static void calculateAndInitConstants(Transform &t) {
     }
   }
 
-  does_ptr_store_constantsonly &= does_ptr_store;
   does_ptr_mem_access = has_ptr_load || does_ptr_store;
   if (does_any_byte_access && !does_int_mem_access && !does_ptr_mem_access)
     // Use int bytes only
@@ -812,8 +811,8 @@ static void calculateAndInitConstants(Transform &t) {
                   << "\nhas_free: " << has_free
                   << "\nhas_null_block: " << has_null_block
                   << "\ndoes_ptr_store: " << does_ptr_store
-                  << "\ndoes_ptr_store_constantsonly: "
-                  << does_ptr_store_constantsonly
+                  << "\ndoes_ptr_store_nonconstant: "
+                  << does_ptr_store_nonconstant
                   << "\ndoes_mem_access: " << does_mem_access
                   << "\ndoes_ptr_mem_access: " << does_ptr_mem_access
                   << "\ndoes_int_mem_access: " << does_int_mem_access


### PR DESCRIPTION
This is a simple patch that makes Memory::checkNocapture() return simply true if only constant pointers (null, global vars, undef) are stored into memory.