### PR TITLE
Remove return type from name mangling

### DIFF
--- a/ir/instr.cpp
+++ b/ir/instr.cpp
@@ -1696,7 +1696,6 @@ StateValue FnCall::toSMT(State &s) const {
                   ptr_inputs);
     fnName_mangled << '#' << arg->getType();
   }
-  fnName_mangled << '!' << getType();
   if (!isVoid())
     unpack_ret_ty(out_types, getType());
 

--- a/ir/state.cpp
+++ b/ir/state.cpp
@@ -746,7 +746,14 @@ State::addFnCall(const string &name, vector<StateValue> &&inputs,
       auto [d, domain, qvar, pre] = data();
       addUB(move(domain));
       addUB(move(d.ub));
-      retval = move(d.retvals);
+
+      // It is possible that tgt's fn call returns nothingt whereas src's
+      // fn call returns something.
+      if (!out_types.empty()) {
+        assert(out_types.size() == d.retvals.size());
+        retval = move(d.retvals);
+      }
+
       if (writes_memory)
         memory.setState(d.callstate);
 

--- a/tests/alive-tv/issue516.src.ll
+++ b/tests/alive-tv/issue516.src.ll
@@ -1,0 +1,6 @@
+declare i32 @f()
+
+define void @src() {
+  call i32 @f()
+  ret void
+}

--- a/tests/alive-tv/issue516.tgt.ll
+++ b/tests/alive-tv/issue516.tgt.ll
@@ -1,0 +1,6 @@
+declare void @f()
+
+define void @src() {
+  call void @f()
+  ret void
+}


### PR DESCRIPTION
```
-- 26. InstCombinePass

----------------------------------------
define void @_Z1bv() {
%entry:
  %call = call i32 @_ZL1av()
  ret void
}
=>
define void @_Z1bv() {
%entry:
  call void @_ZL1av()
  ret void
}
Transformation doesn't verify!
ERROR: Source is more defined than target

Example:

Source:
i32 %call = poison

SOURCE MEMORY STATE
===================
NON-LOCAL BLOCKS:
Block 0 >	size: 0	align: 1	alloc type: 0
Block 1 >	size: 0	align: 2	alloc type: 0

Target:
```

According to issue #516 's log, InstCombine can change a function's return type to void if the result is never used.
Let's support this by removing the return type from name mangling.