### PR TITLE
loop: do not replace the source which has value different than val

### DIFF
--- a/ir/function.cpp
+++ b/ir/function.cpp
@@ -637,9 +637,12 @@ void Function::unroll(unsigned k) {
           auto *i = dynamic_cast<Instr*>(user);
           assert(i);
           if (auto phi = dynamic_cast<Phi*>(i)) {
-            for (auto &pred : phi->sources()) {
-              if (dom_tree.dominates(dst, &getBB(pred)))
+            for (auto &[pv, pred] : phi->getValues()) {
+              if (pv != val)
+                continue;
+              if (dom_tree.dominates(dst, &getBB(pred))){
                 phi->replace(pred, *newphi);
+              }
             }
           } else {
             i->rauw(*val, *newphi);

--- a/tests/alive-tv/loops/issue562.srctgt.ll
+++ b/tests/alive-tv/loops/issue562.srctgt.ll
@@ -19,7 +19,6 @@ BBif:
   br i1 true, label %BB2, label %loop
 }
 
-
 define i64 @tgt(i32 %x) {
 entry:
   br label %loop
@@ -39,5 +38,3 @@ loop:
 BBif:
   br i1 true, label %BB2, label %loop
 }
-
-

--- a/tests/alive-tv/loops/issue562.srctgt.ll
+++ b/tests/alive-tv/loops/issue562.srctgt.ll
@@ -1,0 +1,43 @@
+; TEST-ARGS: -tgt-unroll=1
+define i64 @src(i32 %x) {
+entry:
+  br label %loop
+
+BB1:
+  br label %BB2
+
+BB2:
+  %ret = phi i64 [ %j, %BBif ], [ -1, %BB1 ]
+  ret i64 %ret
+
+loop:
+  %j = phi i64 [ 0, %BBif ], [ 2, %entry ]
+  %cmp = icmp sgt i32 %x, -1
+  br i1 %cmp, label %BB1, label %BBif
+
+BBif:
+  br i1 true, label %BB2, label %loop
+}
+
+
+define i64 @tgt(i32 %x) {
+entry:
+  br label %loop
+
+BB1:
+  br label %BB2
+
+BB2:
+  %ret = phi i64 [ %j, %BBif ], [ -1, %BB1 ]
+  ret i64 %ret
+
+loop:
+  %j = phi i64 [ 0, %BBif ], [ 2, %entry ]
+  %cmp = icmp sgt i32 %x, -1
+  br i1 %cmp, label %BB1, label %BBif
+
+BBif:
+  br i1 true, label %BB2, label %loop
+}
+
+


### PR DESCRIPTION
Not all of the sources of phi is using the value we're replacing. We only patch the designated phi source. This patch fixes issue https://github.com/AliveToolkit/alive2/issues/562.