### PR TITLE
clang plugin: encode I/O calls as unknown fncalls except when running…

### DIFF
--- a/ir/function.h
+++ b/ir/function.h
@@ -62,6 +62,8 @@ class Function final {
   unsigned bits_pointers = 64;
   unsigned bits_ptr_offset = 64;
   bool little_endian = true;
+  // If this is true, FnCalls having DependsOnFlag become valid unknown fn calls
+  bool fncall_valid_flag = true;
 
   // constants used in this function
   std::vector<std::unique_ptr<Value>> constants;
@@ -85,6 +87,9 @@ public:
   const std::string& getName() const { return name; }
 
   auto& getFnAttrs() { return attrs; }
+
+  bool getFnCallValidFlag() const { return fncall_valid_flag; }
+  void setFnCallValidFlag(bool f) { fncall_valid_flag = f; }
 
   smt::expr getTypeConstraints() const;
   void fixupTypes(const smt::Model &m);

--- a/ir/instr.cpp
+++ b/ir/instr.cpp
@@ -1583,7 +1583,9 @@ void FnCall::print(ostream &os) const {
   }
   os << ')' << attrs;
 
-  if (!valid)
+  // To print this when valid == DependsOnFlag, FnCall::print should know
+  // Function::fncall_valid_flag
+  if (valid == Invalid)
     os << "\t; WARNING: unknown known function";
 }
 
