### PR TITLE
make fn call range empty if function never reads memory

### DIFF
--- a/ir/state.cpp
+++ b/ir/state.cpp
@@ -693,8 +693,8 @@ State::addFnCall(const string &name, vector<StateValue> &&inputs,
     auto call_data_pair
       = calls_fn.try_emplace(
           { move(inputs), move(ptr_inputs),
-            reads_memory ? analysis.ranges_fn_calls :
-                           State::ValueAnalysis::FnCallRanges(),
+            reads_memory ? analysis.ranges_fn_calls
+                         : State::ValueAnalysis::FnCallRanges(),
             reads_memory ? memory : Memory(*this),
             reads_memory, argmemonly });
     auto &I = call_data_pair.first;

--- a/ir/state.cpp
+++ b/ir/state.cpp
@@ -743,11 +743,9 @@ State::addFnCall(const string &name, vector<StateValue> &&inputs,
     ChoiceExpr<FnCallOutput> data;
 
     for (auto &[in, out] : fn_call_data[name]) {
-      auto refined
-        = in.refinedBy(*this, inputs, ptr_inputs,
-                        reads_memory ? analysis.ranges_fn_calls :
-                                       State::ValueAnalysis::FnCallRanges(),
-                        memory, reads_memory, argmemonly);
+      auto refined = in.refinedBy(*this, inputs, ptr_inputs,
+                                  analysis.ranges_fn_calls, memory,
+                                  reads_memory, argmemonly);
       data.add(out, move(refined));
     }
 

--- a/ir/state.cpp
+++ b/ir/state.cpp
@@ -691,10 +691,12 @@ State::addFnCall(const string &name, vector<StateValue> &&inputs,
   if (isSource()) {
     auto &calls_fn = fn_call_data[name];
     auto call_data_pair
-      = calls_fn.try_emplace({ move(inputs), move(ptr_inputs),
-                               analysis.ranges_fn_calls,
-                               reads_memory ? memory : Memory(*this),
-                               reads_memory, argmemonly });
+      = calls_fn.try_emplace(
+          { move(inputs), move(ptr_inputs),
+            reads_memory ? analysis.ranges_fn_calls :
+                           State::ValueAnalysis::FnCallRanges(),
+            reads_memory ? memory : Memory(*this),
+            reads_memory, argmemonly });
     auto &I = call_data_pair.first;
     bool inserted = call_data_pair.second;
 
@@ -741,9 +743,11 @@ State::addFnCall(const string &name, vector<StateValue> &&inputs,
     ChoiceExpr<FnCallOutput> data;
 
     for (auto &[in, out] : fn_call_data[name]) {
-      auto refined = in.refinedBy(*this, inputs, ptr_inputs,
-                                  analysis.ranges_fn_calls, memory,
-                                  reads_memory, argmemonly);
+      auto refined
+        = in.refinedBy(*this, inputs, ptr_inputs,
+                        reads_memory ? analysis.ranges_fn_calls :
+                                       State::ValueAnalysis::FnCallRanges(),
+                        memory, reads_memory, argmemonly);
       data.add(out, move(refined));
     }
 

--- a/tests/alive-tv/calls/readnone-duplicated.srctgt.ll
+++ b/tests/alive-tv/calls/readnone-duplicated.srctgt.ll
@@ -1,20 +1,11 @@
-target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-unknown-linux-gnu"
-
 declare void @g()
 
 define void @src(i1 %cmp) {
 entry:
   %call = call i32* @__errno_location()
   call void @g()
-  br i1 %cmp, label %if.then, label %if.end
-
-if.then:
   %call2 = call i32* @__errno_location()
   store i32 0, i32* %call2, align 4
-  br label %if.end
-
-if.end:
   ret void
 }
 
@@ -22,16 +13,7 @@ define void @tgt(i1 %cmp) {
 entry:
   %call = call i32* @__errno_location()
   call void @g()
-  br i1 %cmp, label %if.then, label %if.else
-
-if.then:
   store i32 0, i32* %call, align 4
-  br label %if.end
-
-if.else:
-  br label %if.end
-
-if.end:
   ret void
 }
 

--- a/tests/alive-tv/calls/readnone-duplicated.srctgt.ll
+++ b/tests/alive-tv/calls/readnone-duplicated.srctgt.ll
@@ -1,7 +1,6 @@
 declare void @g()
 
-define void @src(i1 %cmp) {
-entry:
+define void @src() {
   %call = call i32* @__errno_location()
   call void @g()
   %call2 = call i32* @__errno_location()
@@ -9,8 +8,7 @@ entry:
   ret void
 }
 
-define void @tgt(i1 %cmp) {
-entry:
+define void @tgt() {
   %call = call i32* @__errno_location()
   call void @g()
   store i32 0, i32* %call, align 4

--- a/tests/alive-tv/calls/readnone-duplicated.srctgt.ll
+++ b/tests/alive-tv/calls/readnone-duplicated.srctgt.ll
@@ -1,0 +1,38 @@
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+declare void @g()
+
+define void @src(i1 %cmp) {
+entry:
+  %call = call i32* @__errno_location()
+  call void @g()
+  br i1 %cmp, label %if.then, label %if.end
+
+if.then:
+  %call2 = call i32* @__errno_location()
+  store i32 0, i32* %call2, align 4
+  br label %if.end
+
+if.end:
+  ret void
+}
+
+define void @tgt(i1 %cmp) {
+entry:
+  %call = call i32* @__errno_location()
+  call void @g()
+  br i1 %cmp, label %if.then, label %if.else
+
+if.then:
+  store i32 0, i32* %call, align 4
+  br label %if.end
+
+if.else:
+  br label %if.end
+
+if.end:
+  ret void
+}
+
+declare i32* @__errno_location() readnone


### PR DESCRIPTION
This is my solution of https://github.com/AliveToolkit/alive2/issues/477#issuecomment-719904013 .

IIUC, `analysis.ranges_fn_calls` states how many other functions have been called before the current function call is reached.
This is used to prune out pairwise equivalence encoding between function calls by ignoring calls from different input memory state.

However, if a function never reads memory, outputs are equivalent regardless of the input memory.
`analysis.ranges_fn_calls` should not prune out the equivalence encoding of such no-read calls in this case.