### PR TITLE
Add undefImpliesUB, poisonImpliesUB

### DIFF
--- a/ir/attrs.h
+++ b/ir/attrs.h
@@ -24,6 +24,14 @@ public:
   bool has(Attribute a) const { return (bits & a) != 0; }
   void set(Attribute a) { bits |= (unsigned)a; }
 
+  // Returns true if it is UB for the argument to be poison / have poison elems.
+  bool poisonImpliesUB() const
+  { return has(NonNull) || has(Dereferenceable) || has(NoUndef) || has(ByVal); }
+
+   // Returns true if it is UB for the argument to be (partially) undef.
+  bool undefImpliesUB() const
+  { return has(NoUndef); }
+
   friend std::ostream& operator<<(std::ostream &os, const ParamAttrs &attr);
 };
 
@@ -44,6 +52,14 @@ public:
   void set(Attribute a) { bits |= (unsigned)a; }
   uint64_t getDerefBytes() const { return derefBytes; }
   void setDerefBytes(uint64_t bytes) { derefBytes = bytes; }
+
+  // Returns true if returning poison is UB
+  bool poisonImpliesUB() const
+  { return has(NonNull) || has(Dereferenceable) || has(NoUndef); }
+
+  // Returns true if returning (partially) undef is UB
+  bool undefImpliesUB() const
+  { return has(NoUndef); }
 
   friend std::ostream& operator<<(std::ostream &os, const FnAttrs &attr);
 };

--- a/ir/attrs.h
+++ b/ir/attrs.h
@@ -24,7 +24,7 @@ public:
   bool has(Attribute a) const { return (bits & a) != 0; }
   void set(Attribute a) { bits |= (unsigned)a; }
 
-  // Returns true if it is UB for the argument to be poison / have poison elems.
+  // Returns true if it's UB for the argument to be poison / have a poison elem.
   bool poisonImpliesUB() const
   { return has(NonNull) || has(Dereferenceable) || has(NoUndef) || has(ByVal); }
 
@@ -53,7 +53,7 @@ public:
   uint64_t getDerefBytes() const { return derefBytes; }
   void setDerefBytes(uint64_t bytes) { derefBytes = bytes; }
 
-  // Returns true if returning poison is UB
+  // Returns true if returning poison or an aggregate having a poison is UB
   bool poisonImpliesUB() const
   { return has(NonNull) || has(Dereferenceable) || has(NoUndef); }
 

--- a/ir/value.cpp
+++ b/ir/value.cpp
@@ -198,8 +198,6 @@ StateValue Input::mkInput(State &s, const Type &ty, unsigned child) const {
 
   bool has_byval = hasAttribute(ParamAttrs::ByVal);
   bool has_deref = hasAttribute(ParamAttrs::Dereferenceable);
-  bool has_nonnull = hasAttribute(ParamAttrs::NonNull);
-  bool has_noundef = hasAttribute(ParamAttrs::NoUndef);
 
   expr val;
   if (has_byval) {
@@ -227,8 +225,7 @@ StateValue Input::mkInput(State &s, const Type &ty, unsigned child) const {
     s.addAxiom(p.isDereferenceable(attrs.derefBytes, bits_byte/8, false));
   }
 
-  bool never_poison = config::disable_poison_input || has_byval || has_deref ||
-                      has_nonnull || has_noundef;
+  bool never_poison = config::disable_poison_input || attrs.poisonImpliesUB();
   string np_name = "np_" + getSMTName(child);
 
   return { move(val), never_poison ? true : expr::mkBoolVar(np_name.c_str()) };
@@ -239,10 +236,12 @@ StateValue Input::toSMT(State &s) const {
 }
 
 expr Input::getUndefVar(const Type &ty, unsigned child) const {
+  // TODO: Clarify whether byval/dereferenceable accept partially undefined
+  // pointers
   if (config::disable_undef_input ||
       hasAttribute(ParamAttrs::ByVal) ||
       hasAttribute(ParamAttrs::Dereferenceable) ||
-      hasAttribute(ParamAttrs::NoUndef))
+      attrs.undefImpliesUB())
     return {};
 
   string tyname = "isundef_" + getSMTName(child);


### PR DESCRIPTION
This is a refactoring that adds undefImpliesUB, poisonImpliesUB which return whether passing undef/poison to an argument with the attributes or returning undef/poison at the end of a function call is UB.

 