### PR TITLE
Fix invalid expr error when an empty struct is used

### DIFF
--- a/tests/alive-tv/attrs/noundefaggr-empty.srctgt.ll
+++ b/tests/alive-tv/attrs/noundefaggr-empty.srctgt.ll
@@ -1,4 +1,3 @@
-; FIXME: Empty aggregate should be well-supported
 @g = global {{}, i32} undef
 
 ; Does not touch padding
@@ -28,6 +27,3 @@ A:
 B:
   ret i32 1
 }
-
-; FIXME: This should be correct
-; XFAIL: Source is more defined than target

--- a/tests/alive-tv/emptyaggr-load.srctgt.ll
+++ b/tests/alive-tv/emptyaggr-load.srctgt.ll
@@ -1,0 +1,13 @@
+; SKIP-IDENTITY
+
+define {} @src({}* %p, {}* %q) {
+  %v = load {}, {}* %p
+  %w = load {}, {}* %q
+  ret {} %v
+}
+
+define {} @tgt({}* %p, {}* %q) {
+  %v = load {}, {}* %p
+  %w = load {}, {}* %q
+  ret {} %w
+}

--- a/tests/alive-tv/emptyaggr-store.srctgt.ll
+++ b/tests/alive-tv/emptyaggr-store.srctgt.ll
@@ -1,0 +1,9 @@
+define void @src(i8* %p) {
+  %p2 = bitcast i8* %p to {}*
+  store {} {}, {}* %p2
+  ret void
+}
+
+define void @tgt(i8* %p) {
+  ret void
+}

--- a/tests/alive-tv/emptyaggr-store2.srctgt.ll
+++ b/tests/alive-tv/emptyaggr-store2.srctgt.ll
@@ -1,0 +1,11 @@
+; Show that storing {} is a nop
+
+define void @src(i8* noundef %p) {
+  ret void
+}
+
+define void @tgt(i8* noundef %p) {
+  %p2 = bitcast i8* %p to {}*
+  store {} {}, {}* %p2
+  ret void
+}

--- a/tests/alive-tv/emptyaggr.srctgt.ll
+++ b/tests/alive-tv/emptyaggr.srctgt.ll
@@ -1,0 +1,9 @@
+; SKIP-IDENTITY
+
+define {} @src({} %v, {} %w) {
+  ret {} %v
+}
+
+define {} @tgt({} %v, {} %w) {
+  ret {} %w
+}


### PR DESCRIPTION
This patch encodes an empty aggregate as a statevalue `{expr::mkUInt(0, 1), expr::mkUInt(1, 1)}`.
I used uint for non-poison to make `AggregateType::np_bits` return a valid value.

LLVM unit tests: no failure regression, no invalidexpr test added