### PR TITLE
Fix issue 455

### DIFF
--- a/ir/state.cpp
+++ b/ir/state.cpp
@@ -374,7 +374,7 @@ void State::syncSEdataWithSrc(const State &src) {
     }
   }
 
-  memory.syncWithSrc(src.memory);
+  memory.syncWithSrc(src.returnMemory());
 }
 
 void State::mkAxioms(State &tgt) {

--- a/tests/alive-tv/calls/issue455.srctgt.ll
+++ b/tests/alive-tv/calls/issue455.srctgt.ll
@@ -1,0 +1,37 @@
+define i32 @src(i1 %cond) {
+entry:
+  br label %do.body
+
+do.body:
+  br i1 %cond, label %do.end, label %if.then5
+
+if.then5:
+  unreachable
+
+do.end:
+  %call14 = call i32* @readnone()
+  store i32 0, i32* %call14, align 4
+  tail call void @read_error()
+  unreachable
+}
+
+define i32 @tgt(i1 %cond) {
+entry:
+  br label %do.body
+
+do.body:
+  br i1 %cond, label %do.end, label %if.then5
+
+if.then5:
+  unreachable
+
+do.end:
+  %call14 = call i32* @readnone()
+  store i32 0, i32* %call14, align 4
+  tail call void @read_error()
+  unreachable
+}
+
+declare i32 @f()
+declare void @read_error() noreturn
+declare i32* @readnone() readnone


### PR DESCRIPTION
The memory to synchronize should be the return memory of the source, otherwise it may miss memories from some returning blocks.