### PR TITLE
Load/store's pointer offset can have undef bits

### DIFF
--- a/tests/alive-tv/undef/load-undefidx.srctgt.ll
+++ b/tests/alive-tv/undef/load-undefidx.srctgt.ll
@@ -1,0 +1,14 @@
+; Relevant patch: https://reviews.llvm.org/D87994
+
+define i8 @src() {
+  ret i8 0
+}
+
+define i8 @tgt() {
+  %p = alloca [2 x i8]
+  store [2 x i8] [i8 0, i8 0], [2 x i8]* %p
+  %idx = and i64 undef, 1
+  %p2 = getelementptr [2 x i8], [2 x i8]* %p, i64 0, i64 %idx
+  %v = load i8, i8* %p2
+  ret i8 %v
+}


### PR DESCRIPTION
... and add a minor non-poison optimization to memset/memcpy.

BTW, I observed an interesting thing - actually, after my undef analysis patch had landed, `-smt-verbose` showed worse SMT formula for `alive-tv/memory/storeptr.src.ll`. It added 2 more undef quantified variables that are never used, and interestingly that led to better performance.

I attach the printed SMT formula.  [smt2.zip](https://github.com/AliveToolkit/alive2/files/5260859/smt2.zip)

If the formula is solved via command line z3, it succefully prints unsat. I think this may be related to that optimizations aren't sufficiently done after smt tactic is called.