### PR TITLE
add more bug reproducers

### DIFF
--- a/tests/alive-tv/bugs/pr1014-nolocal.srctgt.ll
+++ b/tests/alive-tv/bugs/pr1014-nolocal.srctgt.ll
@@ -1,0 +1,41 @@
+; TEST-ARGS: -io-nobuiltin
+target datalayout = "e-p:32:32"
+@str = constant [3 x i8] undef
+@str2 = constant [4 x i8] undef
+
+define i32 @src(i32* %v0) {
+entry:
+  %tmp = getelementptr [3 x i8], [3 x i8]* @str, i32 0, i32 0
+  call void (i8*, ...) @scanf(i8* %tmp, i32* %v0)
+  %tmp1 = load i32, i32* %v0
+  %ovm = and i32 %tmp1, 32
+  %ov3 = add i32 %ovm, 145
+  %ov110 = xor i32 %ov3, 153
+  %hvar174 = add i32 %ov110, 1
+  %tmp2 = getelementptr [4 x i8], [4 x i8]* @str2, i32 0, i32 0
+  call void (i8*, ...) @printf(i8* %tmp2, i32 %hvar174)
+  br label %return
+return:
+  ret i32 0
+}
+
+define i32 @tgt(i32* %v0) {
+entry:
+  %tmp = getelementptr [3 x i8], [3 x i8]* @str, i32 0, i32 0
+  call void (i8*, ...) @scanf(i8* %tmp, i32* %v0)
+  %tmp1 = load i32, i32* %v0
+  %ovm = and i32 %tmp1, 32
+  %ov110 = or i32 %ovm, 9
+  %hvar174 = add i32 %ov110, 1
+  %tmp2 = getelementptr [4 x i8], [4 x i8]* @str2, i32 0, i32 0
+  call void (i8*, ...) @printf(i8* %tmp2, i32 %hvar174)
+  br label %return
+return:
+  ret i32 0
+
+}
+
+declare void @scanf(i8*, ...)
+declare void @printf(i8*, ...)
+
+; ERROR: Source is more defined than target

--- a/tests/alive-tv/bugs/pr1014.srctgt.ll
+++ b/tests/alive-tv/bugs/pr1014.srctgt.ll
@@ -1,0 +1,43 @@
+; TEST-ARGS: -io-nobuiltin
+; In order to detect a bug, a function call should be able to update escaped local blocks
+target datalayout = "e-p:32:32"
+@str = constant [3 x i8] undef
+@str2 = constant [4 x i8] undef
+
+define i32 @src() {
+entry:
+  %v0 = alloca i32, align 4
+  %tmp = getelementptr [3 x i8], [3 x i8]* @str, i32 0, i32 0
+  call void (i8*, ...) @scanf(i8* %tmp, i32* %v0)
+  %tmp1 = load i32, i32* %v0
+  %ovm = and i32 %tmp1, 32
+  %ov3 = add i32 %ovm, 145
+  %ov110 = xor i32 %ov3, 153
+  %hvar174 = add i32 %ov110, 1
+  %tmp2 = getelementptr [4 x i8], [4 x i8]* @str2, i32 0, i32 0
+  call void (i8*, ...) @printf(i8* %tmp2, i32 %hvar174)
+  br label %return
+return:
+  ret i32 0
+}
+
+define i32 @tgt() {
+entry:
+  %v0 = alloca i32, align 4
+  %tmp = getelementptr [3 x i8], [3 x i8]* @str, i32 0, i32 0
+  call void (i8*, ...) @scanf(i8* %tmp, i32* %v0)
+  %tmp1 = load i32, i32* %v0
+  %ovm = and i32 %tmp1, 32
+  %ov110 = or i32 %ovm, 9
+  %hvar174 = add i32 %ov110, 1
+  %tmp2 = getelementptr [4 x i8], [4 x i8]* @str2, i32 0, i32 0
+  call void (i8*, ...) @printf(i8* %tmp2, i32 %hvar174)
+  br label %return
+return:
+  ret i32 0
+
+}
+
+declare void @scanf(i8*, ...)
+declare void @printf(i8*, ...)
+

--- a/tests/alive-tv/bugs/pr1014.srctgt.ll
+++ b/tests/alive-tv/bugs/pr1014.srctgt.ll
@@ -1,5 +1,6 @@
 ; TEST-ARGS: -io-nobuiltin
-; In order to detect a bug, a function call should be able to update escaped local blocks
+; FIXME: In order to detect this bug, a function call should be able to update escaped local blocks
+
 target datalayout = "e-p:32:32"
 @str = constant [3 x i8] undef
 @str2 = constant [4 x i8] undef
