### PR TITLE
Free's ptr arg is noundef, minor patches

### DIFF
--- a/ir/instr.cpp
+++ b/ir/instr.cpp
@@ -2623,7 +2623,7 @@ void Free::print(std::ostream &os) const {
 }
 
 StateValue Free::toSMT(State &s) const {
-  auto &p = s.getAndAddPoisonUB(*ptr).value;
+  auto &p = s.getAndAddPoisonUB(*ptr, true).value;
   // If not heaponly, don't encode constraints
   s.getMemory().free(p, !heaponly);
 

--- a/tests/alive-tv/switch.srctgt.ll
+++ b/tests/alive-tv/switch.srctgt.ll
@@ -1,0 +1,26 @@
+define i32 @src(i32 %t) {
+  switch i32 %t, label %DEFAULT [
+    i32 1, label %ONE
+    i32 2, label %TWO
+  ]
+DEFAULT:
+  %v = freeze i32 %t
+  ret i32 %v
+ONE:
+  ret i32 1
+TWO:
+  ret i32 2
+}
+
+define i32 @tgt(i32 %t) {
+  switch i32 %t, label %DEFAULT [
+    i32 1, label %ONE
+    i32 2, label %TWO
+  ]
+DEFAULT:
+  ret i32 %t
+ONE:
+  ret i32 1
+TWO:
+  ret i32 2
+}

--- a/tools/alive-exec.cpp
+++ b/tools/alive-exec.cpp
@@ -152,8 +152,6 @@ static optional<smt::smt_initializer> smt_init;
 
 static void execFunction(llvm::Function &F, llvm::Triple &targetTriple,
 			 unsigned &successCount, unsigned &errorCount) {
-  TransformPrintOpts print_opts;
-
   omit_array_size = opt_omit_array_size;
 
   auto Func = llvm2alive(F, llvm::TargetLibraryInfoWrapperPass(targetTriple)


### PR DESCRIPTION
This patch contains a few minor patches:

- free's ptr argument is noundef
- a simple switch test (there hasn't been switch test)
- remove unused variable from alive-exec.cpp