### PR TITLE
Fix recommending abnormal cmake usage in the build directions

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ cmake -GNinja -DLLVM_ENABLE_RTTI=ON -DLLVM_ENABLE_EH=ON -DBUILD_SHARED_LIBS=ON -
 
 Alive2 should then be configured as follows:
 ```
-cmake -GNinja -DLLVM_DIR=~/llvm/build/lib/cmake/llvm -DBUILD_TV=1 -DCMAKE_BUILD_TYPE=Release ..
+cmake -GNinja -DCMAKE_PREFIX_PATH=~/llvm/build -DBUILD_TV=1 -DCMAKE_BUILD_TYPE=Release ..
 ```
 
 If you want to use Alive2 as a clang plugin, add `-DCLANG_PLUGIN=1` to the


### PR DESCRIPTION
LLVM_DIR is an internally set variable by find_package. It's better to
prioritize finding it through the standard search mechanisms, rather
than directly setting this.