@@ -40,4 +41,3 @@ return:
 
 declare void @scanf(i8*, ...)
 declare void @printf(i8*, ...)
-

--- a/tests/alive-tv/bugs/pr1111.srctgt.ll
+++ b/tests/alive-tv/bugs/pr1111.srctgt.ll
@@ -1,0 +1,11 @@
+; This is incorrect when %X = NaN
+define i1 @src(double %X) {
+  %tmp = fcmp une double %X, %X
+  ret i1 %tmp
+}
+
+define i1 @tgt(double %X) {
+  ret i1 false
+}
+
+; ERROR: Value mismatch

--- a/tests/alive-tv/bugs/pr1244.srctgt.ll
+++ b/tests/alive-tv/bugs/pr1244.srctgt.ll
@@ -1,0 +1,13 @@
+define i1 @src(i32 %c.3.i, i32 %d.292.2.i) {
+   %tmp266.i = icmp slt i32 %c.3.i, %d.292.2.i     
+   %tmp276.i = icmp eq i32 %c.3.i, %d.292.2.i 
+   %sel_tmp80 = or i1 %tmp266.i, %tmp276.i 
+   ret i1 %sel_tmp80
+}
+
+define i1 @tgt(i32 %c.3.i, i32 %d.292.2.i) {
+  %sel_tmp187.demorgan.i = icmp ule i32 %c.3.i, %d.292.2.i
+  ret i1 %sel_tmp187.demorgan.i
+}
+
+; ERROR: Value mismatch

--- a/tests/alive-tv/bugs/pr22727.srctgt.ll
+++ b/tests/alive-tv/bugs/pr22727.srctgt.ll
@@ -1,0 +1,59 @@
+; This test shows that pr22727 was actually not a bug. :)
+
+target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+; Function Attrs: nounwind uwtable
+define i32 @src(i32* %bp) #0 {
+entry:
+  %bp.addr = alloca i32*, align 8
+  %lbp = alloca i32*, align 8
+  %lbp1 = alloca double, align 8
+  store i32* %bp, i32** %bp.addr, align 8
+  %0 = load i32*, i32** %bp.addr, align 8
+  %add.ptr = getelementptr inbounds i32, i32* %0, i64 1
+  store i32* %add.ptr, i32** %lbp, align 8
+  %1 = load i32*, i32** %lbp, align 8
+  %2 = ptrtoint i32* %1 to i64
+  %conv = uitofp i64 %2 to double
+  store double %conv, double* %lbp1, align 8
+  %3 = load double, double* %lbp1, align 8
+  %cmp = fcmp ogt double %3, 0.000000e+00
+  br i1 %cmp, label %if.then, label %if.end
+
+if.then:                                          ; preds = %entry
+  %4 = load i32*, i32** %lbp, align 8
+  %isnull = icmp eq i32* %4, null
+  br i1 %isnull, label %delete.end, label %delete.notnull
+
+delete.notnull:                                   ; preds = %if.then
+  %5 = bitcast i32* %4 to i8*
+  call void @_ZdaPv(i8* %5) #2
+  br label %delete.end
+
+delete.end:                                       ; preds = %delete.notnull, %if.then
+  br label %if.end
+
+if.end:                                           ; preds = %delete.end, %entry
+  ret i32 0
+}
+
+define i32 @tgt(i32* %bp) #0 {
+entry:
+  %add.ptr = getelementptr inbounds i32, i32* %bp, i64 1
+  %0 = bitcast i32* %add.ptr to i8*
+  tail call void @_ZdaPv(i8* %0) #2
+  ret i32 0
+}
+
+
+; Function Attrs: nobuiltin nounwind
+declare void @_ZdaPv(i8*) #1
+
+attributes #0 = { nounwind uwtable "less-precise-fpmad"="false" "no-frame-pointer-elim"="true" "no-frame-pointer-elim-non-leaf" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #1 = { nobuiltin nounwind "less-precise-fpmad"="false" "no-frame-pointer-elim"="true" "no-frame-pointer-elim-non-leaf" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #2 = { builtin nounwind }
+
+!llvm.ident = !{!0}
+
+!0 = !{!"clang version 3.7.0 (git@idcvgits01.amd.com:llvm/cpu/clang.git 15ee028e66c804d4828f031b51794675117a5bf3) (llvm/cpu/llvm.git 662ad67fab3049591e2259fa02f8786a29478466)"}

--- a/tests/alive-tv/bugs/pr22727.srctgt.ll
+++ b/tests/alive-tv/bugs/pr22727.srctgt.ll
@@ -3,8 +3,7 @@
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-unknown-linux-gnu"
 
