### PR TITLE
Add InferFunctionAttrsPass to the skip list

### DIFF
--- a/tv/tv.cpp
+++ b/tv/tv.cpp
@@ -402,6 +402,7 @@ bool do_skip(const llvm::StringRef &ref) {
     "ModuleInlinerWrapperPass", // inliner pass wrapper
     "OpenMPOptPass", // open mp optimization (concurrency)
     "PostOrderFunctionAttrsPass", // changes fn signatures
+    "InferFunctionAttrsPass", // changes fn signatures
     "EntryExitInstrumenterPass", // instruments profiler-related fn calls
     "EliminateAvailableExternallyPass", // Del. available_externally linkage fns
   };


### PR DESCRIPTION
A super simple patch that adds `InferFunctionAttrsPass` to the list of optimizations to skip.