### PR TITLE
Fixed a bug in loop analyzer

### DIFF
--- a/ir/function.cpp
+++ b/ir/function.cpp
@@ -484,6 +484,7 @@ void LoopAnalysis::getDepthFirstSpanningTree() {
 
   unsigned current = 0;
   vector<pair<const BasicBlock*, bool>> worklist = { {&f.getFirstBB(), false} };
+  set<const BasicBlock *> visited;
   while(!worklist.empty()) {
     auto &[bb, flag] = worklist.back();
     if (flag) {
@@ -495,7 +496,7 @@ void LoopAnalysis::getDepthFirstSpanningTree() {
       flag = true;
 
       for (auto &tgt : bb->targets())
-        if (!number.count(&tgt))
+        if (visited.insert(&tgt).second)
           worklist.emplace_back(&tgt, false);
     }
   }


### PR DESCRIPTION
In getDepthFirstSpanningTree(), using map "number" to avoid revisiting is buggy. The map "number" updates only after a node is visited. Before a node is visited, multiple pointers to that node may already be pushed to the worklist. 

Rather, we should record the basicblock immediately after the basicblock being pushed.