### PR TITLE
Add a link to alive2.llvm.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Included tools:
 * Translation validation plugins for clang and LLVM's `opt`
 * Standalone translation validation tool: `alive-tv` ([online](https://alive2.llvm.org))
 
+
 WARNING
 -------
 Alive2 does not support inter-procedural transformations. Alive2 may crash

--- a/README.md
+++ b/README.md
@@ -13,8 +13,7 @@ Alive2 includes the following libraries:
 Included tools:
 * Alive drop-in replacement
 * Translation validation plugins for clang and LLVM's `opt`
-* Standalone translation validation tool: `alive-tv`
-
+* Standalone translation validation tool: `alive-tv` ([online](https://alive2.llvm.org))
 
 WARNING
 -------


### PR DESCRIPTION
This is a small patch that adds a link to https://alive2.llvm.org . :)