### PR TITLE
Use Z3_get_app_num_args instead

### DIFF
--- a/smt/expr.cpp
+++ b/smt/expr.cpp
@@ -217,7 +217,7 @@ expr expr::mkQuantVar(unsigned i, Z3_sort sort) {
 
 bool expr::isBinOp(expr &a, expr &b, int z3op) const {
   if (auto app = isAppOf(z3op)) {
-    if (Z3_get_app_num_args(ctx(), decl()) != 2)
+    if (Z3_get_app_num_args(ctx(), app) != 2)
       return false;
     a = Z3_get_app_arg(ctx(), app, 0);
     b = Z3_get_app_arg(ctx(), app, 1);

--- a/smt/expr.cpp
+++ b/smt/expr.cpp
@@ -217,7 +217,7 @@ expr expr::mkQuantVar(unsigned i, Z3_sort sort) {
 
 bool expr::isBinOp(expr &a, expr &b, int z3op) const {
   if (auto app = isAppOf(z3op)) {
-    if (Z3_get_domain_size(ctx(), decl()) != 2)
+    if (Z3_get_app_num_args(ctx(), decl()) != 2)
       return false;
     a = Z3_get_app_arg(ctx(), app, 0);
     b = Z3_get_app_arg(ctx(), app, 1);


### PR DESCRIPTION
Some binary operations in Z3 can take more than 2 arguments, and `expr::isBinOp(expr &a, expr &b, int z3op)` should either fail or rebuild subexpressions that fit in 'a op b'.
But `Z3_get_domain_size` which is used in expr::isBinOp returns 2 regardless of how many operands the expression has, making the remaining operands lost.
`Z3_get_app_num_args` can be used instead to make it fail successfully.