### PR TITLE
a possible solution for pr32838.ll crash

### DIFF
--- a/ir/function.cpp
+++ b/ir/function.cpp
@@ -863,8 +863,8 @@ void DomTree::buildDominators(const CFG &cfg) {
       auto &b_node = doms.at(b);
       if (b_node.preds.empty())
         continue;
-      
-      auto new_idom = b_node.preds.front();
+
+      DomTreeNode *new_idom = nullptr;
       for (auto p : b_node.preds) {
         if (p->dominator != nullptr) {
           new_idom = intersect(p, new_idom);
@@ -880,6 +880,8 @@ void DomTree::buildDominators(const CFG &cfg) {
 }
 
 DomTree::DomTreeNode* DomTree::intersect(DomTreeNode *f1, DomTreeNode *f2) {
+  if (f2 == nullptr)
+    return f1;
   while (f1->order != f2->order) {
     while (f1->order < f2->order)
       f1 = f1->dominator;

--- a/tests/alive-tv/loops/domtree.srctgt.ll
+++ b/tests/alive-tv/loops/domtree.srctgt.ll
@@ -1,0 +1,49 @@
+; TEST-ARGS: -src-unroll=2
+; SKIP-IDENTITY
+define void @src() {
+entry:
+  br label %BB
+
+BB:
+  br i1 undef, label %if.then, label %if.end
+
+if.then:
+  br label %if.end
+
+if.end:
+  br label %while.cond
+
+while.cond:
+  br i1 undef, label %while.cond, label %while.end
+
+while.end:
+  switch i32 undef, label %sw.default [
+    i32 65, label %BB
+    i32 3, label %return
+    i32 57, label %BB
+    i32 60, label %if.then
+  ]
+
+sw.default:
+  unreachable
+
+return:
+  ret void
+}
+
+;    entry
+;     |
+;     BB
+;   /    \
+;  /      \
+; if.then if.end
+;           |
+;         while.cond
+;           |
+;         while.end
+;         /      \
+;    sw.default  return
+
+define void @tgt() {
+  ret void
+}


### PR DESCRIPTION
Transforms/NewGVN/pr32838.ll crashes when building a dominator tree, and the reason is really interesting.

IIUC, in DomTree, a parent DomTreeNode's order should be larger than the child's order (note that the entry's order is the maximum).

But, idom finding algorithm always starts with the first element of a predecessor block, and the predecessor block *can* have a ~~larger~~ smaller order than the current block.

This caused a crash in `DomTree::intersect`'s while loop.

But interesting thing is that, the paper (https://www.cs.rice.edu/~keith/EMBED/dom.pdf ) was using the predecessor-starting algorithm.
Would it be a bug in the paper?