### PR TITLE
Add refinedLocal/refinedByVal, make byval at definition have no effect

### DIFF
--- a/ir/instr.cpp
+++ b/ir/instr.cpp
@@ -2044,6 +2044,7 @@ StateValue Return::toSMT(State &s) const {
   auto &retval = s[*val];
   s.addUB(s.getMemory().checkNocapture());
   addUBForNoCaptureRet(s, retval, val->getType());
+  s.getMemory().markAllocasAsDead();
 
   auto &attrs = s.getFn().getFnAttrs();
   bool isDeref = attrs.has(FnAttrs::Dereferenceable);

--- a/ir/memory.h
+++ b/ir/memory.h
@@ -99,6 +99,9 @@ class Pointer {
                       const smt::FunctionExpr &nonlocal_fn,
                       const smt::expr &ret_type, bool src_name = false) const;
 
+  smt::expr refinedLocal(const Pointer &other) const;
+  smt::expr refinedByVal(const Pointer &other) const;
+
 public:
   Pointer(const Memory &m, const char *var_name,
           const smt::expr &local = false, bool unique_name = true,
@@ -200,6 +203,7 @@ class Memory {
 
   smt::expr non_local_block_liveness; // BV w/ 1 bit per bid (1 if live)
   smt::expr local_block_liveness;
+  bool allocasAreDead; // A fast switch for treating all allocas as dead
 
   smt::FunctionExpr local_blk_addr; // bid -> (bits_size_t - 1)
   smt::FunctionExpr local_blk_size;
@@ -284,6 +288,9 @@ public:
   // If unconstrained is true, the pointer offset, liveness, and block kind
   // are not checked.
   void free(const smt::expr &ptr, bool unconstrained);
+
+  // Free all allocas.
+  void markAllocasAsDead();
 
   static unsigned getStoreByteSize(const Type &ty);
   void store(const smt::expr &ptr, const StateValue &val, const Type &type,

--- a/tests/alive-tv/attrs/byval-fail.srctgt.ll
+++ b/tests/alive-tv/attrs/byval-fail.srctgt.ll
@@ -1,0 +1,16 @@
+define i8 @src(i8* byval %p) {
+  %a = alloca i8
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* %a, i8* %p, i64 1, i1 false)
+  %b = call i8 @g(i8* %a)
+  ret i8 %b
+}
+
+define i8 @tgt(i8* byval %p) {
+  %b = call i8 @g(i8* %p)
+  ret i8 %b
+}
+
+declare void @llvm.memcpy.p0i8.p0i8.i64(i8*, i8*, i64, i1)
+declare i8 @g(i8*)
+
+; ERROR: Source is more defined than target

--- a/tests/alive-tv/bugs/pr10067.srctgt.ll
+++ b/tests/alive-tv/bugs/pr10067.srctgt.ll
@@ -1,6 +1,3 @@
-; To support this test, escaped local blocks should have bytes updated after
-; unkown fn calls.
-
 target datalayout = "e-p:32:32:32-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:32:64-f32:32:32-f64:32:64-v64:64:64-v128:128:128-a0:0:64-f80:128:128-n8:16:32"
 target triple = "i386-apple-darwin10"
 
@@ -44,3 +41,5 @@ define i32 @tgt() noinline {
 }
 
 declare void @bar(%struct1* sret)
+
+; ERROR: Source is more defined than target

--- a/tests/alive-tv/calls/call.src.ll
+++ b/tests/alive-tv/calls/call.src.ll
@@ -34,13 +34,6 @@ define i8 @f5() {
   ret i8 %b
 }
 
-define i8 @f6(i8* byval %p) {
-  %a = alloca i8
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* %a, i8* %p, i64 1, i1 false)
-  %b = call i8 @g(i8* %a)
-  ret i8 %b
-}
-
 define i8 @f6_2(i8* %p) {
   %a = alloca i8
   call void @llvm.memcpy.p0i8.p0i8.i64(i8* %a, i8* %p, i64 1, i1 false)

--- a/tests/alive-tv/calls/call.tgt.ll
+++ b/tests/alive-tv/calls/call.tgt.ll
@@ -34,11 +34,6 @@ define i8 @f5() {
   ret i8 %b
 }
 
-define i8 @f6(i8* byval %p) {
-  %b = call i8 @g(i8* %p)
-  ret i8 %b
-}
-
 define i8 @f6_2(i8* %p) {
   %b = call i8 @g2(i8* byval %p)
   ret i8 %b

--- a/tests/alive-tv/refinement/alloca-to-heap.srctgt.ll
+++ b/tests/alive-tv/refinement/alloca-to-heap.srctgt.ll
@@ -1,0 +1,12 @@
+declare i8* @malloc(i64)
+
+define i8* @src() {
+ %p = alloca i64
+ %p8 = bitcast i64* %p to i8*
+ ret i8* %p8
+}
+
+define i8* @tgt() {
+ %p = call i8* @malloc(i64 8)
+ ret i8* %p
+}

--- a/tests/alive-tv/refinement/heap-to-alloca.srctgt.ll
+++ b/tests/alive-tv/refinement/heap-to-alloca.srctgt.ll
@@ -1,0 +1,19 @@
+declare i8* @malloc(i64)
+
+define i8* @src(i64 %x) {
+ %p = call i8* @malloc(i64 8)
+ %c = icmp ne i8* %p, null
+ br i1 %c, label %RET, label %UNREACHABLE
+RET:
+ ret i8* %p
+UNREACHABLE:
+ unreachable
+}
+
+define i8* @tgt(i64 %x) {
+ %p = alloca i64
+ %p8 = bitcast i64* %p to i8*
+ ret i8* %p8
+}
+
+; ERROR: Value mismatch


### PR DESCRIPTION
This is the first splitted pull request from #428.
Originally I planned to contain the byval bug only, became to think that having relevant codes included would be better.

Conceptually, what this patch does is to make Pointer::refined and Pointer::fninputRefined equivalent except byval processing. This is done by factoring out two functions and calling them:

- Pointer::refinedByVal(other) encodes a refinement for byval-passed pointers. This purely does dereferenceability check only, and doesn't check alloc type / etc. In the upcoming patches, this should compare bytes as well.
- Pointer::refinedLocal(other) encodes a refinement for local pointers. This check alloc types, offsets, etc.

Note that this PR makes refinement of local blocks at Pointer::fninputRefined more strict: even if two blocks are alloca, their sizes should be equivalent. LLVM does not seem to change the size of an alloca passed to fn arg, unless it is passed as byval. I tested it with LLVM unit tests and had no regression. Same with bzip2/gzip.