### PR TITLE
Don't undef rewrite if unused in the ctrl flow

### DIFF
--- a/ir/state.h
+++ b/ir/state.h
@@ -51,6 +51,8 @@ private:
     std::set<const Value *> non_poison_vals; // vars that are not poison
     // vars that are not undef (partially undefs are not allowed too)
     std::map<const Value *, smt::expr> non_undef_vals;
+    // vars that have never been used
+    std::set<const Value *> unused_vars;
 
     struct FnCallRanges
       : public std::map<std::string, std::pair<unsigned, unsigned>> {
@@ -80,9 +82,9 @@ private:
   const BasicBlock *current_bb = nullptr;
   std::set<smt::expr> quantified_vars;
 
-  // var -> ((value, not_poison), undef_vars, already_used?)
+  // var -> ((value, not_poison), undef_vars)
   std::unordered_map<const Value*, unsigned> values_map;
-  std::vector<std::tuple<const Value*, ValTy, bool>> values;
+  std::vector<std::tuple<const Value*, ValTy>> values;
 
   // dst BB -> src BB -> BasicBlockInfo
   std::unordered_map<const BasicBlock*,

--- a/ir/state.h
+++ b/ir/state.h
@@ -84,7 +84,7 @@ private:
 
   // var -> ((value, not_poison), undef_vars)
   std::unordered_map<const Value*, unsigned> values_map;
-  std::vector<std::tuple<const Value*, ValTy>> values;
+  std::vector<std::pair<const Value*, ValTy>> values;
 
   // dst BB -> src BB -> BasicBlockInfo
   std::unordered_map<const BasicBlock*,

--- a/tools/transform.cpp
+++ b/tools/transform.cpp
@@ -149,8 +149,7 @@ static void error(Errors &errs, State &src_state, State &tgt_state,
     s << " for " << *var;
   s << "\n\nExample:\n";
 
-  for (auto &[var, val, used] : src_state.getValues()) {
-    (void)used;
+  for (auto &[var, val] : src_state.getValues()) {
     if (!dynamic_cast<const Input*>(var) &&
         !dynamic_cast<const ConstantInput*>(var))
       continue;
@@ -169,8 +168,7 @@ static void error(Errors &errs, State &src_state, State &tgt_state,
       }
     }
 
-    for (auto &[var, val, used] : st->getValues()) {
-      (void)used;
+    for (auto &[var, val] : st->getValues()) {
       auto &name = var->getName();
       if (name == var_name)
         break;
@@ -945,7 +943,7 @@ Errors TransformVerify::verify() const {
     auto [src_state, tgt_state] = exec();
 
     if (check_each_var) {
-      for (auto &[var, val, used] : src_state->getValues()) {
+      for (auto &[var, val] : src_state->getValues()) {
         auto &name = var->getName();
         if (name[0] != '%' || !dynamic_cast<const Instr*>(var))
           continue;


### PR DESCRIPTION
This patch adds `unused_vars` to value analysis, to support the optimization discussed yesterday