### PR TITLE
Add undef analysis

### DIFF
--- a/ir/attrs.cpp
+++ b/ir/attrs.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT license that can be found in the LICENSE file.
 
 #include "ir/attrs.h"
+#include <cassert>
 
 using namespace std;
 

--- a/ir/attrs.cpp
+++ b/ir/attrs.cpp
@@ -49,4 +49,16 @@ ostream& operator<<(ostream &os, const FnAttrs &attr) {
   return os;
 }
 
+bool ParamAttrs::undefImpliesUB() const {
+  bool ub = has(NoUndef);
+  assert(!ub || poisonImpliesUB());
+  return ub;
+}
+
+bool FnAttrs::undefImpliesUB() const {
+  bool ub = has(NoUndef);
+  assert(!ub || poisonImpliesUB());
+  return ub;
+}
+
 }

--- a/ir/attrs.h
+++ b/ir/attrs.h
@@ -29,8 +29,7 @@ public:
   { return has(NonNull) || has(Dereferenceable) || has(NoUndef) || has(ByVal); }
 
    // Returns true if it is UB for the argument to be (partially) undef.
-  bool undefImpliesUB() const
-  { return has(NoUndef); }
+  bool undefImpliesUB() const;
 
   friend std::ostream& operator<<(std::ostream &os, const ParamAttrs &attr);
 };
@@ -58,8 +57,7 @@ public:
   { return has(NonNull) || has(Dereferenceable) || has(NoUndef); }
 
   // Returns true if returning (partially) undef is UB
-  bool undefImpliesUB() const
-  { return has(NoUndef); }
+  bool undefImpliesUB() const;
 
   friend std::ostream& operator<<(std::ostream &os, const FnAttrs &attr);
 };

--- a/ir/state.cpp
+++ b/ir/state.cpp
@@ -254,7 +254,7 @@ State::getAndAddPoisonUB(const Value &val, bool undef_ub_too) {
       v = I->second;
     } else {
       v = strip_undef_and_add_ub(*this, val, v);
-      analysis.non_undef_vals[&val] = v;
+      analysis.non_undef_vals.emplace(&val, v);
     }
   }
 

--- a/ir/state.h
+++ b/ir/state.h
@@ -49,6 +49,8 @@ private:
 
   struct ValueAnalysis {
     std::set<const Value *> non_poison_vals; // vars that are not poison
+    // vars that are not undef (partially undefs are not allowed too)
+    std::map<const Value *, smt::expr> non_undef_vals;
 
     void intersect(const ValueAnalysis &other);
     void reset();
@@ -130,10 +132,12 @@ public:
   const StateValue& exec(const Value &v);
   const StateValue& operator[](const Value &val);
   const StateValue& getAndAddUndefs(const Value &val);
-  const StateValue& getAndAddPoisonUB(const Value &val);
+  // If undef_ub is true, UB is also added when val was undef
+  const StateValue& getAndAddPoisonUB(const Value &val, bool undef_ub = false);
+
   const ValTy& at(const Value &val) const;
   const smt::OrExpr* jumpCondFrom(const BasicBlock &bb) const;
-  bool isUndef(const smt::expr &e) const;
+  bool isUndef(const smt::expr &e, const Value *used_by = nullptr) const;
 
   bool startBB(const BasicBlock &bb);
   void addJump(const BasicBlock &dst);

--- a/ir/value.cpp
+++ b/ir/value.cpp
@@ -231,6 +231,13 @@ StateValue Input::mkInput(State &s, const Type &ty, unsigned child) const {
   return { move(val), never_poison ? true : expr::mkBoolVar(np_name.c_str()) };
 }
 
+bool Input::isUndefMask(const expr &e, const expr &var) {
+  auto ty_name = e.fn_name();
+  auto var_name = var.fn_name();
+  return string_view(ty_name).substr(0, 8) == "isundef_" &&
+         string_view(ty_name).substr(8, var_name.size()) == var_name;
+}
+
 StateValue Input::toSMT(State &s) const {
   return mkInput(s, getType(), 0);
 }

--- a/ir/value.h
+++ b/ir/value.h
@@ -122,6 +122,8 @@ public:
   const ParamAttrs &getAttributes() const { return attrs; }
   StateValue toSMT(State &s) const override;
   smt::expr getUndefVar(const Type &ty, unsigned child) const;
+
+  static bool isUndefMask(const smt::expr &e, const smt::expr &var);
 };
 
 }

--- a/tests/alive-tv/undef/opt-noundef.srctgt.ll
+++ b/tests/alive-tv/undef/opt-noundef.srctgt.ll
@@ -1,0 +1,14 @@
+; TEST-ARGS: -se-verbose
+declare void @f(i32 noundef)
+
+define i32 @src(i32 %x) {
+  call void @f(i32 %x)
+  ret i32 %x
+}
+
+define i32 @tgt(i32 %x) {
+  call void @f(i32 %x)
+  ret i32 %x
+}
+
+; CHECK: return = %x / true


### PR DESCRIPTION
This is a patch that follows #472 .

This patch adds a boolean argument to `State::getAndAddPoisonUB` that states whether passing an undef is UB as well and should strip it.

Consists of two commits - with the first commit only, the result of single file benchmark didn't improve. 

With the second comment, on my machine, `alive-tv/memory/storeptr.src.ll` raises no more timeout (became 2.7 sec). Single file benchmarks and unit tests are running.
But the second commit requires an assumption that passing a partially undefined pointer to load/store raises UB. I think this can be justified because memory sanitizer also detects such case (when an 'expensive detection' flag is turned on)