### PR TITLE
Reuse undef variables if allowed

### DIFF
--- a/ir/memory.cpp
+++ b/ir/memory.cpp
@@ -1601,7 +1601,7 @@ pair<expr, expr> Memory::mkUndefInput(const ParamAttrs &attrs) const {
   bool nonnull = attrs.has(ParamAttrs::NonNull);
   unsigned log_offset = ilog2_ceil(bits_for_offset, false);
   unsigned bits_undef = bits_for_offset + nonnull * log_offset;
-  expr undef = expr::mkFreshVar("undef", expr::mkUInt(0, bits_undef));
+  expr undef = state->mkFreshUndef(expr::mkUInt(0, bits_undef));
   expr offset = undef;
 
   if (nonnull) {

--- a/ir/state.cpp
+++ b/ir/state.cpp
@@ -364,7 +364,7 @@ smt::expr State::mkFreshUndef(const smt::expr &e_ty, bool do_register) {
   }
 
   if (latest_unused_undef_id == undef_var_pool.size()) {
-    string_view name = "undef_" + to_string(latest_unused_undef_id);
+    string name = "undef_" + to_string(latest_unused_undef_id);
     newv = expr::mkFreshVar(name.data(), e_ty);
     undef_var_pool.emplace_back(newv);
   } else {

--- a/ir/state.cpp
+++ b/ir/state.cpp
@@ -345,20 +345,11 @@ bool State::isUndef(const expr &e, const Value *used_by) const {
 smt::expr State::mkFreshUndef(const smt::expr &e_ty, bool do_register) {
   expr newv;
 
-  auto same_type = [](const expr &e1, const expr &e2) {
-    if (e1.isBV())
-      return e2.isBV() && e1.bits() == e2.bits();
-    else if (e1.isBool())
-      return e2.isBool();
-    // TODO: float type comparison
-    return false;
-  };
-
   // Try to reuse undef variable
   assert(latest_unused_undef_id <= undef_var_pool.size());
 
   while (latest_unused_undef_id < undef_var_pool.size()) {
-    if (same_type(e_ty, undef_var_pool[latest_unused_undef_id]))
+    if (e_ty.hasSameSort(undef_var_pool[latest_unused_undef_id]))
       break;
     latest_unused_undef_id++;
   }

--- a/ir/state.h
+++ b/ir/state.h
@@ -43,6 +43,7 @@ private:
     smt::OrExpr path;
     smt::DisjointExpr<smt::expr> UB;
     std::set<smt::expr> undef_vars;
+    unsigned unused_undef_id = 0; // latest unused undef var id
 
     smt::expr operator()() const;
   };
@@ -83,6 +84,9 @@ private:
   // var -> ((value, not_poison), undef_vars, already_used?)
   std::unordered_map<const Value*, unsigned> values_map;
   std::vector<std::tuple<const Value*, ValTy, bool>> values;
+  // undef_var_pool[i]: the real undef var corresponding to "undef_i"
+  // This is for reusing undef variables.
+  std::vector<smt::expr> undef_var_pool;
 
   // dst BB -> src BB -> BasicBlockInfo
   std::unordered_map<const BasicBlock*,
@@ -100,6 +104,8 @@ private:
   ValueAnalysis analysis;
   std::array<StateValue, 64> tmp_values;
   unsigned i_tmp_values = 0; // next available position in tmp_values
+  bool first_bb_visited = false;
+  unsigned latest_unused_undef_id = 0;
 
   // return_domain: a boolean expression describing return condition
   smt::OrExpr return_domain;
@@ -182,6 +188,7 @@ public:
 
   void addQuantVar(const smt::expr &var);
   void addFnQuantVar(const smt::expr &var);
+  smt::expr mkFreshUndef(const smt::expr &e, bool do_register = false);
   void addUndefVar(smt::expr &&var);
   auto& getUndefVars() const { return undef_vars; }
   void resetUndefVars();

--- a/ir/state.h
+++ b/ir/state.h
@@ -84,7 +84,7 @@ private:
   // var -> ((value, not_poison), undef_vars, already_used?)
   std::unordered_map<const Value*, unsigned> values_map;
   std::vector<std::tuple<const Value*, ValTy, bool>> values;
-  // undef_var_pool[i]: the real undef var corresponding to "undef_i"
+  // undef_var_pool[i]: the SMT undef var corresponding to "undef_i"
   // This is for reusing undef variables.
   std::vector<smt::expr> undef_var_pool;
 

--- a/ir/type.cpp
+++ b/ir/type.cpp
@@ -249,7 +249,7 @@ expr Type::combine_poison(const expr &boolean, const expr &orig) const {
 }
 
 pair<expr, expr> Type::mkUndefInput(State &s, const ParamAttrs &attrs) const {
-  auto var = expr::mkFreshVar("undef", mkInput(s, "", attrs));
+  auto var = s.mkFreshUndef(mkInput(s, "", attrs));
   return { var, var };
 }
 

--- a/ir/value.cpp
+++ b/ir/value.cpp
@@ -46,8 +46,7 @@ void UndefValue::print(ostream &os) const {
 
 StateValue UndefValue::toSMT(State &s) const {
   auto val = getType().getDummyValue(true);
-  expr var = expr::mkFreshVar("undef", val.value);
-  s.addUndefVar(expr(var));
+  expr var = s.mkFreshUndef(val.value, true);
   return { move(var), move(val.non_poison) };
 }
 

--- a/smt/expr.cpp
+++ b/smt/expr.cpp
@@ -324,6 +324,11 @@ bool expr::isFalse() const {
   return Z3_get_bool_value(ctx(), ast()) == Z3_L_FALSE;
 }
 
+bool expr::hasSameSort(const expr &e) const {
+  C();
+  return sort() == e.sort();
+}
+
 bool expr::isZero() const {
   uint64_t n;
   return isUInt(n) && n == 0;

--- a/smt/expr.h
+++ b/smt/expr.h
@@ -117,6 +117,7 @@ public:
   bool isVar() const;
   bool isBV() const;
   bool isBool() const;
+  bool hasSameSort(const expr &rhs) const;
   bool isTrue() const;
   bool isFalse() const;
   bool isZero() const;


### PR DESCRIPTION
This patch implements the third one of the optimizations described at https://github.com/AliveToolkit/alive2/pull/491#issuecomment-697299407

Given a program
```
br i1 cond, A, B
A:
  %v1 = undef
  ...
  br C
B:
  %v2 = undef
  ...
  br C
C:
  %v = phi (%v1, %v2)
```

The undef values at %v1 and %v2 can be encoded with the same SMT variable.
The reason is that, if cond is either true or false, only one of the branches is executed.
At the successor of A and B (which is C), the undef variable cannot be reused anymore.

This patch implements this optimization by tracking the latest undef variable id per basic block, increment the id whenever a fresh undef var is created, and merge maximum value at the successors.
Naturally, it explains the sharing between undef variables in returning blocks too.

I'll leave the experimental result after running is done here.