-; Function Attrs: nounwind uwtable
-define i32 @src(i32* %bp) #0 {
+define i32 @src(i32* %bp) {
 entry:
   %bp.addr = alloca i32*, align 8
   %lbp = alloca i32*, align 8
@@ -28,7 +27,7 @@ if.then:                                          ; preds = %entry
 
 delete.notnull:                                   ; preds = %if.then
   %5 = bitcast i32* %4 to i8*
-  call void @_ZdaPv(i8* %5) #2
+  call void @_ZdaPv(i8* %5)
   br label %delete.end
 
 delete.end:                                       ; preds = %delete.notnull, %if.then
@@ -38,22 +37,12 @@ if.end:                                           ; preds = %delete.end, %entry
   ret i32 0
 }
 
-define i32 @tgt(i32* %bp) #0 {
+define i32 @tgt(i32* %bp) {
 entry:
   %add.ptr = getelementptr inbounds i32, i32* %bp, i64 1
   %0 = bitcast i32* %add.ptr to i8*
-  tail call void @_ZdaPv(i8* %0) #2
+  tail call void @_ZdaPv(i8* %0)
   ret i32 0
 }
 
-
-; Function Attrs: nobuiltin nounwind
-declare void @_ZdaPv(i8*) #1
-
-attributes #0 = { nounwind uwtable "less-precise-fpmad"="false" "no-frame-pointer-elim"="true" "no-frame-pointer-elim-non-leaf" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #1 = { nobuiltin nounwind "less-precise-fpmad"="false" "no-frame-pointer-elim"="true" "no-frame-pointer-elim-non-leaf" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #2 = { builtin nounwind }
-
-!llvm.ident = !{!0}
-
-!0 = !{!"clang version 3.7.0 (git@idcvgits01.amd.com:llvm/cpu/clang.git 15ee028e66c804d4828f031b51794675117a5bf3) (llvm/cpu/llvm.git 662ad67fab3049591e2259fa02f8786a29478466)"}
+declare void @_ZdaPv(i8*)

--- a/tests/alive-tv/bugs/pr27036.srctgt.ll
+++ b/tests/alive-tv/bugs/pr27036.srctgt.ll
@@ -1,0 +1,20 @@
+; TEST-ARGS: -disable-undef-input
+
+define float @src(i26 %x, i26 %y) {
+  %xx = or i26 %x, 42074059
+  %yy = and i26 %y, 14942208
+  %t0 = sitofp i26 %xx to float
+  %t1 = sitofp i26 %yy to float
+  %rr = fadd float %t0, %t1
+  ret float %rr
+}
+
+define float @tgt(i26 %x, i26 %y) {
+  %xx = or i26 %x, -25034805
+  %yy = and i26 %y, 14942208
+  %addconv = add nsw i26 %xx, %yy
+  %rr = sitofp i26 %addconv to float
+  ret float %rr
+}
+
+; ERROR: Value mismatch

--- a/tests/alive-tv/bugs/pr31633.srctgt.ll
+++ b/tests/alive-tv/bugs/pr31633.srctgt.ll
@@ -1,0 +1,14 @@
+; Our old select bug
+
+define i1 @src(i1 %c, i32 %y) {
+  %y2 = add nsw i32 %y, 1
+  %s = select i1 %c, i32 undef, i32 %y2
+  %r = icmp sgt i32 %s, %y
+  ret i1 %r
+}
+
+define i1 @tgt(i1 %c, i32 %y) {
+  ret i1 true
+}
+
+; ERROR: Value mismatch

--- a/tests/alive-tv/bugs/pr34349.srctgt.ll
+++ b/tests/alive-tv/bugs/pr34349.srctgt.ll
@@ -1,0 +1,21 @@
+define i8 @src(i8 %p) {
+entry:
+  %v3 = zext i8 %p to i16
+  %v4 = mul i16 %v3, 71
+  %v5 = lshr i16 %v4, 8
+  %v6 = trunc i16 %v5 to i8
+  %v7 = sub i8 %p, %v6
+  %v8 = lshr i8 %v7, 1
+  %v9 = zext i8 %p to i16
+  %v10 = mul i16 %v9, 71
+  %v11 = lshr i16 %v10, 8
+  %v12 = trunc i16 %v11 to i8
+  %v13 = add i8 %v12, %v8
+  %v14 = lshr i8 %v13, 7
+  ret i8 %v14
+}
+
+define i8 @tgt(i8 %p) {
+	ret i8 0
+}
+; ERROR: Value mismatch

