### PR TITLE
If opt_error_fatal is false, tv doesn't abort

### DIFF
--- a/tv/tv.cpp
+++ b/tv/tv.cpp
@@ -331,7 +331,10 @@ struct TVPass final : public llvm::FunctionPass {
     --initialized;
 
     if (has_failure) {
-      cerr << "Alive2: Transform doesn't verify; aborting!" << endl;
+      if (opt_error_fatal)
+        cerr << "Alive2: Transform doesn't verify; aborting!" << endl;
+      else
+        cerr << "Alive2: Transform doesn't verify!" << endl;
       exit(1);
     }
     return false;


### PR DESCRIPTION
... and the printing message does not reflect that.
This is a simple patch that updates it