@@ -1666,7 +1668,9 @@ pack_return(State &s, Type &ty, vector<StateValue> &vals, const FnAttrs &attrs,
 }
 
 StateValue FnCall::toSMT(State &s) const {
-  if (!valid) {
+  bool is_valid = valid == Valid ||
+                  (valid == DependsOnFlag && s.getFn().getFnCallValidFlag());
+  if (!is_valid) {
     s.addUB(expr());
     return {};
   }

--- a/ir/instr.h
+++ b/ir/instr.h
@@ -769,14 +769,20 @@ public:
 
 
 class FnCall final : public MemInstr {
+public:
+  enum ValidKind {
+    Invalid, Valid,
+    // This fn call is valid iff Function::fncall_valid_flag is true
+    DependsOnFlag
+  };
 private:
   std::string fnName;
   std::vector<std::pair<Value*, ParamAttrs>> args;
   FnAttrs attrs;
-  bool valid;
+  ValidKind valid;
 public:
   FnCall(Type &type, std::string &&name, std::string &&fnName,
-         FnAttrs &&attrs = FnAttrs::None, bool valid = true)
+         FnAttrs &&attrs = FnAttrs::None, ValidKind valid = Valid)
     : MemInstr(type, std::move(name)), fnName(std::move(fnName)),
       attrs(std::move(attrs)), valid(valid) {}
   void addArg(Value &arg, ParamAttrs &&attrs);

--- a/llvm_util/known_fns.cpp
+++ b/llvm_util/known_fns.cpp
@@ -14,13 +14,14 @@
 using namespace IR;
 using namespace std;
 
-#define RETURN_KNOWN(op)    return { op, true }
-#define RETURN_FAIL_KNOWN() return { nullptr, true }
-#define RETURN_FAIL_UNKNOWN() return { nullptr, false }
+#define RETURN_KNOWN(op)    return { op, FnKnown }
+#define RETURN_FAIL_KNOWN() return { nullptr, FnKnown }
+#define RETURN_FAIL_DEPENDS() return { nullptr, FnDependsOnOpt }
+#define RETURN_FAIL_UNKNOWN() return { nullptr, FnUnknown }
 
 namespace llvm_util {
 
-pair<unique_ptr<Instr>, bool>
+pair<unique_ptr<Instr>, KnownFnKind>
 known_call(llvm::CallInst &i, const llvm::TargetLibraryInfo &TLI,
            BasicBlock &BB, const vector<Value*> &args) {
   auto ty = llvm_type2alive(i.getType());
@@ -64,7 +65,7 @@ known_call(llvm::CallInst &i, const llvm::TargetLibraryInfo &TLI,
     case llvm::LibFunc_perror:
     case llvm::LibFunc_read:
     case llvm::LibFunc_write:
-      RETURN_FAIL_UNKNOWN();
+      RETURN_FAIL_DEPENDS();
     default:
       break;
     }

--- a/llvm_util/known_fns.h
+++ b/llvm_util/known_fns.h
@@ -21,8 +21,14 @@ class Value;
 
 namespace llvm_util {
 
+enum KnownFnKind {
+  FnUnknown,
+  FnDependsOnOpt, // some optimizations know this fn, some opts don't
+  FnKnown
+};
+
 // returned bool indicates whether it's a known function call
-std::pair<std::unique_ptr<IR::Instr>, bool>
+std::pair<std::unique_ptr<IR::Instr>, KnownFnKind>
 known_call(llvm::CallInst &i, const llvm::TargetLibraryInfo &TLI,
            IR::BasicBlock &BB, const std::vector<IR::Value*> &args);
 

--- a/tv/tv.cpp
+++ b/tv/tv.cpp
@@ -122,7 +122,8 @@ llvm::cl::opt<unsigned> opt_omit_array_size(
 
 llvm::cl::opt<bool> opt_io_nobuiltin(
     "tv-io-nobuiltin",
-    llvm::cl::desc("Encode standard I/O functions as an unknown function"),
+    llvm::cl::desc("Encode standard I/O functions as an unknown function "
+                   "(unused by clang plugin)"),
     llvm::cl::init(false));
 
 struct FnInfo {
@@ -149,6 +150,7 @@ bool is_clangtv = false;
 struct TVPass final : public llvm::FunctionPass {
   static char ID;
   bool skip_verify = false;
+  bool encode_io_fns_as_unknown = false;
 
   TVPass() : FunctionPass(ID) {}
 
@@ -213,6 +215,9 @@ struct TVPass final : public llvm::FunctionPass {
     if (first || skip_verify)
       return false;
 
+    if (is_clangtv)
+      I->second.fn.setFnCallValidFlag(encode_io_fns_as_unknown);
+
     smt_init->reset();
     Transform t;
     t.src = move(old_fn);
@@ -220,6 +225,9 @@ struct TVPass final : public llvm::FunctionPass {
     t.preprocess();
     TransformVerify verifier(t, false);
     t.print(*out, print_opts);
+
+    if (is_clangtv)
+      I->second.fn.setFnCallValidFlag(false);
 
     {
       auto types = verifier.getTypings();
@@ -303,7 +311,17 @@ struct TVPass final : public llvm::FunctionPass {
     smt::set_random_seed(to_string(opt_smt_random_seed));
     smt::set_memory_limit(opt_max_mem * 1024 * 1024);
     config::skip_smt = opt_smt_skip;
-    config::io_nobuiltin = opt_io_nobuiltin;
+
+    if (!is_clangtv)
+      config::io_nobuiltin = opt_io_nobuiltin;
+    else {
+      config::io_nobuiltin = true;
+      if (opt_io_nobuiltin)
+        cerr << "Warning: -tv-io-nobuiltin isn't used by clang plugin. I/O"
+                " function calls will be always regarded as unknown fn calls"
+                " except InstCombine.\n";
+    }
+
     config::symexec_print_each_value = opt_se_verbose;
     config::disable_undef_input = opt_disable_undef_input;
     config::disable_poison_input = opt_disable_poison_input;
@@ -450,6 +468,11 @@ llvmGetPassPluginInfo() {
 
         TVPass tv;
         tv.skip_verify = skip_pass;
+        // For I/O known calls like printf, it is fine to regard them as valid
+        // 'unknown calls' except when it is InstCombine.
+        tv.encode_io_fns_as_unknown = P != "InstCombinePass" &&
+                                      P != "AggressiveInstCombinePass";
+
         auto M = const_cast<llvm::Module *>(unwrapModule(IR));
         for (auto &F: *M)
           // If skip_pass is true, this updates fns map only.


### PR DESCRIPTION
… InstCombine (issue #522 ).

1. With this patch, known_call() now returns `FnKnown`, `FnUnknown`, or `FnDependsOnOpt`. The last option means some optimizations know this fn, some opts don't.
2. If it is `FnDependsOnOpt`, llvm2alive creates `FnCall` instance with valid = `DependsOnFlag`.
3. FnCall::toSMT returns {} if valid = `DependsOnFlag` and Alive2 Function says it should be invalid (as discussed in #522).