--- a/tests/alive-tv/bugs/pr38461.srctgt.ll
+++ b/tests/alive-tv/bugs/pr38461.srctgt.ll
@@ -1,0 +1,17 @@
+; Found by Alive2
+; The PR had several function pairs.
+; I reproduced the first one which was a concrete IR program
+
+define i2 @src(i2, i1, i4, i2, i1, i4, i2, i1, i4, i2, i1, i4) {
+  %13 = urem i2 %0, -1
+  ret i2 %13
+}
+
+define i2 @tgt(i2, i1, i4, i2, i1, i4, i2, i1, i4, i2, i1, i4) {
+  %13 = icmp eq i2 %0, -1
+  %14 = zext i1 %13 to i2
+  %15 = add i2 %14, %0
+  ret i2 %15
+}
+
+; ERROR: Value mismatch

--- a/tests/alive-tv/bugs/pr39861.srctgt.ll
+++ b/tests/alive-tv/bugs/pr39861.srctgt.ll
@@ -1,0 +1,16 @@
+; Found by Alive2
+
+define i1 @src(i8 %x, i8 %y) {
+  %tmp0 = lshr i8 255, %y
+  %tmp1 = and i8 %tmp0, %x
+  %ret = icmp sge i8 %tmp1, %x
+  ret i1 %ret
+}
+
+define i1 @tgt(i8 %x, i8 %y) {
+  %tmp0 = lshr i8 255, %y
+  %1 = icmp sge i8 %tmp0, %x
+  ret i1 %1
+}
+
+; ERROR: Value mismatch

--- a/tests/alive-tv/bugs/pr42198.srctgt.ll
+++ b/tests/alive-tv/bugs/pr42198.srctgt.ll
@@ -1,0 +1,20 @@
+; Found by Alive2
+
+define i1 @src(i8 %y) {
+  %x = call i8 @gen8()
+  %tmp0 = lshr i8 255, %y
+  %tmp1 = and i8 %tmp0, %x
+  %ret = icmp sgt i8 %x, %tmp1
+  ret i1 %ret
+}
+
+define i1 @tgt(i8 %y) {
+  %x = call i8 @gen8()
+  %tmp0 = lshr i8 255, %y
+  %1 = icmp sgt i8 %x, %tmp0
+  ret i1 %1
+}
+
+declare i8 @gen8()
+
+; ERROR: Value mismatch

--- a/tests/alive-tv/bugs/pr42619.srctgt.ll
+++ b/tests/alive-tv/bugs/pr42619.srctgt.ll
@@ -1,0 +1,19 @@
+; Found by Alive2
+
+define void @src(i32 %a, i32 %b) {
+  %rem = srem i32 %a, %b
+  %div = sdiv i32 %a, %b
+  call void @foo(i32 %rem, i32 %div)
+  ret void
+}
+define void @tgt(i32 %a, i32 %b) {
+  %div = sdiv i32 %a, %b
+  %1 = mul i32 %div, %b
+  %2 = sub i32 %a, %1
+  call void @foo(i32 %2, i32 %div)
+  ret void
+}
+
+declare void @foo(i32, i32)
+
+; ERROR: Source is more defined than target

--- a/tests/alive-tv/bugs/pr43665.srctgt.ll
+++ b/tests/alive-tv/bugs/pr43665.srctgt.ll
@@ -1,0 +1,14 @@
+; Found by Alive2
+
+define <2 x i8> @src(<2 x i8> %a0) {
+  %1 = ashr <2 x i8> < i8 251, i8 undef >, %a0
+  %2 = xor <2 x i8> < i8 255, i8 255 >, %1
+  ret <2 x i8> %2
+}
+
+define <2 x i8> @tgt(<2 x i8> %a0) {
+  %1 = lshr <2 x i8> < i8 4, i8 undef >, %a0
+  ret <2 x i8> %1
+}
+
+; ERROR: Value mismatch

--- a/tests/alive-tv/bugs/pr43689.srctgt.ll
+++ b/tests/alive-tv/bugs/pr43689.srctgt.ll
@@ -1,0 +1,16 @@
+define <2 x i16> @src(i16 %a, i1 %cmp) {
+  %splatinsert = insertelement <2 x i16> undef, i16 %a, i32 0
+  %t1 = srem <2 x i16> %splatinsert, <i16 2, i16 1>
+  %splat.op = shufflevector <2 x i16> %t1, <2 x i16> undef, <2 x i32> <i32 undef, i32 0>
+  %t2 = select i1 %cmp, <2 x i16> <i16 77, i16 99>, <2 x i16> %splat.op
+  ret <2 x i16> %t2
+}
+
+define <2 x i16> @tgt(i16 %a, i1 %cmp) {
+  %1 = insertelement <2 x i16> undef, i16 %a, i32 1
+  %2 = srem <2 x i16> %1, <i16 undef, i16 2>
+  %t2 = select i1 %cmp, <2 x i16> <i16 77, i16 99>, <2 x i16> %2
+  ret <2 x i16> %t2
+}
+
+; ERROR: Source is more defined than target

