### PR TITLE
bug fix: break on self pointing dom node so that .dominates() terminates

### DIFF
--- a/ir/function.cpp
+++ b/ir/function.cpp
@@ -829,7 +829,7 @@ bool DomTree::dominates(const BasicBlock *a, const BasicBlock *b) const {
   auto *dom_a = &doms.at(a);
   auto *dom_b = &doms.at(b);
   // walk up the dominator tree of 'b' until we find 'a' or the function's entry
-  while (dom_b) {
+  while (true) {
     if (dom_b == dom_a)
       return true;
     if (dom_b == dom_b->dominator)

--- a/ir/function.cpp
+++ b/ir/function.cpp
@@ -832,6 +832,8 @@ bool DomTree::dominates(const BasicBlock *a, const BasicBlock *b) const {
   while (dom_b) {
     if (dom_b == dom_a)
       return true;
+    if (dom_b == dom_b->dominator)
+      break;
     dom_b = dom_b->dominator;
   }
   return false;


### PR DESCRIPTION
entry node is self pointing so when the dominates() hit entry bb, it'll stuck in the while infinitely.