### PR TITLE
clang tv: add lit test

### DIFF
--- a/scripts/alivecc.in
+++ b/scripts/alivecc.in
@@ -13,6 +13,13 @@ else
   exit -1
 fi
 
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  # Mac
+  TV_SHAREDLIB=tv.dylib
+else
+  # Linux, Cygwin/Msys, or Win32?
+  TV_SHAREDLIB=tv.so
+fi
 @LLVM_BINARY_DIR@/bin/$EXE \
-  -fpass-plugin=@CMAKE_BINARY_DIR@/tv/tv.so -fexperimental-new-pass-manager \
-  -Xclang -load -Xclang @CMAKE_BINARY_DIR@/tv/tv.so $*
+  -fpass-plugin=@CMAKE_BINARY_DIR@/tv/$TV_SHAREDLIB -fexperimental-new-pass-manager \
+  -Xclang -load -Xclang @CMAKE_BINARY_DIR@/tv/$TV_SHAREDLIB $*

--- a/tests/clang-tv/interprocedural.cpp
+++ b/tests/clang-tv/interprocedural.cpp
@@ -1,0 +1,8 @@
+// TEST-ARGS: -O3
+// A simple test that checks whether InferFunctionAttrsPass is skipped and
+// SimplifyCFGPass is not skipped.
+
+int f(){ return 0; }
+
+// CHECK: InferFunctionAttrsPass : Skipping
+// CHECK-NOT: SimplifyCFGPass : Skipping

--- a/tests/clang-tv/issue569.cpp
+++ b/tests/clang-tv/issue569.cpp
@@ -1,0 +1,6 @@
+// TEST-ARGS: -O3 -mllvm -tv-tgt-unroll=2 -mllvm -tv-src-unroll=2
+void a() {
+  for (;;)
+    for (int b; b;)
+      ;
+}

--- a/tests/clang-tv/issue569.cpp
+++ b/tests/clang-tv/issue569.cpp
@@ -4,3 +4,7 @@ void a() {
     for (int b; b;)
       ;
 }
+
+// Since it has 'ERROR: Precondition is always false', this CHECK is necessary
+// (otherwise this test will fail)
+// CHECK: Transformation seems to be correct

--- a/tests/clang-tv/issue579.c
+++ b/tests/clang-tv/issue579.c
@@ -1,0 +1,7 @@
+// TEST-ARGS: -O3 -mllvm -tv-tgt-unroll=2 -mllvm -tv-src-unroll=2 -mllvm -tv-smt-to=10000 -mllvm -tv-disable-undef-input -mllvm -tv-disable-poison-input
+short *d;
+
+e(int a, int b, int c) {
+  for (int f = 0; f < b; f += c)
+    a = d[c];
+}

--- a/tests/lit/lit/formats/alive2test.py
+++ b/tests/lit/lit/formats/alive2test.py
@@ -49,9 +49,9 @@ class Alive2Test(TestFormat):
   def __init__(self):
     self.regex_errs = re.compile(r";\s*(ERROR:.*)")
     self.regex_xfail = re.compile(r";\s*XFAIL:\s*(.*)")
-    self.regex_args = re.compile(r"(;|//)\s*TEST-ARGS:(.*)")
-    self.regex_check = re.compile(r"(;|//)\s*CHECK:(.*)")
-    self.regex_check_not = re.compile(r"(;|//)\s*CHECK-NOT:(.*)")
+    self.regex_args = re.compile(r"(?:;|//)\s*TEST-ARGS:(.*)")
+    self.regex_check = re.compile(r"(?:;|//)\s*CHECK:(.*)")
+    self.regex_check_not = re.compile(r"(?:;|//)\s*CHECK-NOT:(.*)")
     self.regex_skip_identity = re.compile(r";\s*SKIP-IDENTITY")
     self.regex_errs_out = re.compile("ERROR:.*")
 
@@ -100,7 +100,7 @@ class Alive2Test(TestFormat):
     # add test-specific args
     m = self.regex_args.search(input)
     if m != None:
-      cmd += m.group(2).split()
+      cmd += m.group(1).split()
 
     do_identity = self.regex_skip_identity.search(input) is None
 
@@ -134,11 +134,11 @@ class Alive2Test(TestFormat):
       return lit.Test.PASS, ''
 
     chk = self.regex_check.search(input)
-    if chk != None and output.find(chk.group(2).strip()) == -1:
+    if chk != None and output.find(chk.group(1).strip()) == -1:
       return lit.Test.FAIL, output
 
     chk_not = self.regex_check_not.search(input)
-    if chk_not != None and output.find(chk_not.group(2).strip()) != -1:
+    if chk_not != None and output.find(chk_not.group(1).strip()) != -1:
       return lit.Test.FAIL, output
 
     if clang_tv and exitCode != 0:

--- a/tests/lit/lit/formats/alive2test.py
+++ b/tests/lit/lit/formats/alive2test.py
@@ -150,10 +150,8 @@ class Alive2Test(TestFormat):
     if expect_err is None and xfail is None and chk is None and chk_not is None:
       # If there's no other test, correctness of the transformation should be
       # checked.
-      # In case of clang tv, it may have multiple results, so ignore validation
-      # fail if at least one ok_string match exists
       if exitCode == 0 and output.find(ok_string) != -1 and \
-          (clang_tv or self.regex_errs_out.search(output) is None):
+          self.regex_errs_out.search(output) is None:
         return lit.Test.PASS, ''
       return lit.Test.FAIL, output
 


### PR DESCRIPTION
This PR adds lit test for clang tv (#585 ).

It invokes `scripts/alivecc` or `scripts/alive++` if the file exists (otherwise it marks the test as unsupported).

Another minor edit in this PR is that `scripts/alivecc.in` is updated to use `.dylib` extension when used in Mac.