### PR TITLE
Update local block refinement rule

### DIFF
--- a/ir/memory.cpp
+++ b/ir/memory.cpp
@@ -797,7 +797,7 @@ expr Pointer::refined(const Pointer &other) const {
   // TODO: this induces an infinite loop
   //local &= block_refined(other);
 
-  return expr::mkIf(isLocal(), isHeapAllocated().implies(local), *this == other)
+  return expr::mkIf(isLocal(), move(local), *this == other)
       && isBlockAlive().implies(other.isBlockAlive());
 }
 


### PR DESCRIPTION
This removes `isHeapAllocated().implies` as discussed before
LLVM unit tests: no regression
Single file benchmark: [results.txt](https://github.com/AliveToolkit/alive2/files/5078492/results.txt); the new incorrect pairs in sqlite3 are miscompilations (a known bug in simplifycfg that introduces UB)