### PR TITLE
Add poison analysis

### DIFF
--- a/ir/instr.cpp
+++ b/ir/instr.cpp
@@ -632,7 +632,7 @@ StateValue BinOp::toSMT(State &s) const {
   } else {
     scalar_op = [&](auto a, auto ap, auto b, auto bp) -> StateValue {
       auto [v, np] = fn(a, ap, b, bp);
-      return { move(v), ap && (BinOp::isDivOrRem(op) ? true : bp) && np };
+      return { move(v), ap && bp && np };
     };
   }
 

--- a/ir/instr.cpp
+++ b/ir/instr.cpp
@@ -2758,9 +2758,9 @@ void Store::print(std::ostream &os) const {
 }
 
 StateValue Store::toSMT(State &s) const {
-  auto p = s.getAndAddPoisonUB(*ptr).value;
+  auto &p = s.getAndAddPoisonUB(*ptr).value;
   auto &v = s[*val];
-  s.getMemory().store(move(p), v, val->getType(), align, s.getUndefVars());
+  s.getMemory().store(p, v, val->getType(), align, s.getUndefVars());
   return {};
 }
 

--- a/ir/instr.cpp
+++ b/ir/instr.cpp
@@ -2542,9 +2542,9 @@ void Free::print(std::ostream &os) const {
 }
 
 StateValue Free::toSMT(State &s) const {
-  auto p = s.getAndAddPoisonUB(*ptr).value;
+  auto &p = s.getAndAddPoisonUB(*ptr).value;
   // If not heaponly, don't encode constraints
-  s.getMemory().free(move(p), !heaponly);
+  s.getMemory().free(p, !heaponly);
 
   if (s.getFn().getFnAttrs().has(FnAttrs::NoFree) && heaponly)
     s.addUB(expr(false));
@@ -2717,8 +2717,8 @@ void Load::print(std::ostream &os) const {
 }
 
 StateValue Load::toSMT(State &s) const {
-  auto p = s.getAndAddPoisonUB(*ptr).value;
-  auto [sv, ub] = s.getMemory().load(move(p), getType(), align);
+  auto &p = s.getAndAddPoisonUB(*ptr).value;
+  auto [sv, ub] = s.getMemory().load(p, getType(), align);
   s.addUB(move(ub));
   return sv;
 }

--- a/ir/instr.cpp
+++ b/ir/instr.cpp
@@ -3008,7 +3008,7 @@ void Strlen::print(ostream &os) const {
 }
 
 StateValue Strlen::toSMT(State &s) const {
-  auto eptr = s.getAndAddPoisonUB(*ptr).value;
+  auto &eptr = s.getAndAddPoisonUB(*ptr).value;
 
   Pointer p(s.getMemory(), eptr);
   Type &ty = getType();

--- a/ir/instr.h
+++ b/ir/instr.h
@@ -66,6 +66,8 @@ public:
   StateValue toSMT(State &s) const override;
   smt::expr getTypeConstraints(const Function &f) const override;
   std::unique_ptr<Instr> dup(const std::string &suffix) const override;
+
+  static bool isDivOrRem(const Op op);
 };
 
 

--- a/ir/state.cpp
+++ b/ir/state.cpp
@@ -127,9 +127,7 @@ const StateValue& State::getAndAddPoisonUB(const Value &val) {
   auto &v = (*this)[val];
   if (v.isValid()) {
     // If val is an aggregate, all elements should be non-poison
-    expr is_np = v.non_poison.isBool() ?
-                  v.non_poison :
-                  v.non_poison == expr::mkUInt(0, v.non_poison.bits());
+    expr is_np = v.non_poison.isBool() ? v.non_poison : v.non_poison == 0;
     if (!is_np.isTrue()) {
       analysis.non_poison_vals.insert(&val);
       addUB(move(is_np));

--- a/ir/state.cpp
+++ b/ir/state.cpp
@@ -125,8 +125,7 @@ const StateValue& State::getAndAddUndefs(const Value &val) {
 
 const StateValue& State::getAndAddPoisonUB(const Value &val) {
   auto &v = (*this)[val];
-  auto inserted = analysis.non_poison_vals.insert(&val);
-  if (!inserted.second)
+  if (!analysis.non_poison_vals.insert(&val).second)
     return v;
 
   // If val is an aggregate, all elements should be non-poison

--- a/ir/state.cpp
+++ b/ir/state.cpp
@@ -72,7 +72,7 @@ const StateValue& State::operator[](const Value &val) {
   auto &[sval, uvars] = val_uvars;
   (void)var;
 
-  auto simplify = [&](StateValue& sv, bool use_new_slot) -> StateValue& {
+  auto simplify = [&](StateValue &sv, bool use_new_slot) -> StateValue& {
     if (analysis.non_poison_vals.count(&val)) {
       if (use_new_slot) {
         assert(i_tmp_values < tmp_values.size());

--- a/ir/state.cpp
+++ b/ir/state.cpp
@@ -124,16 +124,11 @@ const StateValue& State::getAndAddUndefs(const Value &val) {
 }
 
 const StateValue& State::getAndAddPoisonUB(const Value &val) {
-  auto &v = (*this)[val];
-  if (v.isValid()) {
-    // If val is an aggregate, all elements should be non-poison
-    expr is_np = v.non_poison.isBool() ? v.non_poison : v.non_poison == 0;
-    if (!is_np.isTrue()) {
-      analysis.non_poison_vals.insert(&val);
-      addUB(move(is_np));
-    }
-  }
-  return v;
+  analysis.non_poison_vals.insert(&val);
+  auto &np = get<1>(values[values_map.at(&val)]).first.non_poison;
+  // If val is an aggregate, all elements should be non-poison
+  addUB(np.isBool() ? np : np == 0);
+  return (*this)[val];
 }
 
 const State::ValTy& State::at(const Value &val) const {

--- a/ir/state.h
+++ b/ir/state.h
@@ -47,6 +47,19 @@ private:
     smt::expr operator()() const;
   };
 
+  struct ValueAnalysis {
+    std::set<const Value *> non_poison_vals; // vars that are not poison
+
+    void intersect(const ValueAnalysis &other);
+    void reset();
+  };
+
+  struct BasicBlockInfo {
+    DomainPreds domain;
+    ValueAnalysis analysis;
+    smt::DisjointExpr<Memory> mem;
+  };
+
   // TODO: make this const again
   Function &f;
   bool source;
@@ -63,11 +76,9 @@ private:
   std::unordered_map<const Value*, unsigned> values_map;
   std::vector<std::tuple<const Value*, ValTy, bool>> values;
 
-  // dst BB -> src BB -> (domain data, memory)
+  // dst BB -> src BB -> BasicBlockInfo
   std::unordered_map<const BasicBlock*,
-                     std::unordered_map<const BasicBlock*,
-                                        std::pair<DomainPreds,
-                                                  smt::DisjointExpr<Memory>>>>
+                     std::unordered_map<const BasicBlock*, BasicBlockInfo>>
     predecessor_data;
   std::unordered_set<const BasicBlock*> seen_bbs;
 
@@ -78,6 +89,7 @@ private:
   CurrentDomain domain;
   Memory memory;
   std::set<smt::expr> undef_vars;
+  ValueAnalysis analysis;
   std::array<StateValue, 64> tmp_values;
   unsigned i_tmp_values = 0; // next available position in tmp_values
 
@@ -117,6 +129,7 @@ public:
   const StateValue& exec(const Value &v);
   const StateValue& operator[](const Value &val);
   const StateValue& getAndAddUndefs(const Value &val);
+  const StateValue& getAndAddPoisonUB(const Value &val);
   const ValTy& at(const Value &val) const;
   const smt::OrExpr* jumpCondFrom(const BasicBlock &bb) const;
   bool isUndef(const smt::expr &e) const;


### PR DESCRIPTION
This implements #468.

This removes one timeout from Alive2 unit tests.
I'll run & leave the LLVM unit test / single file benchmark results here.