### PR TITLE
bits_program_pointer should be initialized in advance

### DIFF
--- a/ir/memory.cpp
+++ b/ir/memory.cpp
@@ -1915,6 +1915,8 @@ void Memory::free(const expr &ptr, bool unconstrained) {
 }
 
 unsigned Memory::getStoreByteSize(const Type &ty) {
+  assert(bits_program_pointer != 0);
+
   if (ty.isPtrType())
     return divide_up(bits_program_pointer, 8);
 

--- a/tools/transform.cpp
+++ b/tools/transform.cpp
@@ -597,10 +597,6 @@ static void calculateAndInitConstants(Transform &t) {
   num_globals_src = globals_src.size();
   unsigned num_globals = num_globals_src;
 
-  // FIXME: varies among address spaces
-  bits_program_pointer = t.src.bitsPointers();
-  assert(bits_program_pointer > 0 && bits_program_pointer <= 64);
-  assert(bits_program_pointer == t.tgt.bitsPointers());
   heap_block_alignment = 8;
 
   num_consts_src = 0;
@@ -1193,6 +1189,12 @@ void Transform::preprocess() {
                                                 : src.getGlobalVarNames());
     } while (changed);
   }
+
+  // bits_program_pointer is used by unroll. Initialize it in advance
+  // FIXME: varies among address spaces
+  bits_program_pointer = src.bitsPointers();
+  assert(bits_program_pointer > 0 && bits_program_pointer <= 64);
+  assert(bits_program_pointer == tgt.bitsPointers());
 
   src.unroll(config::src_unroll_cnt);
   tgt.unroll(config::tgt_unroll_cnt);


### PR DESCRIPTION
This PR resolves Transforms/GVN/pr25440.ll.

`Function::unroll()` can create an alloca whose size is `Memory::getStoreByteSize`, but pointer's store size is returning zero because `bits_program_pointer` isn't initialized yet.