### PR TITLE
a possible solution for illegal-addr-modes.ll: refresh users after cloning bbs

### DIFF
--- a/ir/function.cpp
+++ b/ir/function.cpp
@@ -583,7 +583,8 @@ void Function::unroll(unsigned k) {
 
       for (auto &[user, user_bb] : I->second) {
         // users inside the loop have been patched already
-        if (bbmap.count(user_bb))
+        if (find(unrolled_bbs.begin(), unrolled_bbs.end(), user_bb) !=
+            unrolled_bbs.end())
           continue;
 
         // insert a new phi on each dominator exit

--- a/ir/function.cpp
+++ b/ir/function.cpp
@@ -452,8 +452,6 @@ void Function::unroll(unsigned k) {
   // computed bottom-up during the post-order traversal below
   unordered_map<BasicBlock*, vector<BasicBlock*>> loop_nodes;
 
-  // grab all value users before duplication so the list is shorter
-  auto users = getUsers();
   auto phi_preds = getPhiPredecessors(*this);
 
   // traverse each loop tree in post-order
@@ -521,6 +519,8 @@ void Function::unroll(unsigned k) {
         unrolled_bbs.emplace_back(copies.back());
       }
     }
+
+    auto users = getUsers();
 
     // Clone the header once more so that the last iteration of the loop can
     // exit. Otherwise the last iteration would be wasted.

--- a/tests/alive-tv/loops/illegal-addr-modes.srctgt.ll
+++ b/tests/alive-tv/loops/illegal-addr-modes.srctgt.ll
@@ -50,5 +50,3 @@ while2.latch:
 return:
   ret i8* %p.1
 }
-
-

--- a/tests/alive-tv/loops/illegal-addr-modes.srctgt.ll
+++ b/tests/alive-tv/loops/illegal-addr-modes.srctgt.ll
@@ -13,14 +13,14 @@ while1:
   br i1 %cmp, label %while2, label %while1
 
 while2:
-  %i = phi i32 [ %i.next, %while2.body ], [ 0, %while1 ]
-  %p.1 = phi i8* [ %p.1.next, %while2.body ], [ %p.0, %while1 ]
+  %i = phi i32 [ %i.next, %while2.latch ], [ 0, %while1 ]
+  %p.1 = phi i8* [ %p.1.next, %while2.latch ], [ %p.0, %while1 ]
   %i.next = add i32 %i, 1
   %p.1.next = getelementptr i8, i8* %p.1, i32 1
   %cmp3 = icmp eq i32 2, %i
-  br i1 %cmp3, label %return, label %while2.body
+  br i1 %cmp3, label %return, label %while2.latch
 
-while2.body:
+while2.latch:
   br label %while2
 
 return:
@@ -38,13 +38,13 @@ while1:
   br i1 %cmp, label %while2, label %while1
 
 while2:
-  %i = phi i32 [ %i.next, %while2.body ], [ 0, %while1 ]
+  %i = phi i32 [ %i.next, %while2.latch ], [ 0, %while1 ]
   %p.1 = getelementptr i8, i8* %p.0, i32 %i
   %i.next = add i32 %i, 1
   %cmp3 = icmp eq i32 2, %i
-  br i1 %cmp3, label %return, label %while2.body
+  br i1 %cmp3, label %return, label %while2.latch
 
-while2.body:
+while2.latch:
   br label %while2
 
 return:

--- a/tests/alive-tv/loops/illegal-addr-modes.srctgt.ll
+++ b/tests/alive-tv/loops/illegal-addr-modes.srctgt.ll
@@ -1,0 +1,57 @@
+; TEST-ARGS: -src-unroll=2 -tgt-unroll=2
+target datalayout = "e-m:e-p:32:32-i64:64-v128:64:128-a:0:32-n32-S64"
+
+define void @src(i8* %a) {
+entry:
+  br label %while.cond
+
+while.cond:
+  %p.0 = phi i8* [ %a, %entry ], [ %incdec.ptr, %while.cond ]
+  %incdec.ptr = getelementptr i8, i8* %p.0, i32 1
+  %0 = load i8, i8* %p.0, align 1
+  %cmp = icmp eq i8 %0, 0
+  br i1 %cmp, label %while.cond2, label %while.cond
+
+while.cond2:
+  %i = phi i32 [ %i.next, %while.body5 ], [ 0, %while.cond ]
+  %p.1 = phi i8* [ %p.1.next, %while.body5 ], [ %p.0, %while.cond ]
+  %cmp3 = icmp eq i32 2, %i
+  br i1 %cmp3, label %while.end8, label %while.body5
+
+while.body5:
+  %i.next = add i32 %i, 1
+  store i8 1, i8* %p.1, align 1
+  %p.1.next = getelementptr i8, i8* %p.1, i32 1
+  br label %while.cond2
+
+while.end8:
+  ret void
+}
+
+define void @tgt(i8* %a) {
+entry:
+  br label %while.cond
+
+while.cond:
+  %p.0 = phi i8* [ %a, %entry ], [ %incdec.ptr, %while.cond ]
+  %incdec.ptr = getelementptr i8, i8* %p.0, i32 1
+  %0 = load i8, i8* %p.0, align 1
+  %cmp = icmp eq i8 %0, 0
+  br i1 %cmp, label %while.cond2, label %while.cond
+
+while.cond2:
+  %i = phi i32 [ %i.next, %while.body5 ], [ 0, %while.cond ]
+  %p.1 = getelementptr i8, i8* %p.0, i32 %i
+  %cmp3 = icmp eq i32 2, %i
+  br i1 %cmp3, label %while.end8, label %while.body5
+
+while.body5:
+  %i.next = add i32 %i, 1
+  store i8 1, i8* %p.1, align 1
+  br label %while.cond2
+
+while.end8:
+  ret void
+}
+
+


### PR DESCRIPTION
Transforms/LoopStrengthReduce/illegal-addr-modes.ll fails because unroll fails to replace cloned instructions' operands.

`getUsers()` is being called before `cloneBB()`, so newly created instructions aren't there.

`illegal-addr-modes.srctgt.ll` is a reduced example having small diff only.
After unrolling, `%p.0` in tgt's `%p.1 = getelementptr i8, i8* %p.0, i32 %i` should be replaced with a newly inserted phi.
But, after unrolled twice, `%p.1` in the second iteration still uses `%p.0`.

I hope this is the correct direction :)