### PR TITLE
tv: when recreating tgt, pass an empty set to gvnamesInSrc

### DIFF
--- a/tv/tv.cpp
+++ b/tv/tv.cpp
@@ -218,10 +218,8 @@ struct TVPass final : public llvm::FunctionPass {
 
     auto [I, first] = fns.try_emplace(F.getName().str());
 
-    vector<string_view> src_global_vars;
-    if (!first)
-      src_global_vars = I->second.fn.getGlobalVarNames();
-    auto fn = llvm2alive(F, *TLI, src_global_vars);
+    auto fn = llvm2alive(F, *TLI, first ? vector<string_view>()
+                                        : I->second.fn.getGlobalVarNames());
     if (!fn) {
       fns.erase(I);
       return false;
@@ -289,7 +287,7 @@ struct TVPass final : public llvm::FunctionPass {
     }
 
     // Regenerate tgt because preprocessing may have changed it
-    I->second.fn = *llvm2alive(F, *TLI, move(src_global_vars));
+    I->second.fn = *llvm2alive(F, *TLI);
     return false;
   }
 


### PR DESCRIPTION
This patch passes an empty set to `gvnamesInSrc` when recreating tgt.
`gvnamesInSrc` specifies which global variables should exist in tgt.
The recreated tgt works as src in the next pass, so the information is not necessary.

In reality, this issue was slightly more complex: before https://github.com/AliveToolkit/alive2/commit/4d914925428cc4be6b5eb33427e611e44800b71a was added, src's global vars were being passed to descendants all the way.
But, `removeUnused()` (which was called by `preprocess()`) was removing unused global variables, so things were okay.
To summarize, before https://github.com/AliveToolkit/alive2/commit/4d914925428cc4be6b5eb33427e611e44800b71a, tv was depending on `preprocess()` to keep tgt in a good state. :/
I believe making the new tgt independent from preprocess() is a better direction.

This resolves #579 and I checked that #569 still does not crash as well.