### PR TITLE
Add refinement between undef and non-undef value

### DIFF
--- a/ir/type.cpp
+++ b/ir/type.cpp
@@ -1377,9 +1377,6 @@ bool hasPtr(const Type &t) {
 
   if (auto agg = t.getAsAggregateType()) {
     for (unsigned i = 0, e = agg->numElementsConst(); i != e; ++i) {
-      if (agg->isPadding(i))
-        continue;
-
       if (hasPtr(agg->getChild(i)))
         return true;
     }

--- a/ir/type.cpp
+++ b/ir/type.cpp
@@ -1377,6 +1377,9 @@ bool hasPtr(const Type &t) {
 
   if (auto agg = t.getAsAggregateType()) {
     for (unsigned i = 0, e = agg->numElementsConst(); i != e; ++i) {
+      if (agg->isPadding(i))
+        continue;
+
       if (hasPtr(agg->getChild(i)))
         return true;
     }

--- a/tests/alive-tv/bugs/pr1107.srctgt.ll
+++ b/tests/alive-tv/bugs/pr1107.srctgt.ll
@@ -12,4 +12,4 @@ define i1 @tgt(i8 %A, i8 %B) {
         ret i1 %c
 }
 
-; ERROR: Value mismatch
+; ERROR: Target's return value is more undefined

--- a/tests/alive-tv/freeze-undef.srctgt.ll
+++ b/tests/alive-tv/freeze-undef.srctgt.ll
@@ -1,0 +1,10 @@
+define i32 @src() {
+  %v = freeze i32 undef
+  ret i32 %v
+}
+
+define i32 @tgt() {
+  ret i32 undef
+}
+
+; ERROR: Target's return value is more undefined

--- a/tests/alive-tv/memory/malloc-large-error.src.ll
+++ b/tests/alive-tv/memory/malloc-large-error.src.ll
@@ -5,6 +5,6 @@ define i8* @malloc_large() {
   ret i8* %ret
 }
 
-; ERROR: Value mismatch
+; ERROR: Target's return value is more undefined
 
 declare i8* @malloc(i64)

--- a/tests/unit/abs/undef-0.opt
+++ b/tests/unit/abs/undef-0.opt
@@ -3,4 +3,4 @@ Name: t0
   =>
 %t = undef
 
-; ERROR: Value mismatch for i8 %t
+; ERROR: Target's return value is more undefined for i8 %t

--- a/tests/unit/abs/undef-1.opt
+++ b/tests/unit/abs/undef-1.opt
@@ -3,4 +3,4 @@ Name: t0
   =>
 %t = undef
 
-; ERROR: Value mismatch for i8 %t
+; ERROR: Target's return value is more undefined for i8 %t

--- a/tests/unit/freeze-undef.opt
+++ b/tests/unit/freeze-undef.opt
@@ -1,0 +1,5 @@
+%x = freeze i4 undef
+  =>
+%x = undef
+
+; ERROR: Target's return value is more undefined for i4 %x

--- a/tests/unit/reduce_add/undef-0.opt
+++ b/tests/unit/reduce_add/undef-0.opt
@@ -3,4 +3,4 @@ Name: t0
   =>
 %r = undef
 
-; ERROR: Value mismatch for i8 %r
+; ERROR: Target's return value is more undefined for i8 %r

--- a/tests/unit/reduce_and/undef-0.opt
+++ b/tests/unit/reduce_and/undef-0.opt
@@ -3,4 +3,4 @@ Name: t0
   =>
 %r = undef
 
-; ERROR: Value mismatch for i8 %r
+; ERROR: Target's return value is more undefined for i8 %r

--- a/tests/unit/reduce_and/undef-2.opt
+++ b/tests/unit/reduce_and/undef-2.opt
@@ -4,4 +4,4 @@ Name: t0
   =>
 %r = undef
 
-; ERROR: Value mismatch for i8 %r
+; ERROR: Target's return value is more undefined for i8 %r

--- a/tests/unit/reduce_mul/undef-0.opt
+++ b/tests/unit/reduce_mul/undef-0.opt
@@ -3,4 +3,4 @@ Name: t0
   =>
 %r = undef
 
-; ERROR: Value mismatch for i8 %r
+; ERROR: Target's return value is more undefined for i8 %r

--- a/tests/unit/reduce_mul/undef-2.opt
+++ b/tests/unit/reduce_mul/undef-2.opt
@@ -4,4 +4,4 @@ Name: t0
   =>
 %r = undef
 
-; ERROR: Value mismatch for i8 %r
+; ERROR: Target's return value is more undefined for i8 %r

--- a/tests/unit/reduce_or/undef-0.opt
+++ b/tests/unit/reduce_or/undef-0.opt
@@ -3,4 +3,4 @@ Name: t0
   =>
 %r = undef
 
-; ERROR: Value mismatch for i8 %r
+; ERROR: Target's return value is more undefined for i8 %r

--- a/tests/unit/reduce_or/undef-2.opt
+++ b/tests/unit/reduce_or/undef-2.opt
@@ -4,4 +4,4 @@ Name: t0
   =>
 %r = undef
 
-; ERROR: Value mismatch for i8 %r
+; ERROR: Target's return value is more undefined for i8 %r

--- a/tests/unit/reduce_smax/expand-undef.opt
+++ b/tests/unit/reduce_smax/expand-undef.opt
@@ -6,4 +6,4 @@ Name: t0
 %cmp = icmp sgt i8 %v0, %v1
 %r = select i1 %cmp, i8 %v0, i8 %v1
 
-; ERROR: Value mismatch for i8 %r
+; ERROR: Target's return value is more undefined for i8 %r

--- a/tests/unit/reduce_smax/undef-0.opt
+++ b/tests/unit/reduce_smax/undef-0.opt
@@ -3,4 +3,4 @@ Name: t0
   =>
 %r = undef
 
-; ERROR: Value mismatch for i8 %r
+; ERROR: Target's return value is more undefined for i8 %r

--- a/tests/unit/reduce_smax/undef-2.opt
+++ b/tests/unit/reduce_smax/undef-2.opt
@@ -4,4 +4,4 @@ Name: t0
   =>
 %r = undef
 
-; ERROR: Value mismatch for i8 %r
+; ERROR: Target's return value is more undefined for i8 %r

--- a/tests/unit/reduce_smin/expand-undef.opt
+++ b/tests/unit/reduce_smin/expand-undef.opt
@@ -6,4 +6,4 @@ Name: t0
 %cmp = icmp slt i8 %v0, %v1
 %r = select i1 %cmp, i8 %v0, i8 %v1
 
-; ERROR: Value mismatch for i8 %r
+; ERROR: Target's return value is more undefined for i8 %r

--- a/tests/unit/reduce_smin/undef-0.opt
+++ b/tests/unit/reduce_smin/undef-0.opt
@@ -3,4 +3,4 @@ Name: t0
   =>
 %r = undef
 
-; ERROR: Value mismatch for i8 %r
+; ERROR: Target's return value is more undefined for i8 %r

--- a/tests/unit/reduce_smin/undef-2.opt
+++ b/tests/unit/reduce_smin/undef-2.opt
@@ -4,4 +4,4 @@ Name: t0
   =>
 %r = undef
 
-; ERROR: Value mismatch for i8 %r
+; ERROR: Target's return value is more undefined for i8 %r

--- a/tests/unit/reduce_umax/expand-undef.opt
+++ b/tests/unit/reduce_umax/expand-undef.opt
@@ -6,4 +6,4 @@ Name: t0
 %cmp = icmp ugt i8 %v0, %v1
 %r = select i1 %cmp, i8 %v0, i8 %v1
 
-; ERROR: Value mismatch for i8 %r
+; ERROR: Target's return value is more undefined for i8 %r

--- a/tests/unit/reduce_umax/undef-0.opt
+++ b/tests/unit/reduce_umax/undef-0.opt
@@ -3,4 +3,4 @@ Name: t0
   =>
 %r = undef
 
-; ERROR: Value mismatch for i8 %r
+; ERROR: Target's return value is more undefined for i8 %r

--- a/tests/unit/reduce_umax/undef-2.opt
+++ b/tests/unit/reduce_umax/undef-2.opt
@@ -4,4 +4,4 @@ Name: t0
   =>
 %r = undef
 
-; ERROR: Value mismatch for i8 %r
+; ERROR: Target's return value is more undefined for i8 %r

--- a/tests/unit/reduce_umin/expand-undef.opt
+++ b/tests/unit/reduce_umin/expand-undef.opt
@@ -6,4 +6,4 @@ Name: t0
 %cmp = icmp ult i8 %v0, %v1
 %r = select i1 %cmp, i8 %v0, i8 %v1
 
-; ERROR: Value mismatch for i8 %r
+; ERROR: Target's return value is more undefined for i8 %r

--- a/tests/unit/reduce_umin/undef-0.opt
+++ b/tests/unit/reduce_umin/undef-0.opt
@@ -3,4 +3,4 @@ Name: t0
   =>
 %r = undef
 
-; ERROR: Value mismatch for i8 %r
+; ERROR: Target's return value is more undefined for i8 %r

--- a/tests/unit/reduce_umin/undef-2.opt
+++ b/tests/unit/reduce_umin/undef-2.opt
@@ -4,4 +4,4 @@ Name: t0
   =>
 %r = undef
 
-; ERROR: Value mismatch for i8 %r
+; ERROR: Target's return value is more undefined for i8 %r

--- a/tests/unit/reduce_xor/undef-0.opt
+++ b/tests/unit/reduce_xor/undef-0.opt
@@ -3,4 +3,4 @@ Name: t0
   =>
 %r = undef
 
-; ERROR: Value mismatch for i8 %r
+; ERROR: Target's return value is more undefined for i8 %r

--- a/tests/unit/smax/expand-poison-0.opt
+++ b/tests/unit/smax/expand-poison-0.opt
@@ -4,4 +4,4 @@ Name: t0
 %cond = icmp sgt i8 %a, %b
 %t = select i1 %cond, i8 %a, i8 %b
 
-; ERROR: Value mismatch for i8 %t
+; ERROR: Target's return value is more undefined for i8 %t

--- a/tests/unit/smax/expand-poison-1.opt
+++ b/tests/unit/smax/expand-poison-1.opt
@@ -5,4 +5,4 @@ Name: t0
 %cond = icmp sgt i8 %frozen_a, %b
 %t = select i1 %cond, i8 %frozen_a, i8 %b
 
-; ERROR: Value mismatch for i8 %t
+; ERROR: Target's return value is more undefined for i8 %t

--- a/tests/unit/smax/undef-0.opt
+++ b/tests/unit/smax/undef-0.opt
@@ -3,4 +3,4 @@ Name: t0
   =>
 %t = undef
 
-; ERROR: Value mismatch for i8 %t
+; ERROR: Target's return value is more undefined for i8 %t

--- a/tests/unit/smax/undef-1.opt
+++ b/tests/unit/smax/undef-1.opt
@@ -3,4 +3,4 @@ Name: t0
   =>
 %t = undef
 
-; ERROR: Value mismatch for i8 %t
+; ERROR: Target's return value is more undefined for i8 %t

--- a/tests/unit/smin/expand-poison-0.opt
+++ b/tests/unit/smin/expand-poison-0.opt
@@ -4,4 +4,4 @@ Name: t0
 %cond = icmp slt i8 %a, %b
 %t = select i1 %cond, i8 %a, i8 %b
 
-; ERROR: Value mismatch for i8 %t
+; ERROR: Target's return value is more undefined for i8 %t

--- a/tests/unit/smin/expand-poison-1.opt
+++ b/tests/unit/smin/expand-poison-1.opt
@@ -5,4 +5,4 @@ Name: t0
 %cond = icmp slt i8 %frozen_a, %b
 %t = select i1 %cond, i8 %frozen_a, i8 %b
 
-; ERROR: Value mismatch for i8 %t
+; ERROR: Target's return value is more undefined for i8 %t

--- a/tests/unit/smin/undef-0.opt
+++ b/tests/unit/smin/undef-0.opt
@@ -3,4 +3,4 @@ Name: t0
   =>
 %t = undef
 
-; ERROR: Value mismatch for i8 %t
+; ERROR: Target's return value is more undefined for i8 %t

--- a/tests/unit/smin/undef-1.opt
+++ b/tests/unit/smin/undef-1.opt
@@ -3,4 +3,4 @@ Name: t0
   =>
 %t = undef
 
-; ERROR: Value mismatch for i8 %t
+; ERROR: Target's return value is more undefined for i8 %t

--- a/tests/unit/sshl_sat/undef-0.opt
+++ b/tests/unit/sshl_sat/undef-0.opt
@@ -3,4 +3,4 @@ Name: t0
   =>
 %r = undef
 
-; ERROR: Value mismatch for i8 %r
+; ERROR: Target's return value is more undefined for i8 %r

--- a/tests/unit/umax/expand-poison-0.opt
+++ b/tests/unit/umax/expand-poison-0.opt
@@ -4,4 +4,4 @@ Name: t0
 %cond = icmp ugt i8 %a, %b
 %t = select i1 %cond, i8 %a, i8 %b
 
-; ERROR: Value mismatch for i8 %t
+; ERROR: Target's return value is more undefined for i8 %t

--- a/tests/unit/umax/expand-poison-1.opt
+++ b/tests/unit/umax/expand-poison-1.opt
@@ -5,4 +5,4 @@ Name: t0
 %cond = icmp ugt i8 %frozen_a, %b
 %t = select i1 %cond, i8 %frozen_a, i8 %b
 
-; ERROR: Value mismatch for i8 %t
+; ERROR: Target's return value is more undefined for i8 %t

--- a/tests/unit/umax/undef-0.opt
+++ b/tests/unit/umax/undef-0.opt
@@ -3,4 +3,4 @@ Name: t0
   =>
 %t = undef
 
-; ERROR: Value mismatch for i8 %t
+; ERROR: Target's return value is more undefined for i8 %t

--- a/tests/unit/umax/undef-1.opt
+++ b/tests/unit/umax/undef-1.opt
@@ -3,4 +3,4 @@ Name: t0
   =>
 %t = undef
 
-; ERROR: Value mismatch for i8 %t
+; ERROR: Target's return value is more undefined for i8 %t

--- a/tests/unit/umin/expand-poison-0.opt
+++ b/tests/unit/umin/expand-poison-0.opt
@@ -4,4 +4,4 @@ Name: t0
 %cond = icmp ult i8 %a, %b
 %t = select i1 %cond, i8 %a, i8 %b
 
-; ERROR: Value mismatch for i8 %t
+; ERROR: Target's return value is more undefined for i8 %t

--- a/tests/unit/umin/expand-poison-1.opt
+++ b/tests/unit/umin/expand-poison-1.opt
@@ -5,4 +5,4 @@ Name: t0
 %cond = icmp ult i8 %frozen_a, %b
 %t = select i1 %cond, i8 %frozen_a, i8 %b
 
-; ERROR: Value mismatch for i8 %t
+; ERROR: Target's return value is more undefined for i8 %t

--- a/tests/unit/umin/undef-0.opt
+++ b/tests/unit/umin/undef-0.opt
@@ -3,4 +3,4 @@ Name: t0
   =>
 %t = undef
 
-; ERROR: Value mismatch for i8 %t
+; ERROR: Target's return value is more undefined for i8 %t

--- a/tests/unit/umin/undef-1.opt
+++ b/tests/unit/umin/undef-1.opt
@@ -3,4 +3,4 @@ Name: t0
   =>
 %t = undef
 
-; ERROR: Value mismatch for i8 %t
+; ERROR: Target's return value is more undefined for i8 %t

--- a/tests/unit/undef-error.opt
+++ b/tests/unit/undef-error.opt
@@ -1,4 +1,4 @@
-; ERROR: Value mismatch
+; ERROR: Target's return value is more undefined for i1 %r
 %r = 0
   =>
 %r = undef

--- a/tests/unit/ushl_sat/undef-0.opt
+++ b/tests/unit/ushl_sat/undef-0.opt
@@ -3,4 +3,4 @@ Name: t0
   =>
 %r = undef
 
-; ERROR: Value mismatch for i8 %r
+; ERROR: Target's return value is more undefined for i8 %r

--- a/tools/transform.cpp
+++ b/tools/transform.cpp
@@ -316,9 +316,8 @@ encode_undef_refinement(const Type &type, const State::ValTy &ap,
   //
   // Full refinement formula:
   //   forall N_tgt, exists N_src,
-  //      (src_nonpoison /\
-  //       forall N_src', retval_src(N_src) == retval_src(N_src')) ->
-  //      forall N_tgt', retval_tgt(N_tgt) == retval_tgt(N_tgt')
+  //    (src_nonpoison /\ forall N_src', retval_src(N_src)==retval_src(N_src'))
+  //      -> forall N_tgt', retval_tgt(N_tgt) == retval_tgt(N_tgt')
   //
   // Since retval_tgt is the return value of the target program, it never uses
   // N_src. Therefore, N_tgt' can be moved to the outer forall quantifier.

--- a/tools/transform.cpp
+++ b/tools/transform.cpp
@@ -333,8 +333,8 @@ encode_undef_refinement(const Type &type, const State::ValTy &ap,
   vector<pair<expr, expr>> repls_src, repls_tgt;
   for (auto &u : ap.second) {
     expr newvar = expr::mkFreshVar("undef", u);
-    repls_src.emplace_back(u, expr::mkFreshVar("undef", u));
-    qvars.insert(newvar);
+    repls_src.emplace_back(u, newvar);
+    qvars.insert(move(newvar));
   }
 
   const expr &a = ap.first.value;


### PR DESCRIPTION
This patch adds a refinement that if the target's return value is undefined, so should the source's return value be.

I left the description as a comment at `encode_undef_refinement()`.

This patch resolves #3 .