### PR TITLE
don't exit if clang plugin is used

### DIFF
--- a/tv/tv.cpp
+++ b/tv/tv.cpp
@@ -335,7 +335,9 @@ struct TVPass final : public llvm::FunctionPass {
         cerr << "Alive2: Transform doesn't verify; aborting!" << endl;
       else
         cerr << "Alive2: Transform doesn't verify!" << endl;
-      exit(1);
+
+      if (!is_clangtv)
+        exit(1);
     }
     return false;
   }


### PR DESCRIPTION
... due to two reasons.

(1) Non-zero exit makes `make` stop
(2) It prevents clang from doing cleanup, leaving temporary files in the current directory (name of which is something like `<filename>-cfad9157.ll.tmp`)