### PR TITLE
Check whether src and tgt have same param attributes

### DIFF
--- a/ir/attrs.cpp
+++ b/ir/attrs.cpp
@@ -56,10 +56,33 @@ bool ParamAttrs::undefImpliesUB() const {
   return ub;
 }
 
+bool ParamAttrs::operator==(const ParamAttrs &rhs) const {
+  if (bits != rhs.bits)
+    return false;
+
+  if (has(Dereferenceable) && derefBytes != rhs.derefBytes)
+    return false;
+  if (has(ByVal) && blockSize != rhs.blockSize)
+    return false;
+  if (has(Align) && align != rhs.align)
+    return false;
+
+  return true;
+}
+
 bool FnAttrs::undefImpliesUB() const {
   bool ub = has(NoUndef);
   assert(!ub || poisonImpliesUB());
   return ub;
 }
 
+bool FnAttrs::operator==(const FnAttrs &rhs) const {
+  if (bits != rhs.bits)
+    return false;
+
+  if (has(Dereferenceable) && getDerefBytes() != rhs.getDerefBytes())
+    return false;
+
+  return true;
+}
 }

--- a/ir/attrs.h
+++ b/ir/attrs.h
@@ -32,6 +32,9 @@ public:
   bool undefImpliesUB() const;
 
   friend std::ostream& operator<<(std::ostream &os, const ParamAttrs &attr);
+
+  bool operator==(const ParamAttrs &rhs) const;
+  bool operator!=(const ParamAttrs &rhs) const { return !(*this == rhs); };
 };
 
 
@@ -60,6 +63,9 @@ public:
   bool undefImpliesUB() const;
 
   friend std::ostream& operator<<(std::ostream &os, const FnAttrs &attr);
+
+  bool operator==(const FnAttrs &rhs) const;
+  bool operator!=(const FnAttrs &rhs) const { return !(*this == rhs); };
 };
 
 }

--- a/ir/function.cpp
+++ b/ir/function.cpp
@@ -178,7 +178,7 @@ bool Function::hasSameInputs(const Function &rhs) const {
   while (litr != lend && ritr != rend) {
     auto *lv = dynamic_cast<Input *>((*litr).get());
     auto *rv = dynamic_cast<Input *>((*ritr).get());
-    // TODO: &lv->getType() != &rv->getType() doesn't work when
+    // TODO: &lv->getType() != &rv->getType() doesn't work because
     // two struct types that are structurally equivalent don't compare equal
     if (lv->getAttributes() != rv->getAttributes()) {
       return false;

--- a/ir/function.h
+++ b/ir/function.h
@@ -119,6 +119,7 @@ public:
   util::const_strip_unique_ptr<decltype(inputs)> getInputs() const {
     return inputs;
   }
+  bool hasSameInputs(const Function &rhs) const;
 
   bool hasReturn() const;
   unsigned bitsPointers() const { return bits_pointers; }

--- a/tests/alive-tv/issue476.srctgt.ll
+++ b/tests/alive-tv/issue476.srctgt.ll
@@ -6,4 +6,4 @@ define i32 @tgt(i8* dereferenceable(8) %p) {
   ret i32 0
 }
 
-; ERROR: Only functions with identical signatures can be checked
+; ERROR: Unsupported interprocedural transformation: signature mismatch between src and tgt

--- a/tests/alive-tv/issue476.srctgt.ll
+++ b/tests/alive-tv/issue476.srctgt.ll
@@ -1,0 +1,9 @@
+define i32 @src(i8* dereferenceable(4) %p) {
+  ret i32 0
+}
+
+define i32 @tgt(i8* dereferenceable(8) %p) {
+  ret i32 0
+}
+
+; ERROR: Only functions with identical signatures can be checked

--- a/tools/alive-tv.cpp
+++ b/tools/alive-tv.cpp
@@ -184,8 +184,7 @@ static int cmpTypes(llvm::Type *TyL, llvm::Type *TyR,
   if (PTyR && PTyR->getAddressSpace() == 0)
     TyR = DL.getIntPtrType(TyR);
 
-  // If it is a function type, attributes should be compared
-  if (TyL == TyR && !TyL->isFunctionTy())
+  if (TyL == TyR)
     return 0;
 
   if (int Res = cmpNumbers(TyL->getTypeID(), TyR->getTypeID()))
@@ -242,14 +241,6 @@ static int cmpTypes(llvm::Type *TyL, llvm::Type *TyR,
       return Res;
 
     for (unsigned i = 0, e = FTyL->getNumParams(); i != e; ++i) {
-      for (unsigned a = llvm::Attribute::AttrKind::None + 1;
-           a != llvm::Attribute::AttrKind::EndAttrKinds; ++a) {
-        auto ak = (llvm::Attribute::AttrKind)a;
-        auto al = FnL->getParamAttribute(i, ak),
-             ar = FnR->getParamAttribute(i, ak);
-        if (al != ar)
-          return al < ar ? -1 : 1;
-      }
       if (int Res = cmpTypes(FTyL->getParamType(i), FTyR->getParamType(i), FnL, FnR))
         return Res;
     }

--- a/tools/transform.cpp
+++ b/tools/transform.cpp
@@ -884,6 +884,12 @@ TransformVerify::TransformVerify(Transform &t, bool check_each_var) :
 }
 
 Errors TransformVerify::verify() const {
+  if (t.src.getFnAttrs() != t.tgt.getFnAttrs() ||
+      !t.src.hasSameInputs(t.tgt)) {
+    return { "Unsupported interprocedural transformation: signature mismatch "
+             "between src and tgt", false };
+  }
+
   try {
     t.tgt.syncDataWithSrc(t.src);
   } catch (AliveException &ae) {


### PR DESCRIPTION
This patch resolves #476 by conservatively checking whether src/tgt have same param attributes.


