### PR TITLE
add simple compiler drivers alivecc and alive++ that load our clang plugin transparently

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -175,6 +175,21 @@ if (BUILD_TV)
   endif()
   message(STATUS "Compiling translation validation plugin")
   add_subdirectory(tv)
+  configure_file(
+    ${CMAKE_SOURCE_DIR}/scripts/opt-alive.sh.in
+    ${CMAKE_BINARY_DIR}/scripts/opt-alive.sh
+    @ONLY
+  )
+  configure_file(
+    ${CMAKE_SOURCE_DIR}/scripts/alivecc.in
+    ${CMAKE_BINARY_DIR}/scripts/alivecc
+    @ONLY
+  )
+  configure_file(
+    ${CMAKE_SOURCE_DIR}/scripts/alivecc.in
+    ${CMAKE_BINARY_DIR}/scripts/alive++
+    @ONLY
+  )
 else()
   message(STATUS "Skiping translation validation plugin")
 endif()

--- a/README.md
+++ b/README.md
@@ -69,11 +69,11 @@ cmake command.
 
 Translation validation of one or more LLVM passes transforming an IR file on Linux:
 ```
-~/llvm/build/bin/opt -load /home/user/alive2/build/tv/tv.so -tv -instcombine -tv -o /dev/null foo.ll
+~/llvm/build/bin/opt -load $HOME/alive2/build/tv/tv.so -tv -instcombine -tv -o /dev/null foo.ll
 ```
 On a Mac:
 ```
-~/llvm/build/bin/opt -load /home/user/alive2/build/tv/tv.dylib -tv -instcombine -tv -o /dev/null foo.ll
+~/llvm/build/bin/opt -load $HOME/alive2/build/tv/tv.dylib -tv -instcombine -tv -o /dev/null foo.ll
 ```
 You can run any pass or combination of passes, but on the command line
 they must be placed in between the two invocations of the Alive2 `-tv`
@@ -82,7 +82,7 @@ pass.
 
 Translation validation of a single LLVM unit test, using lit:
 ```
-~/llvm/build/bin/llvm-lit -vv -Dopt=/home/user/alive2/scripts/opt-alive.sh ~/llvm/llvm/test/Transforms/InstCombine/canonicalize-constant-low-bit-mask-and-icmp-sge-to-icmp-sle.ll
+~/llvm/build/bin/llvm-lit -vv -Dopt=$HOME/alive2/build/scripts/opt-alive.sh ~/llvm/llvm/test/Transforms/InstCombine/canonicalize-constant-low-bit-mask-and-icmp-sge-to-icmp-sle.ll
 ```
 
 The output should be:
@@ -96,7 +96,7 @@ Testing Time: 0.11s
 Translation validation of the LLVM unit tests:
 
 ```
-~/llvm/build/bin/llvm-lit -vv -Dopt=/home/user/alive2/scripts/opt-alive.sh ~/llvm/llvm/test/Transforms
+~/llvm/build/bin/llvm-lit -vv -Dopt=$HOME/alive2/build/scripts/opt-alive.sh ~/llvm/llvm/test/Transforms
 ```
 
 Running Alive2 as a Clang plugin:
@@ -105,6 +105,13 @@ Running Alive2 as a Clang plugin:
 $ clang -O3 <src.c> -S -emit-llvm \
   -fpass-plugin=$HOME/alive2/build/tv/tv.so -fexperimental-new-pass-manager \
   -Xclang -load -Xclang $HOME/alive2/build/tv/tv.so
+```
+
+Or, more conveniently:
+
+```
+$ $HOME/alive2/build/scripts/alivecc -O3 -c <src.c>
+$ $HOME/alive2/build/scripts/alive++ -O3 -c <src.cpp>
 ```
 
 

--- a/scripts/alivecc.in
+++ b/scripts/alivecc.in
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -e
+
+COMPILER=`basename "$0"`
+
+if [ $COMPILER = "alivecc" ]; then
+  EXE=clang
+elif [ $COMPILER = "alive++" ]; then
+  EXE=clang++
+else
+  echo "Unexpected invocation as $COMPILER";
+  exit -1
+fi
+
+@LLVM_BINARY_DIR@/bin/$EXE \
+  -fpass-plugin=@CMAKE_BINARY_DIR@/tv/tv.so -fexperimental-new-pass-manager \
+  -Xclang -load -Xclang @CMAKE_BINARY_DIR@/tv/tv.so $*

--- a/scripts/opt-alive.sh.in
+++ b/scripts/opt-alive.sh.in
@@ -37,4 +37,4 @@ else
   # Linux, Cygwin/Msys, or Win32?
   TV_SHAREDLIB=tv.so
 fi
-timeout 1000 $HOME/llvm/build/bin/opt -load=$HOME/alive2/build/tv/$TV_SHAREDLIB -tv-exit-on-error $TV $@ $TV -tv-smt-to=10000 -tv-report-dir=$HOME/alive2/build/logs -tv-smt-stats $IO_NOBUILTIN
+timeout 1000 @LLVM_BINARY_DIR@/bin/opt -load=@CMAKE_BINARY_DIR@/tv/$TV_SHAREDLIB -tv-exit-on-error $TV $@ $TV -tv-smt-to=10000 -tv-report-dir=@CMAKE_BINARY_DIR@/logs -tv-smt-stats $IO_NOBUILTIN


### PR DESCRIPTION
also, fixup paths in our opt replacement