### PR TITLE
if phi uses another phi in the block, it is previous iteration's one

### DIFF
--- a/ir/function.cpp
+++ b/ir/function.cpp
@@ -390,17 +390,16 @@ cloneBB(Function &F, const BasicBlock &BB, const char *suffix,
         unordered_map<const Value*, vector<pair<BasicBlock*, Value*>>> &vmap) {
   string bb_name = BB.getName() + suffix;
   auto &newbb = F.getBB(bb_name);
-  set<const Value *> phis_from_org_bb; // phi nodes from the original BB
+  unordered_set<const Value *> phis_from_orig_bb;
 
   for (auto &i : BB.instrs()) {
     if (dynamic_cast<const Phi *>(&i))
-      phis_from_org_bb.insert(&i);
+      phis_from_orig_bb.insert(&i);
 
     auto d = i.dup(suffix);
     for (auto &op : d->operands()) {
       auto it = vmap.find(op);
       if (it != vmap.end()) {
-        auto &new_val = *it->second.back().second;
         // consider this case:
         //   loop:
         //     %op = phi ...
@@ -411,9 +410,9 @@ cloneBB(Function &F, const BasicBlock &BB, const char *suffix,
         // %op.
         // If is_phi_to_phi is true, %op is the phi in this block.
         bool is_phi_to_phi = dynamic_cast<const Phi *>(&i) &&
-                             phis_from_org_bb.count(op);
+                             phis_from_orig_bb.count(op);
         if (!is_phi_to_phi) {
-          d->rauw(*op, new_val);
+          d->rauw(*op, *it->second.back().second);
         }
       }
     }

--- a/tests/alive-tv/loops/phi-using-phi.srctgt.ll
+++ b/tests/alive-tv/loops/phi-using-phi.srctgt.ll
@@ -1,0 +1,18 @@
+; TEST-ARGS: -src-unroll=2 -tgt-unroll=2
+
+define i32 @src() {
+entry:
+  br label %loop
+loop:
+  %i = phi i32 [0, %entry], [%i.next, %loop]
+  %j = phi i32 [0, %entry], [%i, %loop] ; should point to the previous iteration's %i
+  %i.next = add i32 %i, 1
+  %c = icmp ne i32 %i, 1
+  br i1 %c, label %loop, label %exit
+exit:
+  ret i32 %j
+}
+
+define i32 @tgt() {
+  ret i32 0
+}


### PR DESCRIPTION
Consider this example:
```
loop:
  %i = phi i32 [0, %entry], [%i.next, %loop]
  %j = phi i32 [0, %entry], [%i, %loop] 
  %i.next = add i32 %i, 1
  %c = icmp ne i32 %i, 1
  br i1 %c, label %loop, label %exit
exit:
  ret i32 %j
```

In the first iteration, %i and %j are both 0.
In the second iteration, %i is 1, but %j is still 0, because it is the value of %i of the previous iteration.
See here: https://godbolt.org/z/dTWePq
The returning value should be 0.

This patch fixes `cloneBB` to correctly handle this case. 