### PR TITLE
Introduce multi-memory implementation

### DIFF
--- a/ir/function.h
+++ b/ir/function.h
@@ -153,7 +153,8 @@ public:
   instr_helper instrs() const { return *this; }
 
   std::multimap<Value*, Value*> getUsers() const;
-  bool removeUnusedStuff(const std::multimap<Value*, Value*> &users);
+  bool removeUnusedStuff(const std::multimap<Value*, Value*> &users,
+                         const std::vector<std::string_view> &src_glbs);
 
   void print(std::ostream &os, bool print_header = true) const;
   friend std::ostream &operator<<(std::ostream &os, const Function &f);

--- a/ir/globals.cpp
+++ b/ir/globals.cpp
@@ -13,6 +13,7 @@ namespace IR {
 unsigned num_locals_src;
 unsigned num_locals_tgt;
 unsigned num_consts_src;
+unsigned num_globals_src;
 unsigned num_extra_nonconst_tgt;
 unsigned num_nonlocals;
 unsigned num_nonlocals_src;

--- a/ir/globals.h
+++ b/ir/globals.h
@@ -13,6 +13,8 @@ extern unsigned num_locals_src, num_locals_tgt;
 /// Number of constant global variables in src
 extern unsigned num_consts_src;
 
+extern unsigned num_globals_src;
+
 /// Number of non-constant globals introduced in tgt
 extern unsigned num_extra_nonconst_tgt;
 

--- a/ir/memory.cpp
+++ b/ir/memory.cpp
@@ -1848,7 +1848,7 @@ expr Memory::blockRefined(const Pointer &src, const Pointer &tgt, unsigned bid,
   if (blk_size.isUInt(bytes) && (bytes / bytes_per_byte) <= 8) {
     val_refines = true;
     for (unsigned off = 0; off < bytes; off += bytes_per_byte) {
-      expr off_expr = expr::mkUInt(off, bits_for_offset);
+      expr off_expr = expr::mkUInt(off, Pointer::bitsShortOffset());
       val_refines
         &= (ptr_offset == off_expr).implies(
              blockValRefined(tgt.getMemory(), bid, false, off_expr, undef));

--- a/ir/memory.cpp
+++ b/ir/memory.cpp
@@ -10,9 +10,6 @@
 #include <map>
 #include <string>
 
-// FIXME: REMOVE
-#include <iostream>
-
 using namespace IR;
 using namespace smt;
 using namespace std;
@@ -964,7 +961,8 @@ bool Memory::mayalias(bool local, unsigned bid0, const expr &offset0,
       if ((uint64_t)offset >= blk_size || bytes > (blk_size - offset))
         return false;
     }
-  }
+  } else if (local) // allocated in another branch
+    return false;
 
   // globals are always live
   if (local || (bid0 >= num_globals_src && bid0 < num_nonlocals_src)) {
@@ -986,14 +984,6 @@ void Memory::access(const Pointer &ptr, unsigned bytes, unsigned align,
   access_nonlocal.resize(write ? num_nonlocals_src : numNonlocals());
 
   auto is_deref = [&](bool local, unsigned bid, const expr &offset) -> bool {
-// FIXME: DEBUGGING...
-bool old = Pointer(*this, bid, local, offset).isDereferenceable(bytes, align, write);
-bool n = mayalias(local, bid, offset, bytes, align, write);
-if (old != n && offset.isValid()) {
-cout << "old: " << old<< " LOCAL: " << local << " BID=" <<bid << endl;
-cout << "BYTES=" << bytes << endl;
-  assert(0);
-}
     return !(local ? access_local : access_nonlocal)[bid] &&
            mayalias(local, bid, offset, bytes, align, write);
   };

--- a/ir/memory.cpp
+++ b/ir/memory.cpp
@@ -1104,8 +1104,7 @@ vector<Byte> Memory::load(const Pointer &ptr, unsigned bytes, set<expr> &undef,
   return ret;
 }
 
-
- void Memory::store(const Pointer &ptr,
+void Memory::store(const Pointer &ptr,
                    const vector<pair<unsigned, expr>> &data,
                    const set<expr> &undef, unsigned align) {
   if (data.empty())
@@ -1781,7 +1780,7 @@ Memory::load(const expr &p, const Type &type, unsigned align) const {
 }
 
 Byte Memory::load(const Pointer &p, set<expr> &undef, unsigned align) const {
-  return load(p, bits_byte / 8, undef, align)[0];
+  return move(load(p, bits_byte / 8, undef, align)[0]);
 }
 
 void Memory::memset(const expr &p, const StateValue &val, const expr &bytesize,
@@ -1837,7 +1836,7 @@ void Memory::memcpy(const expr &d, const expr &s, const expr &bytesize,
     vector<pair<unsigned, expr>> to_store;
     set<expr> undef;
     unsigned i = 0;
-    for (auto byte : load(src, n, undef, align_src)) {
+    for (auto &byte : load(src, n, undef, align_src)) {
       to_store.emplace_back(i++ * bytesz, byte());
     }
     store(dst, to_store, undef, align_dst);

--- a/ir/memory.cpp
+++ b/ir/memory.cpp
@@ -1826,7 +1826,6 @@ expr Memory::blockValRefined(const Memory &other, unsigned bid, bool local,
   if (mem1.eq(mem2))
     return true;
 
-  set<expr> undef_vars;
   Byte val(*this, mem1.load(offset));
   Byte val2(other, mem2.load(offset));
 

--- a/ir/memory.cpp
+++ b/ir/memory.cpp
@@ -1143,6 +1143,9 @@ vector<Byte> Memory::load(const Pointer &ptr, unsigned bytes, set<expr> &undef,
   expr offset = ptr.getShortOffset();
   unsigned off_bits = Pointer::bitsShortOffset();
 
+  if (bytes == 0)
+    return;
+
   auto fn = [&](MemVal &blks, unsigned i, bool local, const expr &cond) {
     auto mem = blks[i].first;
 

--- a/ir/memory.cpp
+++ b/ir/memory.cpp
@@ -965,7 +965,7 @@ void Memory::access(const Pointer &ptr, unsigned bytes, unsigned align,
   access_nonlocal.resize(write ? num_nonlocals_src : numNonlocals());
 
   auto is_deref = [&](bool local, unsigned bid, const expr &offset) -> bool {
-    return
+    return !(local ? access_local : access_nonlocal)[bid] &&
       Pointer(*this, bid, local, offset).isDereferenceable(bytes, align, write);
   };
 

--- a/ir/memory.cpp
+++ b/ir/memory.cpp
@@ -1939,6 +1939,10 @@ Memory Memory::mkIf(const expr &cond, const Memory &then, const Memory &els) {
   return ret;
 }
 
+void Memory::resetState() {
+  max_nonlocal_bid.clear();
+}
+
 bool Memory::operator<(const Memory &rhs) const {
   // FIXME: remove this once we move to C++20
   // NOTE: we don't compare field state so that memories from src/tgt can

--- a/ir/memory.cpp
+++ b/ir/memory.cpp
@@ -1138,7 +1138,7 @@ void Memory::storeLambda(const Pointer &p, const expr &offset, const expr &size,
     Pointer q(*this, i, local);
     if (q.isDereferenceable(bytes, bits_byte / 8, true)) {
       auto &arr = mem[i].first;
-      if (is_local.isTrue() && size.eq(q.blockSize())) {
+      if (is_local.isTrue() && val.isConst() && size.eq(q.blockSize())) {
         arr = expr::mkConstArray(offset, val);
       } else {
         arr = expr::mkLambda({ offset }, expr::mkIf(is_local && cond, val,
@@ -1973,8 +1973,7 @@ void Memory::print(ostream &os, const Model &m) const {
   bool did_header = false;
   auto header = [&](const char *msg) {
     if (!did_header) {
-      os << '\n'
-         << (state->isSource() ? "SOURCE" : "TARGET")
+      os << (state->isSource() ? "\nSOURCE" : "\nTARGET")
          << " MEMORY STATE\n===================\n";
     } else
       os << '\n';

--- a/ir/memory.cpp
+++ b/ir/memory.cpp
@@ -1070,7 +1070,7 @@ vector<Byte> Memory::load(const Pointer &ptr, unsigned bytes, set<expr> &undef,
   unsigned bytesz = (bits_byte / 8);
   unsigned loaded_bytes = bytes / bytesz;
   vector<DisjointExpr<expr>> loaded;
-  loaded.resize(loaded_bytes, expr::mkUInt(0, Byte::bitsByte()));
+  loaded.resize(loaded_bytes, Byte::mkPoisonByte(*this)());
 
   expr offset = ptr.getShortOffset();
   unsigned off_bits = Pointer::bitsShortOffset();
@@ -1821,7 +1821,9 @@ void Memory::copy(const Pointer &src, const Pointer &dst) {
   auto &undef = p.second;
   undef.clear();
 
-  DisjointExpr val(expr::mkUInt(0, Byte::bitsByte()));
+  auto offset = expr::mkUInt(0, Pointer::bitsShortOffset());
+  DisjointExpr val(expr::mkConstArray(offset, Byte::mkPoisonByte(*this)()));
+
   auto fn = [&](expr &mem, set<expr> &mem_undef, unsigned bid, bool local,
                 expr &&cond) {
     val.add(mem, move(cond));

--- a/ir/memory.cpp
+++ b/ir/memory.cpp
@@ -1847,7 +1847,7 @@ expr Memory::blockRefined(const Pointer &src, const Pointer &tgt, unsigned bid,
   uint64_t bytes;
   if (blk_size.isUInt(bytes) && (bytes / bytes_per_byte) <= 8) {
     val_refines = true;
-    for (unsigned off = 0; off < bytes; off += bytes_per_byte) {
+    for (unsigned off = 0; off < (bytes / bytes_per_byte); ++off) {
       expr off_expr = expr::mkUInt(off, Pointer::bitsShortOffset());
       val_refines
         &= (ptr_offset == off_expr).implies(

--- a/ir/memory.cpp
+++ b/ir/memory.cpp
@@ -1700,12 +1700,12 @@ void Memory::store(const StateValue &v, const Type &type, unsigned offset0,
 
   auto aty = type.getAsAggregateType();
   if (aty && !isNonPtrVector(type)) {
-    unsigned byteofs = offset0;
+    unsigned byteofs = 0;
     for (unsigned i = 0, e = aty->numElementsConst(); i < e; ++i) {
       auto &child = aty->getChild(i);
       if (child.bits() == 0)
         continue;
-      store(aty->extract(v, i), child, byteofs, data);
+      store(aty->extract(v, i), child, offset0 + byteofs, data);
       byteofs += getStoreByteSize(child);
     }
     assert(byteofs == getStoreByteSize(type));

--- a/ir/memory.cpp
+++ b/ir/memory.cpp
@@ -68,13 +68,13 @@ static string local_name(const State *s, const char *name) {
 }
 
 static bool is_initial_memblock(const expr &e, bool match_any_init = false) {
-  auto name = e.fn_name();
-  {
+  string name;
   expr load, blk, idx;
   unsigned hi, lo;
   if (e.isExtract(load, hi, lo) && load.isLoad(blk, idx))
     name = blk.fn_name();
-  }
+  else
+    name = e.fn_name();
 
   if (string_view(name).substr(0, 9) == "init_mem_")
     return true;

--- a/ir/memory.cpp
+++ b/ir/memory.cpp
@@ -1053,15 +1053,17 @@ void Memory::access(const Pointer &ptr, unsigned bytes, unsigned align,
   bool has_both = has_local && has_nonlocal;
   bool is_singleton = has_local + has_nonlocal == 1;
   expr bid = has_both ? ptr.getBid() : ptr.getShortBid();
-  unsigned bits_bid = bits_shortbid();
   expr one = expr::mkUInt(1, 1);
 
   for (unsigned i = 0, e = access_local.size(); i < e; ++i) {
     if (access_local[i]) {
       auto &[mem, undef] = local_block_val[i];
-      auto n = expr::mkUInt(i, bits_bid);
+      auto n = expr::mkUInt(i, bits_shortbid());
       fn(const_cast<expr&>(mem), const_cast<set<expr>&>(undef), i, true,
-         is_singleton ? true : bid == (has_both ? one.concat(n) : n));
+         is_singleton ? true
+                      : (has_local == 1
+                           ? is_local
+                           : bid == (has_both ? one.concat(n) : n)));
     }
   }
 
@@ -1069,7 +1071,7 @@ void Memory::access(const Pointer &ptr, unsigned bytes, unsigned align,
     if (access_nonlocal[i]) {
       auto &[mem, undef] = non_local_block_val[i];
       fn(const_cast<expr&>(mem), const_cast<set<expr>&>(undef), i, false,
-         is_singleton ? true : bid == i);
+         is_singleton ? true : (has_nonlocal == 1 ? !is_local : bid == i));
     }
   }
 }

--- a/ir/memory.cpp
+++ b/ir/memory.cpp
@@ -1090,7 +1090,7 @@ vector<Byte> Memory::load(const Pointer &ptr, unsigned bytes, set<expr> &undef,
     for (unsigned i = 0; i < loaded_bytes; ++i) {
       unsigned idx = left2right ? i : (loaded_bytes - i - 1);
       expr off = offset + expr::mkUInt(idx, off_bits);
-      loaded[i].add(mem.load(off), move(cond));
+      loaded[i].add(mem.load(off), cond);
       undef.insert(mem_undef.begin(), mem_undef.end());
     }
   };

--- a/ir/memory.cpp
+++ b/ir/memory.cpp
@@ -1866,9 +1866,10 @@ void Memory::copy(const Pointer &src, const Pointer &dst) {
   }
 
   assert(local.isConst());
-  uint64_t bid;
-  ENSURE(dst.getShortBid().isUInt(bid));
-  auto &p = (local.isTrue() ? local_block_val : non_local_block_val)[bid];
+  bool dst_local = local.isTrue();
+  uint64_t dst_bid;
+  ENSURE(dst.getShortBid().isUInt(dst_bid));
+  auto &p = (dst_local ? local_block_val : non_local_block_val)[dst_bid];
   auto &undef = p.second;
   undef.clear();
 
@@ -1877,6 +1878,9 @@ void Memory::copy(const Pointer &src, const Pointer &dst) {
 
   auto fn = [&](expr &mem, set<expr> &mem_undef, unsigned bid, bool local,
                 expr &&cond) {
+    // we assume src != dst
+    if (local == dst_local && bid == dst_bid)
+      return;
     val.add(mem, move(cond));
     undef.insert(mem_undef.begin(), mem_undef.end());
   };

--- a/ir/memory.cpp
+++ b/ir/memory.cpp
@@ -1414,7 +1414,7 @@ Memory::mkFnRet(const char *name,
   expr var
     = expr::mkFreshVar(name, expr::mkUInt(0, bits_bid + bits_for_offset));
   auto p_bid = var.extract(bits_bid + bits_for_offset - 1, bits_for_offset);
-  if (!has_local)
+  if (!has_local && ptr_has_local_bit())
     p_bid = expr::mkUInt(0, 1).concat(p_bid);
   Pointer p(*this, p_bid, var.extract(bits_for_offset-1, 0));
   auto bid = p.getShortBid();

--- a/ir/memory.cpp
+++ b/ir/memory.cpp
@@ -29,9 +29,7 @@ static bool observes_addresses() {
 
 static unsigned zero_bits_offset() {
   assert(is_power2(bits_byte));
-  // If an address is observed, bits_bytes is not necessarily related with
-  // offsets.
-  return observes_addresses() ? 0 : ilog2(bits_byte / 8);
+  return ilog2(bits_byte / 8);
 }
 
 static bool byte_has_ptr_bit() {

--- a/ir/memory.cpp
+++ b/ir/memory.cpp
@@ -1895,7 +1895,7 @@ expr Memory::blockValRefined(const Memory &other, unsigned bid, bool local,
                              const expr &offset, set<expr> &undef) const {
   assert(!local);
   auto &[mem1, undef1] = non_local_block_val[bid];
-  auto &[mem2, undef2] = other.non_local_block_val[bid];
+  auto &mem2 = other.non_local_block_val[bid].first;
 
   if (mem1.eq(mem2))
     return true;
@@ -1907,7 +1907,6 @@ expr Memory::blockValRefined(const Memory &other, unsigned bid, bool local,
     return true;
 
   undef.insert(undef1.begin(), undef1.end());
-  undef.insert(undef2.begin(), undef2.end());
 
   // refinement if offset had non-ptr value
   expr np1 = val.nonptrNonpoison();

--- a/ir/memory.cpp
+++ b/ir/memory.cpp
@@ -1853,6 +1853,14 @@ void Memory::memcpy(const expr &d, const expr &s, const expr &bytesize,
 
 void Memory::copy(const Pointer &src, const Pointer &dst) {
   auto local = dst.isLocal();
+  if (!local.isValid()) {
+    local_block_val.clear();
+    non_local_block_val.clear();
+    local_block_val.resize(numLocals());
+    non_local_block_val.resize(numNonlocals());
+    return;
+  }
+
   assert(local.isConst());
   uint64_t bid;
   ENSURE(dst.getShortBid().isUInt(bid));

--- a/ir/memory.cpp
+++ b/ir/memory.cpp
@@ -1134,7 +1134,8 @@ void Memory::store(const Pointer &ptr,
         blk_size == bytes) {
       mem = expr::mkConstArray(offset, data[0].second);
       full_write = true;
-      mem_undef.clear();
+      if (cond.isTrue())
+        mem_undef.clear();
     }
 
     for (auto &[idx, val] : data) {

--- a/ir/memory.cpp
+++ b/ir/memory.cpp
@@ -1111,8 +1111,8 @@ vector<Byte> Memory::load(const Pointer &ptr, unsigned bytes, set<expr> &undef,
   auto fn = [&](MemVal &blks, unsigned bid, bool local, const expr &cond) {
     // TODO: optimize using loaded type to produce poison
     for (unsigned i = 0; i < loaded_bytes; ++i) {
-      unsigned idx = left2right ? i : (loaded_bytes - i - 1);
-      expr off = offset + expr::mkUInt(idx, off_bits);
+      unsigned idx = (left2right ? i : (loaded_bytes - i - 1)) * bytesz;
+      expr off = offset + expr::mkUInt(idx >> zero_bits_offset(), off_bits);
       loaded[i].add(blks[bid].first.load(off), cond);
       undef.insert(blks[bid].second.begin(), blks[bid].second.end());
     }

--- a/ir/memory.cpp
+++ b/ir/memory.cpp
@@ -1957,7 +1957,8 @@ expr Memory::blockRefined(const Pointer &src, const Pointer &tgt, unsigned bid,
     }
   } else {
     val_refines
-      = blockValRefined(tgt.getMemory(), bid, false, ptr_offset, undef);
+      = src.getOffsetSizet().ult(blk_size).implies(
+          blockValRefined(tgt.getMemory(), bid, false, ptr_offset, undef));
   }
 
   assert(src.isWritable().eq(tgt.isWritable()));
@@ -1968,7 +1969,7 @@ expr Memory::blockRefined(const Pointer &src, const Pointer &tgt, unsigned bid,
          src.getAllocType() == tgt.getAllocType() &&
          state->simplifyWithAxioms(
            src.blockAlignment().ule(tgt.blockAlignment())) &&
-         (alive && src.getOffsetSizet().ult(blk_size)).implies(val_refines);
+         alive.implies(val_refines);
 }
 
 tuple<expr, Pointer, set<expr>>

--- a/ir/memory.h
+++ b/ir/memory.h
@@ -342,6 +342,8 @@ public:
   static Memory mkIf(const smt::expr &cond, const Memory &then,
                      const Memory &els);
 
+  static void resetState();
+
   // for container use only
   bool operator<(const Memory &rhs) const;
 

--- a/ir/memory.h
+++ b/ir/memory.h
@@ -335,6 +335,9 @@ public:
               const smt::expr &bytesize, unsigned align_dst, unsigned align_src,
               bool move);
 
+  // full copy of memory blocks
+  void copy(const Pointer &src, const Pointer &dst);
+
   smt::expr ptr2int(const smt::expr &ptr) const;
   smt::expr int2ptr(const smt::expr &val) const;
 

--- a/ir/memory.h
+++ b/ir/memory.h
@@ -221,11 +221,14 @@ class Memory {
 
   void mk_nonlocal_val_axioms(bool skip_consts);
 
-  enum loadType { LOAD_ANY, LOAD_INT, LOAD_PTR };
+  bool mayalias(bool local, unsigned bid, const smt::expr &offset,
+                unsigned bytes, unsigned align, bool write) const;
 
   template <typename Fn>
   void access(const Pointer &ptr, unsigned btyes, unsigned align, bool write,
               Fn &fn) const;
+
+  enum loadType { LOAD_ANY, LOAD_INT, LOAD_PTR };
 
   std::vector<Byte> load(const Pointer &ptr, unsigned bytes,
                          std::set<smt::expr> &undef, unsigned align,

--- a/ir/memory.h
+++ b/ir/memory.h
@@ -236,9 +236,8 @@ class Memory {
   void store(const Pointer &p, const smt::expr &val, MemVal &blks,
              const smt::expr &cond, const std::set<smt::expr> &undef,
              bool local, unsigned align) const;
-  void store(const Pointer &p, const smt::expr &val, MemVal &local,
-             MemVal &non_local, const std::set<smt::expr> &undef,
-             unsigned align);
+  void store(const Pointer &p, const smt::expr &val,
+             const std::set<smt::expr> &undef, unsigned align);
   void storeLambda(const Pointer &p, const smt::expr &offset,
                    const smt::expr &size, const smt::expr &val,
                    const std::set<smt::expr> &undef);

--- a/ir/memory.h
+++ b/ir/memory.h
@@ -244,9 +244,9 @@ class Memory {
   void store(const StateValue &val, const Type &type, unsigned offset,
              std::vector<std::pair<unsigned, smt::expr>> &data);
 
-  void storeLambda(const Pointer &p, const smt::expr &offset,
-                   const smt::expr &size, const smt::expr &val,
-                   const std::set<smt::expr> &undef);
+  void storeLambda(const Pointer &ptr, const smt::expr &offset,
+                   const smt::expr &bytes, const smt::expr &val,
+                   const std::set<smt::expr> &undef, unsigned align);
 
 public:
   enum BlockKind {

--- a/ir/memory.h
+++ b/ir/memory.h
@@ -116,7 +116,7 @@ public:
   static unsigned totalBitsShort();
   static unsigned bitsShortOffset();
 
-  smt::expr isLocal() const;
+  smt::expr isLocal(bool simplify = true) const;
 
   smt::expr getBid() const;
   smt::expr getShortBid() const; // same as getBid but ignoring is_local bit
@@ -176,7 +176,7 @@ public:
   };
   smt::expr getAllocType() const;
   smt::expr isHeapAllocated() const;
-  smt::expr isNocapture() const;
+  smt::expr isNocapture(bool simplify = true) const;
   smt::expr isReadonly() const;
   smt::expr isReadnone() const;
 

--- a/ir/memory.h
+++ b/ir/memory.h
@@ -158,10 +158,10 @@ public:
   smt::expr blockAlignment() const; // log(bits)
   smt::expr isBlockAligned(unsigned align, bool exact = false) const;
   smt::expr isAligned(unsigned align);
-  smt::AndExpr isDereferenceable(unsigned bytes, unsigned align = bits_byte / 8,
+  smt::AndExpr isDereferenceable(uint64_t bytes, unsigned align = bits_byte / 8,
                                  bool iswrite = false);
   smt::AndExpr isDereferenceable(const smt::expr &bytes, unsigned align,
-                                  bool iswrite);
+                                 bool iswrite);
   void isDisjoint(const smt::expr &len1, const Pointer &ptr2,
                    const smt::expr &len2) const;
   smt::expr isBlockAlive() const;
@@ -226,18 +226,17 @@ class Memory {
   void mk_nonlocal_val_axioms(bool skip_consts);
 
   static smt::expr load(const Pointer &p, const MemVal &blks,
-                        std::set<smt::expr> &undef, bool local, unsigned align);
-  static smt::expr load(const Pointer &p, const MemVal &local,
-                        const MemVal &non_local, std::set<smt::expr> &undef,
-                        unsigned align);
+                        std::set<smt::expr> &undef, bool local,
+                        unsigned align, unsigned limit);
   StateValue load(const Pointer &ptr, const Type &type,
                   std::set<smt::expr> &undef, unsigned align) const;
 
-  void store(const Pointer &p, const smt::expr &val, MemVal &blks,
-             const smt::expr &cond, const std::set<smt::expr> &undef,
-             bool local, unsigned align) const;
-  void store(const Pointer &p, const smt::expr &val,
+  void store(const Pointer &ptr,
+             const std::vector<std::pair<unsigned, smt::expr>> &data,
              const std::set<smt::expr> &undef, unsigned align);
+  void store(const StateValue &val, const Type &type, unsigned offset,
+             std::vector<std::pair<unsigned, smt::expr>> &data);
+
   void storeLambda(const Pointer &p, const smt::expr &offset,
                    const smt::expr &size, const smt::expr &val,
                    const std::set<smt::expr> &undef);
@@ -309,8 +308,7 @@ public:
 
   static unsigned getStoreByteSize(const Type &ty);
   void store(const smt::expr &ptr, const StateValue &val, const Type &type,
-             unsigned align, const std::set<smt::expr> &undef_vars,
-             bool deref_check = true);
+             unsigned align, const std::set<smt::expr> &undef_vars);
   std::pair<StateValue, smt::AndExpr> load(const smt::expr &ptr,
       const Type &type, unsigned align) const;
 

--- a/ir/memory.h
+++ b/ir/memory.h
@@ -185,10 +185,6 @@ public:
   smt::expr refined(const Pointer &other) const;
   smt::expr fninputRefined(const Pointer &other, std::set<smt::expr> &undef,
                            bool is_byval_arg) const;
-  smt::expr blockValRefined(const Pointer &other,
-                            std::set<smt::expr> &undef) const;
-  smt::expr blockRefined(const Pointer &other,
-                         std::set<smt::expr> &undef) const;
 
   const Memory& getMemory() const { return m; }
 
@@ -247,6 +243,12 @@ class Memory {
   void storeLambda(const Pointer &ptr, const smt::expr &offset,
                    const smt::expr &bytes, const smt::expr &val,
                    const std::set<smt::expr> &undef, unsigned align);
+
+  smt::expr blockValRefined(const Memory &other, unsigned bid, bool local,
+                            const smt::expr &offset,
+                            std::set<smt::expr> &undef) const;
+  smt::expr blockRefined(const Pointer &src, const Pointer &tgt, unsigned bid,
+                         std::set<smt::expr> &undef) const;
 
 public:
   enum BlockKind {

--- a/ir/memory.h
+++ b/ir/memory.h
@@ -225,9 +225,16 @@ class Memory {
 
   void mk_nonlocal_val_axioms(bool skip_consts);
 
-  static smt::expr load(const Pointer &p, const MemVal &blks,
-                        std::set<smt::expr> &undef, bool local,
-                        unsigned align, unsigned limit);
+  enum loadType { LOAD_ANY, LOAD_INT, LOAD_PTR };
+
+  template <typename Fn>
+  void access(const Pointer &ptr, unsigned btyes, unsigned align, bool write,
+              Fn &fn) const;
+
+  std::vector<Byte> load(const Pointer &ptr, unsigned bytes,
+                         std::set<smt::expr> &undef, unsigned align,
+                         bool left2right = true,
+                         loadType type = LOAD_ANY) const;
   StateValue load(const Pointer &ptr, const Type &type,
                   std::set<smt::expr> &undef, unsigned align) const;
 

--- a/ir/memory.h
+++ b/ir/memory.h
@@ -269,7 +269,7 @@ public:
 
   void mkAxioms(const Memory &other) const;
 
-  static void resetBids(unsigned last_nonlocal);
+  static void resetBids(unsigned last_nonlocal, bool is_source);
 
   void markByVal(unsigned bid);
   smt::expr mkInput(const char *name, const ParamAttrs &attrs) const;

--- a/ir/state.cpp
+++ b/ir/state.cpp
@@ -321,7 +321,6 @@ StateValue State::rewriteUndef(StateValue &&val, const set<expr> &undef_vars) {
 
 void State::finishInitializer() {
   is_initialization_phase = false;
-  memory.finishInitialization();
 }
 
 expr State::sinkDomain() const {
@@ -414,6 +413,7 @@ void State::mkAxioms(State &tgt) {
         if (refines.isFalse())
           continue;
 
+        set<expr> undef_vars;
         for (unsigned i = 0, e = ptr_ins.size(); i != e; ++i) {
           // TODO: needs to take read/read2 as input to control if mem blocks
           // need to be compared
@@ -427,7 +427,8 @@ void State::mkAxioms(State &tgt) {
             break;
           }
           expr eq_val = Pointer(mem, ptr_in.value)
-                      .fninputRefined(Pointer(mem2, ptr_in2.value), is_byval2);
+                          .fninputRefined(Pointer(mem2, ptr_in2.value),
+                                          undef_vars, is_byval2);
           refines &= ptr_in.non_poison
                        .implies(eq_val && ptr_in2.non_poison);
 
@@ -438,14 +439,13 @@ void State::mkAxioms(State &tgt) {
         if (refines.isFalse())
           continue;
 
+        quantified_vars.insert(undef_vars.begin(), undef_vars.end());
+
         if (reads2) {
           auto restrict_ptrs = argmem2 ? &ptr_ins2 : nullptr;
-          expr mem_refined = mem.refined(mem2, true, restrict_ptrs).first;
-          refines &= mem_refined;
-          if (!mem_refined.isConst()) {
-            auto &u = mem.getUndefVars();
-            quantified_vars.insert(u.begin(), u.end());
-          }
+          auto data = mem.refined(mem2, true, restrict_ptrs);
+          refines &= get<0>(data);
+          quantified_vars.insert(get<2>(data).begin(), get<2>(data).end());
         }
 
         expr ref_expr(true);

--- a/ir/state.cpp
+++ b/ir/state.cpp
@@ -38,7 +38,7 @@ State::State(Function &f, bool source)
     return_val(f.getType().getDummyValue(false)), return_memory(memory) {}
 
 void State::resetGlobals() {
-  Memory::resetBids(has_null_block);
+  Memory::resetBids(has_null_block, true);
 }
 
 const StateValue& State::exec(const Value &v) {
@@ -378,7 +378,7 @@ void State::syncSEdataWithSrc(const State &src) {
   }
 
   // The bid of tgt global starts with num_nonlocals_src
-  Memory::resetBids(num_nonlocals_src);
+  Memory::resetBids(num_nonlocals_src, false);
 }
 
 void State::mkAxioms(State &tgt) {

--- a/ir/state.h
+++ b/ir/state.h
@@ -191,6 +191,10 @@ public:
   void mkAxioms(State &tgt);
   smt::expr simplifyWithAxioms(smt::expr &&e) const;
 
+  struct cleanup_state {
+    ~cleanup_state() { Memory::resetState(); }
+  };
+
 private:
   void addJump(const BasicBlock &dst, smt::expr &&domain);
 };

--- a/smt/ctx.cpp
+++ b/smt/ctx.cpp
@@ -3,7 +3,23 @@
 
 #include "smt/ctx.h"
 #include "smt/smt.h"
+#include <cstdlib>
+#include <iostream>
+#include <string_view>
 #include <z3.h>
+
+using namespace std;
+
+static void z3_error_handler(Z3_context ctx, Z3_error_code err) {
+  string_view str = Z3_get_error_msg(ctx, err);
+
+  // harmless timeout
+  if (str == "canceled")
+    return;
+
+  cerr << "Severe Z3 error: " << str << " [code=" << err << "]\n";
+  exit(-1);
+}
 
 namespace smt {
 
@@ -19,6 +35,7 @@ void context::init() {
   // They generate incorrect formulas when quantifiers are involved
   Z3_global_param_set("rewriter.hi_fp_unspecified", "true");
   ctx = Z3_mk_context_rc(nullptr);
+  Z3_set_error_handler(ctx, z3_error_handler);
 }
 
 void context::destroy() {

--- a/smt/expr.cpp
+++ b/smt/expr.cpp
@@ -1626,7 +1626,9 @@ expr expr::mkLambda(const set<expr> &vars, const expr &val) {
 
 expr expr::simplify() const {
   C();
-  return Z3_simplify(ctx(), ast());
+  auto e = Z3_simplify(ctx(), ast());
+  // Z3_simplify returns null on timeout
+  return e ? e : *this;
 }
 
 expr expr::subst(const vector<pair<expr, expr>> &repls) const {

--- a/smt/expr.cpp
+++ b/smt/expr.cpp
@@ -1368,6 +1368,12 @@ expr expr::concat(const expr &rhs) const {
     if (rhs.isConcat(b, c) && b.isExtract(d, h2, l2) && l == h2+1 && a.eq(d))
       return a.extract(h, l2).concat(c);
   }
+
+  // (concat (concat x extract) extract)
+  if (isConcat(a, b) && b.isExtract(c, h, l) && rhs.isExtract(d, h2, l2) &&
+      l == h2+1 && c.eq(d))
+    return a.concat(c.extract(h, l2));
+
   return binop_fold(rhs, Z3_mk_concat);
 }
 

--- a/smt/expr.cpp
+++ b/smt/expr.cpp
@@ -1168,23 +1168,23 @@ expr expr::operator!=(const expr &rhs) const {
 }
 
 expr expr::operator&&(const expr &rhs) const {
-  C(rhs);
   if (eq(rhs) || isFalse() || rhs.isTrue())
     return *this;
   if (isTrue() || rhs.isFalse())
     return rhs;
 
+  C(rhs);
   Z3_ast args[] = { ast(), rhs() };
   return Z3_mk_and(ctx(), 2, args);
 }
 
 expr expr::operator||(const expr &rhs) const {
-  C(rhs);
   if (eq(rhs) || rhs.isFalse() || isTrue())
     return *this;
   if (rhs.isTrue() || isFalse())
     return rhs;
 
+  C(rhs);
   Z3_ast args[] = { ast(), rhs() };
   return Z3_mk_or(ctx(), 2, args);
 }

--- a/tests/alive-tv/memory/memset-large.src.ll
+++ b/tests/alive-tv/memory/memset-large.src.ll
@@ -1,5 +1,3 @@
-; TEST-ARGS: -disable-undef-input
-
 declare void @llvm.memset.p0i8.i128(i8*, i8, i128, i1)
 
 define void @f(i8* %p, i128 %n) {

--- a/tools/transform.cpp
+++ b/tools/transform.cpp
@@ -1033,7 +1033,9 @@ void Transform::preprocess() {
         to_remove.clear();
       }
 
-      changed |= fn->removeUnusedStuff(users);
+      changed |=
+        fn->removeUnusedStuff(users, fn == &src ? vector<string_view>()
+                                                : src.getGlobalVarNames());
     } while (changed);
   }
 }

--- a/tools/transform.cpp
+++ b/tools/transform.cpp
@@ -827,6 +827,7 @@ Errors TransformVerify::verify() const {
   StopWatch symexec_watch;
   calculateAndInitConstants(t);
   State::resetGlobals();
+  State::cleanup_state cleanup;
   State src_state(t.src, true), tgt_state(t.tgt, false);
 
   try {

--- a/tools/transform.cpp
+++ b/tools/transform.cpp
@@ -513,7 +513,7 @@ static unsigned returns_nonlocal(const Instr &inst,
 static void calculateAndInitConstants(Transform &t) {
   const auto &globals_tgt = t.tgt.getGlobalVars();
   const auto &globals_src = t.src.getGlobalVars();
-  unsigned num_globals_src = globals_src.size();
+  num_globals_src = globals_src.size();
   unsigned num_globals = num_globals_src;
 
   // FIXME: varies among address spaces


### PR DESCRIPTION
Unfortunately I had to replace the single memory implementation, but I'll reimplement it later as it's good for comparison.

Results time-wise are similar, but we get fewer OOMs and more bugs found:
```
file        | OOM | domain | memory | precondition | poison | total |
---------------------------------------------------------------------
bzip2.ic0   |  2  |        |        |      11      |        |  13   |
bzip2.ic6   |  1  |        |        |      11      |        |  12   |
gzip.ic0    |  2  |        |        |      11      |        |  13   |
gzip.ic6    |  1  |        |        |      11      |        |  12   |
oggenc.ic0  |  7  |   6    |   1    |      13      |        |  27   |
oggenc.ic6  |  6  |   6    |   1    |      13      |        |  26   |
ph7.ic0     |  1  |   67   |   5    |      4       |        |  77   |
ph7.ic6     |     |   70   |   5    |      4       |        |  79   |
```

WIP; just to track status and ideas.