### PR TITLE
take arguments' align into account when calculating bits_byte

### DIFF
--- a/tests/alive-tv/attrs/dereferenceable-align-fail2.srctgt.ll
+++ b/tests/alive-tv/attrs/dereferenceable-align-fail2.srctgt.ll
@@ -1,0 +1,19 @@
+define void @src(i1 %c, i32* dereferenceable(4) %p) {
+  br i1 %c, label %A, label %B
+A:
+  load i32, i32* %p, align 4
+  ret void
+B:
+  ret void
+}
+
+define void @tgt(i1 %c, i32* dereferenceable(4) %p) {
+  load i32, i32* %p, align 4 ; %p may not be aligned
+  br i1 %c, label %A, label %B
+A:
+  ret void
+B:
+  ret void
+}
+
+; ERROR: Source is more defined than target

--- a/tests/alive-tv/attrs/dereferenceable-align.srctgt.ll
+++ b/tests/alive-tv/attrs/dereferenceable-align.srctgt.ll
@@ -1,0 +1,17 @@
+define void @src(i1 %c, i32* dereferenceable(4) align 4 %p) {
+  br i1 %c, label %A, label %B
+A:
+  load i32, i32* %p, align 4
+  ret void
+B:
+  ret void
+}
+
+define void @tgt(i1 %c, i32* dereferenceable(4) align 4%p) {
+  load i32, i32* %p, align 4
+  br i1 %c, label %A, label %B
+A:
+  ret void
+B:
+  ret void
+}

--- a/tools/transform.cpp
+++ b/tools/transform.cpp
@@ -673,7 +673,8 @@ static void calculateAndInitConstants(Transform &t) {
 
     for (auto &v : fn->getInputs()) {
       auto *i = dynamic_cast<const Input *>(&v);
-      if (!i) continue;
+      if (!i)
+        continue;
 
       uint64_t align = i->hasAttribute(ParamAttrs::Align) ?
           1ull << i->getAttributes().align : 1;


### PR DESCRIPTION
This fixes another bug regarding `dereferenceable`.

The bug is similar to the one in #442 , but this PR's fix has a smaller code change.