### PR TITLE
fix clang compiler warning

### DIFF
--- a/llvm_util/llvm2alive.cpp
+++ b/llvm_util/llvm2alive.cpp
@@ -1054,7 +1054,7 @@ end:
 
       for (auto &bb : f) {
         auto n = bb_num(&bb);
-        for (const auto &dst : llvm::successors(&bb)) {
+        for (auto *dst : llvm::successors(&bb)) {
           auto n_dst = bb_num(dst);
           edges[n].emplace(n_dst);
         }


### PR DESCRIPTION
This fixes the following compiler warning generated by Clang:

[42/73] Building CXX object CMakeFiles/llvm_util.dir/llvm_util/llvm2alive.cpp.o
../llvm_util/llvm2alive.cpp:1007:26: warning: loop variable 'dst' is always a copy because the range of type 'llvm::succ_range' (aka 'iterator_range<SuccIterator<llvm::Instruction, llvm::BasicBlock> >') does not return a reference [-Wrange-loop-analysis]
        for (const auto &dst : llvm::successors(&bb)) {
                         ^
1 warning generated.