--- a/tests/alive-tv/bugs/pr43730.srctgt.ll
+++ b/tests/alive-tv/bugs/pr43730.srctgt.ll
@@ -1,0 +1,13 @@
+; Found by Alive2
+
+define <2 x i1> @src(<2 x i8> %a) {
+  %cmp = icmp sle <2 x i8> %a, <i8 undef, i8 0>
+  ret <2 x i1> %cmp
+}
+
+define <2 x i1> @tgt(<2 x i8> %a) {
+  %cmp = icmp slt <2 x i8> %a, <i8 undef, i8 1>
+  ret <2 x i1> %cmp
+}
+
+; ERROR: Target's return value is more undefined

--- a/tests/alive-tv/bugs/pr43802.srctgt.ll
+++ b/tests/alive-tv/bugs/pr43802.srctgt.ll
@@ -1,0 +1,28 @@
+define i32 @src(i32 %arg) {
+bb:
+  %tmp = sub nsw i32 0, %arg
+  %tmp1 = icmp eq i32 %arg, -2147483648
+  br i1 %tmp1, label %bb2, label %bb3
+
+bb2:                                              ; preds = %bb
+  br label %bb3
+
+bb3:                                              ; preds = %bb2, %bb
+  %tmp4 = phi i32 [ -2147483648, %bb2 ], [ %tmp, %bb ]
+  ret i32 %tmp4
+}
+
+define i32 @tgt(i32 %arg) {
+bb:
+  %tmp = sub nsw i32 0, %arg
+  %tmp1 = icmp eq i32 %arg, -2147483648
+  br i1 %tmp1, label %bb2, label %bb3
+
+bb2:                                              ; preds = %bb
+  br label %bb3
+
+bb3:                                              ; preds = %bb2, %bb
+  ret i32 %tmp
+}
+
+; ERROR: Target is more poisonous than source

--- a/tests/alive-tv/bugs/pr44186.srctgt.ll
+++ b/tests/alive-tv/bugs/pr44186.srctgt.ll
@@ -1,0 +1,14 @@
+; Found by Alive2
+
+define <4 x i32> @src(<4 x i32> %a0) {
+  %1 = urem <4 x i32> <i32 1, i32 1, i32 1, i32 undef>, %a0
+  ret <4 x i32> %1
+}
+
+define <4 x i32> @tgt(<4 x i32> %a0) {
+  %1 = icmp ne <4 x i32> %a0, <i32 1, i32 1, i32 1, i32 undef>
+  %2 = zext <4 x i1> %1 to <4 x i32>
+  ret <4 x i32> %2
+}
+
+; ERROR: Target's return value is more undefined

--- a/tests/alive-tv/bugs/pr44383.srctgt.ll
+++ b/tests/alive-tv/bugs/pr44383.srctgt.ll
@@ -1,0 +1,19 @@
+; Found by Alive2
+
+define <3 x i1> @src() {
+  %x = call <3 x i8> @gen3x8()
+  %tmp0 = and <3 x i8> %x, <i8 3, i8 undef, i8 3>
+  %ret = icmp sgt <3 x i8> %x, %tmp0
+  ret <3 x i1> %ret
+}
+
+define <3 x i1> @tgt() {
+
+  %x = call <3 x i8> @gen3x8()
+  %1 = icmp sgt <3 x i8> %x, <i8 3, i8 undef, i8 3>
+  ret <3 x i1> %1
+}
+
+declare <3 x i8> @gen3x8()
+
+; ERROR: Target's return value is more undefined

--- a/tests/alive-tv/bugs/pr6940.srctgt.ll
+++ b/tests/alive-tv/bugs/pr6940.srctgt.ll
@@ -1,0 +1,10 @@
+define double @src() {
+  %t = sitofp i32 undef to double
+  ret double %t
+}
+
+define double @tgt() {
+  ret double undef
+}
+
+; ERROR: Value mismatch


### PR DESCRIPTION
This PR contains 18 more src/tgt pairs harvested from bugzilla.

Finding a bug from `pr1014.srctgt.ll` required precise encoding of escaped local blocks, so I wrote `pr1014-nolocal.srctgt.ll` and checked that a bug was found.
`pr22727.srctgt.ll` shows that it was actually not a bug.

