### PR TITLE
[LLVM] Vector reductions are no longer experimental

### DIFF
--- a/llvm_util/llvm2alive.cpp
+++ b/llvm_util/llvm2alive.cpp
@@ -766,27 +766,27 @@ end:
       }
       RETURN_IDENTIFIER(make_unique<UnaryOp>(*ty, value_name(i), *val, op));
     }
-    case llvm::Intrinsic::experimental_vector_reduce_add:
-    case llvm::Intrinsic::experimental_vector_reduce_mul:
-    case llvm::Intrinsic::experimental_vector_reduce_and:
-    case llvm::Intrinsic::experimental_vector_reduce_or:
-    case llvm::Intrinsic::experimental_vector_reduce_xor:
-    case llvm::Intrinsic::experimental_vector_reduce_smax:
-    case llvm::Intrinsic::experimental_vector_reduce_smin:
-    case llvm::Intrinsic::experimental_vector_reduce_umax:
-    case llvm::Intrinsic::experimental_vector_reduce_umin: {
+    case llvm::Intrinsic::vector_reduce_add:
+    case llvm::Intrinsic::vector_reduce_mul:
+    case llvm::Intrinsic::vector_reduce_and:
+    case llvm::Intrinsic::vector_reduce_or:
+    case llvm::Intrinsic::vector_reduce_xor:
+    case llvm::Intrinsic::vector_reduce_smax:
+    case llvm::Intrinsic::vector_reduce_smin:
+    case llvm::Intrinsic::vector_reduce_umax:
+    case llvm::Intrinsic::vector_reduce_umin: {
       PARSE_UNOP();
       UnaryReductionOp::Op op;
       switch (i.getIntrinsicID()) {
-      case llvm::Intrinsic::experimental_vector_reduce_add: op = UnaryReductionOp::Add; break;
-      case llvm::Intrinsic::experimental_vector_reduce_mul: op = UnaryReductionOp::Mul; break;
-      case llvm::Intrinsic::experimental_vector_reduce_and: op = UnaryReductionOp::And; break;
-      case llvm::Intrinsic::experimental_vector_reduce_or:  op = UnaryReductionOp::Or;  break;
-      case llvm::Intrinsic::experimental_vector_reduce_xor: op = UnaryReductionOp::Xor; break;
-      case llvm::Intrinsic::experimental_vector_reduce_smax: op = UnaryReductionOp::SMax; break;
-      case llvm::Intrinsic::experimental_vector_reduce_smin: op = UnaryReductionOp::SMin; break;
-      case llvm::Intrinsic::experimental_vector_reduce_umax: op = UnaryReductionOp::UMax; break;
-      case llvm::Intrinsic::experimental_vector_reduce_umin: op = UnaryReductionOp::UMin; break;
+      case llvm::Intrinsic::vector_reduce_add: op = UnaryReductionOp::Add; break;
+      case llvm::Intrinsic::vector_reduce_mul: op = UnaryReductionOp::Mul; break;
+      case llvm::Intrinsic::vector_reduce_and: op = UnaryReductionOp::And; break;
+      case llvm::Intrinsic::vector_reduce_or:  op = UnaryReductionOp::Or;  break;
+      case llvm::Intrinsic::vector_reduce_xor: op = UnaryReductionOp::Xor; break;
+      case llvm::Intrinsic::vector_reduce_smax: op = UnaryReductionOp::SMax; break;
+      case llvm::Intrinsic::vector_reduce_smin: op = UnaryReductionOp::SMin; break;
+      case llvm::Intrinsic::vector_reduce_umax: op = UnaryReductionOp::UMax; break;
+      case llvm::Intrinsic::vector_reduce_umin: op = UnaryReductionOp::UMin; break;
       default: UNREACHABLE();
       }
       RETURN_IDENTIFIER(make_unique<UnaryReductionOp>(*ty, value_name(i), *val, op));


### PR DESCRIPTION
Since https://reviews.llvm.org/D88787 / https://github.com/llvm/llvm-project/commit/322d0afd875df66b36e4810a2b95c20a8f22ab9b they are no longer experimental.