### PR TITLE
Freeze should keep padding poison

### DIFF
--- a/ir/instr.cpp
+++ b/ir/instr.cpp
@@ -1908,10 +1908,12 @@ StateValue Freeze::toSMT(State &s) const {
     vector<StateValue> vals;
     auto ty = getType().getAsAggregateType();
     for (unsigned i = 0, e = ty->numElementsConst(); i != e; ++i) {
+      if (ty->isPadding(i))
+        continue;
       auto vi = ty->extract(v, i);
       vals.emplace_back(scalar(vi.value, vi.non_poison, ty->getChild(i)));
     }
-    return ty->aggregateVals(vals);
+    return ty->aggregateVals(vals, true);
   }
   return scalar(v.value, v.non_poison, getType());
 }


### PR DESCRIPTION
freeze should keep padding poison when returning an aggregate value.
This resolves `test/Transforms/InstSimplify/freeze-noundef.ll` 's failure:

```
define {i8, i24, i32} @aggr({i8, i24, i32} noundef %x) {                           
%0:                                                                                
  %y = freeze {i8, i24, i32} noundef %x                                            
  ret {i8, i24, i32} %y                                                            
}                                                                                  
=>                                                                                 
define {i8, i24, i32} @aggr({i8, i24, i32} noundef %x) {                           
%0:                                                                                
  ret {i8, i24, i32} noundef %x                                                    
}                                                                                  
Transformation doesn't verify!                                                     
ERROR: Target is more poisonous than source                                        
                                                                                   
Example:                                                                           
{i8, i24, i32} noundef %x = { undef, poison, undef }                               
                                                                                   
Source:                                                                            
{i8, i24, i32} %y = { undef, undef, undef }                                        
                                                                                   
Target:                                                                            
Source value: { undef, undef, undef }                                              
Target value: { undef, poison, undef }                                             
```