### PR TITLE
use 1ms timeout for simplify() calls in DisjointExpr

### DIFF
--- a/smt/expr.cpp
+++ b/smt/expr.cpp
@@ -1667,6 +1667,18 @@ expr expr::simplify() const {
   return e ? e : *this;
 }
 
+expr expr::simplify(unsigned timeout) const {
+  C();
+  Z3_params params = Z3_mk_params(ctx());
+  Z3_params_inc_ref(ctx(), params);
+  Z3_params_set_uint(ctx(), params, Z3_mk_string_symbol(ctx(), "timeout"),
+                     timeout);
+  auto e = Z3_simplify_ex(ctx(), ast(), params);
+  Z3_params_dec_ref(ctx(), params);
+  // Z3_simplify returns null on timeout
+  return e ? e : *this;
+}
+
 expr expr::subst(const vector<pair<expr, expr>> &repls) const {
   C();
   if (repls.empty())

--- a/smt/expr.h
+++ b/smt/expr.h
@@ -310,6 +310,7 @@ public:
   static expr mkLambda(const expr &var, const expr &val);
 
   expr simplify() const;
+  expr simplify(unsigned timeout_ms) const;
 
   // replace v1 -> v2
   expr subst(const std::vector<std::pair<expr, expr>> &repls) const;

--- a/smt/exprs.cpp
+++ b/smt/exprs.cpp
@@ -127,7 +127,8 @@ template<> DisjointExpr<expr>::DisjointExpr(const expr &e, bool unpack_ite,
           }
 
           for (auto &[rhs_v, rhs_domain] : rhs) {
-            add(lhs_v.concat(rhs_v.subst(from, to).simplify()),
+            // Give timeout to simplify() for fast vcgen
+            add(lhs_v.concat(rhs_v.subst(from, to).simplify(1)),
                 c && lhs_domain && rhs_domain);
           }
         }


### PR DESCRIPTION
This adds 1ms timeout to simplify() calls in DisjointExpr. It makes VCGen faster.

I'll share the numbers after running 505.mcf_r/519.lbm_r/544.nab_r/557.xz_r.
