### PR TITLE
only install clang drivers if we're building the clang plugin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -180,18 +180,8 @@ if (BUILD_TV)
     ${CMAKE_BINARY_DIR}/scripts/opt-alive.sh
     @ONLY
   )
-  configure_file(
-    ${CMAKE_SOURCE_DIR}/scripts/alivecc.in
-    ${CMAKE_BINARY_DIR}/scripts/alivecc
-    @ONLY
-  )
-  configure_file(
-    ${CMAKE_SOURCE_DIR}/scripts/alivecc.in
-    ${CMAKE_BINARY_DIR}/scripts/alive++
-    @ONLY
-  )
 else()
-  message(STATUS "Skiping translation validation plugin")
+  message(STATUS "Skipping translation validation plugin")
 endif()
 
 add_executable(alive

--- a/tv/CMakeLists.txt
+++ b/tv/CMakeLists.txt
@@ -10,6 +10,18 @@ if (CLANG_PLUGIN)
   set_target_properties(tv PROPERTIES
       COMPILE_FLAGS "-DCLANG_PLUGIN"
   )
+  configure_file(
+    ${CMAKE_SOURCE_DIR}/scripts/alivecc.in
+    ${CMAKE_BINARY_DIR}/scripts/alivecc
+    @ONLY
+  )
+  configure_file(
+    ${CMAKE_SOURCE_DIR}/scripts/alivecc.in
+    ${CMAKE_BINARY_DIR}/scripts/alive++
+    @ONLY
+  )
+else()
+  message(STATUS "Skipping Clang plugin")
 endif()
 
 target_link_libraries(tv PRIVATE ${ALIVE_LIBS_LLVM} ${Z3_LIBRARIES}


### PR DESCRIPTION
also fix a tiny typo