### PR TITLE
experimental is not needed when compiler is clang

### DIFF
--- a/tv/tv.cpp
+++ b/tv/tv.cpp
@@ -25,7 +25,7 @@
 #include <unordered_map>
 #include <utility>
 
-#if (__GNUC__ < 8) && (!__APPLE__)
+#if (__GNUC__ < 8) && (!__APPLE__) && (!__clang__)
 # include <experimental/filesystem>
   namespace fs = std::experimental::filesystem;
 #else


### PR DESCRIPTION
When clang is used to compile tv.cpp, `__GNUC__` is set to 4, causing `experimental/filesystem` to be used.
This invokes `undefined symbol: _ZNSt12experimental10filesystem2v17__cxx114path14_M_split_cmptsEv` error when clang tv is used in Linux with debug info on.