### PR TITLE
Add hit_half_memory_limit check at DisjointExpr's constructor

### DIFF
--- a/smt/exprs.cpp
+++ b/smt/exprs.cpp
@@ -2,10 +2,13 @@
 // Distributed under the MIT license that can be found in the LICENSE file.
 
 #include "smt/exprs.h"
+#include "smt/smt.h"
 #include "util/compiler.h"
+#include "util/errors.h"
 #include <vector>
 
 using namespace std;
+using namespace util;
 
 namespace smt {
 
@@ -121,6 +124,9 @@ template<> DisjointExpr<expr>::DisjointExpr(const expr &e, bool unpack_ite,
                 c && lhs_domain && rhs_domain);
           }
         }
+
+        if (hit_half_memory_limit())
+          throw AliveException("Out of memory; skipping function.", false);
       }
     }
     else if (unpack_concat && v.isExtract(a, high, low)) {


### PR DESCRIPTION
Note: experiment is still running, I opened PR to share a prospective solution first.

This adds `hit_half_memory_limit()` check at DisjointExpr's constructor, so DisjointExpr doesn't create too many Z3 expressions.

When compiling 525.x264_r, one clang process uses 40gb of memory(!) even when z3's memory usage is limited to 1gb.
I suspected this might be related to DisjointExpr, because attaching gdb and printing stack trace consistently shows `DisjointExpr<smt::expr>::DisjointExpr -> smt::expr::subst` over time.
I'm rerunning 525.x264_r with this patch to see whether the problem disappears.

I am running 544.nab_r to see whether this patch resolves DisjointExpr related issue as well.