### PR TITLE
can_remove_init should consider pointer comparison

### DIFF
--- a/tests/alive-tv/globals/const2.srctgt.ll
+++ b/tests/alive-tv/globals/const2.srctgt.ll
@@ -1,0 +1,12 @@
+@glbl = constant i32 10
+
+define i32 @test61(i32* %ptr) {
+  %A = load i32, i32* %ptr
+  %B = icmp eq i32* %ptr, @glbl
+  %C = select i1 %B, i32 %A, i32 10
+  ret i32 %C
+}
+
+define i32 @tgt(i32* %ptr) {
+	ret i32 10
+}

--- a/tools/transform.cpp
+++ b/tools/transform.cpp
@@ -997,9 +997,14 @@ static map<string_view, Instr*> can_remove_init(Function &fn) {
         continue;
       }
 
+      // if (p == @const) read(load p) ; this should read @const (or raise UB)
+      if (dynamic_cast<ICmp*>(user)) {
+        needed = true;
+        break;
+      }
+
       // no useful users
-      if (dynamic_cast<ICmp*>(user) ||
-          dynamic_cast<Return*>(user))
+      if (dynamic_cast<Return*>(user))
         continue;
 
       if (dynamic_cast<MemInstr*>(user) && !dynamic_cast<GEP*>(user)) {


### PR DESCRIPTION
can_remove_init should consider pointer comparison because a pointer that is equal to the const global may be used to read the data.