### PR TITLE
change attr's align field to store the original value

### DIFF
--- a/ir/attrs.cpp
+++ b/ir/attrs.cpp
@@ -2,11 +2,9 @@
 // Distributed under the MIT license that can be found in the LICENSE file.
 
 #include "ir/attrs.h"
-#include "util/compiler.h"
 #include <cassert>
 
 using namespace std;
-using namespace util;
 
 namespace IR {
 ostream& operator<<(ostream &os, const ParamAttrs &attr) {
@@ -56,18 +54,6 @@ ostream& operator<<(ostream &os, const FnAttrs &attr) {
   return os;
 }
 
-uint64_t ParamAttrs::getAlign() const {
-  assert(has(Align));
-  return 1ull << align;
-}
-
-void ParamAttrs::setAlign(uint64_t a) {
-  assert(has(Align));
-  bool power2 = is_power2(a, &align);
-  (void)power2;
-  assert(power2);
-}
-
 bool ParamAttrs::undefImpliesUB() const {
   bool ub = has(NoUndef);
   assert(!ub || poisonImpliesUB());
@@ -86,18 +72,6 @@ bool ParamAttrs::operator==(const ParamAttrs &rhs) const {
     return false;
 
   return true;
-}
-
-uint64_t FnAttrs::getAlign() const {
-  assert(has(Align));
-  return 1ull << align;
-}
-
-void FnAttrs::setAlign(uint64_t a) {
-  assert(has(Align));
-  bool power2 = is_power2(a, &align);
-  (void)power2;
-  assert(power2);
 }
 
 bool FnAttrs::undefImpliesUB() const {

--- a/ir/attrs.cpp
+++ b/ir/attrs.cpp
@@ -2,9 +2,11 @@
 // Distributed under the MIT license that can be found in the LICENSE file.
 
 #include "ir/attrs.h"
+#include "util/compiler.h"
 #include <cassert>
 
 using namespace std;
+using namespace util;
 
 namespace IR {
 ostream& operator<<(ostream &os, const ParamAttrs &attr) {
@@ -54,6 +56,17 @@ ostream& operator<<(ostream &os, const FnAttrs &attr) {
   return os;
 }
 
+uint64_t ParamAttrs::getAlign() const {
+  assert(has(Align));
+  return 1ull << align;
+}
+
+void ParamAttrs::setAlign(uint64_t a) {
+  assert(has(Align));
+  bool power2 = is_power2(a, &align);
+  assert(power2);
+}
+
 bool ParamAttrs::undefImpliesUB() const {
   bool ub = has(NoUndef);
   assert(!ub || poisonImpliesUB());
@@ -72,6 +85,17 @@ bool ParamAttrs::operator==(const ParamAttrs &rhs) const {
     return false;
 
   return true;
+}
+
+uint64_t FnAttrs::getAlign() const {
+  assert(has(Align));
+  return 1ull << align;
+}
+
+void FnAttrs::setAlign(uint64_t a) {
+  assert(has(Align));
+  bool power2 = is_power2(a, &align);
+  assert(power2);
 }
 
 bool FnAttrs::undefImpliesUB() const {

--- a/ir/attrs.cpp
+++ b/ir/attrs.cpp
@@ -64,6 +64,7 @@ uint64_t ParamAttrs::getAlign() const {
 void ParamAttrs::setAlign(uint64_t a) {
   assert(has(Align));
   bool power2 = is_power2(a, &align);
+  (void)power2;
   assert(power2);
 }
 
@@ -95,6 +96,7 @@ uint64_t FnAttrs::getAlign() const {
 void FnAttrs::setAlign(uint64_t a) {
   assert(has(Align));
   bool power2 = is_power2(a, &align);
+  (void)power2;
   assert(power2);
 }
 

--- a/ir/attrs.cpp
+++ b/ir/attrs.cpp
@@ -23,7 +23,7 @@ ostream& operator<<(ostream &os, const ParamAttrs &attr) {
   if (attr.has(ParamAttrs::NoUndef))
     os << "noundef ";
   if (attr.has(ParamAttrs::Align))
-    os << "align(" << (1ull << attr.align) << ") ";
+    os << "align(" << attr.align << ") ";
   if (attr.has(ParamAttrs::Returned))
     os << "returned ";
   return os;
@@ -50,7 +50,7 @@ ostream& operator<<(ostream &os, const FnAttrs &attr) {
   if (attr.has(FnAttrs::NoUndef))
     os << " noundef";
   if (attr.has(FnAttrs::Align))
-    os << " align(" << (1ull << attr.align) << ")";
+    os << " align(" << attr.align << ")";
   return os;
 }
 

--- a/ir/attrs.cpp
+++ b/ir/attrs.cpp
@@ -42,7 +42,7 @@ ostream& operator<<(ostream &os, const FnAttrs &attr) {
   if (attr.has(FnAttrs::NoReturn))
     os << " noreturn";
   if (attr.has(FnAttrs::Dereferenceable))
-    os << " dereferenceable(" << attr.derefBytes << ")";
+    os << " dereferenceable(" << attr.derefBytes << ')';
   if (attr.has(FnAttrs::NonNull))
     os << " nonnull";
   if (attr.has(FnAttrs::NoFree))
@@ -50,7 +50,7 @@ ostream& operator<<(ostream &os, const FnAttrs &attr) {
   if (attr.has(FnAttrs::NoUndef))
     os << " noundef";
   if (attr.has(FnAttrs::Align))
-    os << " align(" << attr.align << ")";
+    os << " align(" << attr.align << ')';
   return os;
 }
 

--- a/ir/attrs.h
+++ b/ir/attrs.h
@@ -15,11 +15,11 @@ public:
                    ReadOnly = 1<<3, ReadNone = 1<<4, Dereferenceable = 1<<5,
                    NoUndef = 1<<6, Align = 1<<7, Returned = 1<<8 };
 
-  ParamAttrs(unsigned bits = None) : bits(bits), align(1) {}
+  ParamAttrs(unsigned bits = None) : bits(bits) {}
 
   uint64_t derefBytes; // Dereferenceable
   uint64_t blockSize;  // exact block size for e.g. byval args
-  uint64_t align;      // Align
+  uint64_t align = 1;
 
   bool has(Attribute a) const { return (bits & a) != 0; }
   void set(Attribute a) { bits |= (unsigned)a; }
@@ -48,13 +48,13 @@ public:
                    Dereferenceable = 1 << 5, NonNull = 1 << 6,
                    NoFree = 1 << 7, NoUndef = 1 << 8, Align = 1 << 9 };
 
-  FnAttrs(unsigned bits = None) : bits(bits), align(1) {}
+  FnAttrs(unsigned bits = None) : bits(bits) {}
 
   bool has(Attribute a) const { return (bits & a) != 0; }
   void set(Attribute a) { bits |= (unsigned)a; }
 
   uint64_t derefBytes; // Dereferenceable
-  uint64_t align;      // Align
+  uint64_t align = 1;
 
   // Returns true if returning poison or an aggregate having a poison is UB
   bool poisonImpliesUB() const

--- a/ir/attrs.h
+++ b/ir/attrs.h
@@ -9,6 +9,7 @@ namespace IR {
 
 class ParamAttrs final {
   unsigned bits;
+  uint64_t align;      // power-of-2 in bytes
 
 public:
   enum Attribute { None = 0, NonNull = 1<<0, ByVal = 1<<1, NoCapture = 1<<2,
@@ -19,10 +20,12 @@ public:
 
   uint64_t derefBytes; // Dereferenceable
   uint64_t blockSize;  // exact block size for e.g. byval args
-  uint64_t align;      // power-of-2 in bytes
 
   bool has(Attribute a) const { return (bits & a) != 0; }
   void set(Attribute a) { bits |= (unsigned)a; }
+
+  uint64_t getAlign() const;
+  void setAlign(uint64_t a);
 
   // Returns true if it's UB for the argument to be poison / have a poison elem.
   bool poisonImpliesUB() const
@@ -41,6 +44,7 @@ public:
 
 class FnAttrs final {
   unsigned bits;
+  uint64_t align;      // power-of-2 in bytes
 
 public:
   enum Attribute { None = 0, NoRead = 1 << 0, NoWrite = 1 << 1,
@@ -54,7 +58,9 @@ public:
   void set(Attribute a) { bits |= (unsigned)a; }
 
   uint64_t derefBytes; // Dereferenceable
-  uint64_t align;      // power-of-2 in bytes
+
+  uint64_t getAlign() const;
+  void setAlign(uint64_t a);
 
   // Returns true if returning poison or an aggregate having a poison is UB
   bool poisonImpliesUB() const

--- a/ir/attrs.h
+++ b/ir/attrs.h
@@ -9,23 +9,20 @@ namespace IR {
 
 class ParamAttrs final {
   unsigned bits;
-  uint64_t align;      // power-of-2 in bytes
 
 public:
   enum Attribute { None = 0, NonNull = 1<<0, ByVal = 1<<1, NoCapture = 1<<2,
                    ReadOnly = 1<<3, ReadNone = 1<<4, Dereferenceable = 1<<5,
                    NoUndef = 1<<6, Align = 1<<7, Returned = 1<<8 };
 
-  ParamAttrs(unsigned bits = None) : bits(bits) {}
+  ParamAttrs(unsigned bits = None) : bits(bits), align(1) {}
 
   uint64_t derefBytes; // Dereferenceable
   uint64_t blockSize;  // exact block size for e.g. byval args
+  uint64_t align;      // Align
 
   bool has(Attribute a) const { return (bits & a) != 0; }
   void set(Attribute a) { bits |= (unsigned)a; }
-
-  uint64_t getAlign() const;
-  void setAlign(uint64_t a);
 
   // Returns true if it's UB for the argument to be poison / have a poison elem.
   bool poisonImpliesUB() const
@@ -44,7 +41,6 @@ public:
 
 class FnAttrs final {
   unsigned bits;
-  uint64_t align;      // power-of-2 in bytes
 
 public:
   enum Attribute { None = 0, NoRead = 1 << 0, NoWrite = 1 << 1,
@@ -52,15 +48,13 @@ public:
                    Dereferenceable = 1 << 5, NonNull = 1 << 6,
                    NoFree = 1 << 7, NoUndef = 1 << 8, Align = 1 << 9 };
 
-  FnAttrs(unsigned bits = None) : bits(bits) {}
+  FnAttrs(unsigned bits = None) : bits(bits), align(1) {}
 
   bool has(Attribute a) const { return (bits & a) != 0; }
   void set(Attribute a) { bits |= (unsigned)a; }
 
   uint64_t derefBytes; // Dereferenceable
-
-  uint64_t getAlign() const;
-  void setAlign(uint64_t a);
+  uint64_t align;      // Align
 
   // Returns true if returning poison or an aggregate having a poison is UB
   bool poisonImpliesUB() const

--- a/ir/instr.cpp
+++ b/ir/instr.cpp
@@ -1643,7 +1643,7 @@ static void unpack_inputs(State &s, Value &argv, Type &ty,
         s.addUB(p.isNonZero());
 
       if (argflag.has(ParamAttrs::Align))
-        s.addUB(p.isAligned(argflag.getAlign()));
+        s.addUB(p.isAligned(argflag.align));
 
       ptr_inputs.emplace_back(StateValue(p.release(), move(value.non_poison)),
                               argflag.has(ParamAttrs::ByVal),
@@ -1699,7 +1699,7 @@ pack_return(State &s, Type &ty, vector<StateValue> &vals, const FnAttrs &attrs,
     if (isNonNull)
       s.addUB(p.isNonZero());
     if (isAlign)
-      s.addUB(p.isAligned(attrs.getAlign()));
+      s.addUB(p.isAligned(attrs.align));
   }
 
   return ret;
@@ -2344,7 +2344,7 @@ StateValue Return::toSMT(State &s) const {
       s.addUB(p.isNonZero());
     }
     if (isAlign) {
-      s.addUB(p.isAligned(attrs.getAlign()));
+      s.addUB(p.isAligned(attrs.align));
     }
   }
 

--- a/ir/instr.cpp
+++ b/ir/instr.cpp
@@ -1643,7 +1643,7 @@ static void unpack_inputs(State &s, Value &argv, Type &ty,
         s.addUB(p.isNonZero());
 
       if (argflag.has(ParamAttrs::Align))
-        s.addUB(p.isAligned(1ull << argflag.align));
+        s.addUB(p.isAligned(argflag.getAlign()));
 
       ptr_inputs.emplace_back(StateValue(p.release(), move(value.non_poison)),
                               argflag.has(ParamAttrs::ByVal),
@@ -1699,7 +1699,7 @@ pack_return(State &s, Type &ty, vector<StateValue> &vals, const FnAttrs &attrs,
     if (isNonNull)
       s.addUB(p.isNonZero());
     if (isAlign)
-      s.addUB(p.isAligned(1ull << attrs.align));
+      s.addUB(p.isAligned(attrs.getAlign()));
   }
 
   return ret;
@@ -2344,7 +2344,7 @@ StateValue Return::toSMT(State &s) const {
       s.addUB(p.isNonZero());
     }
     if (isAlign) {
-      s.addUB(p.isAligned(1ull << attrs.align));
+      s.addUB(p.isAligned(attrs.getAlign()));
     }
   }
 

--- a/ir/memory.cpp
+++ b/ir/memory.cpp
@@ -1585,7 +1585,7 @@ expr Memory::mkInput(const char *name, const ParamAttrs &attrs) {
   if (attrs.has(ParamAttrs::NonNull))
     state->addAxiom(p.isNonZero());
   if (attrs.has(ParamAttrs::Align))
-    state->addAxiom(p.isAligned(1ull << attrs.align));
+    state->addAxiom(p.isAligned(attrs.getAlign()));
 
   state->addAxiom(bid.ule(max_bid));
 

--- a/ir/memory.cpp
+++ b/ir/memory.cpp
@@ -1585,7 +1585,7 @@ expr Memory::mkInput(const char *name, const ParamAttrs &attrs) {
   if (attrs.has(ParamAttrs::NonNull))
     state->addAxiom(p.isNonZero());
   if (attrs.has(ParamAttrs::Align))
-    state->addAxiom(p.isAligned(attrs.getAlign()));
+    state->addAxiom(p.isAligned(attrs.align));
 
   state->addAxiom(bid.ule(max_bid));
 

--- a/ir/value.cpp
+++ b/ir/value.cpp
@@ -203,7 +203,7 @@ StateValue Input::mkInput(State &s, const Type &ty, unsigned child) const {
   if (has_byval) {
     unsigned bid;
     expr size = expr::mkUInt(attrs.blockSize, bits_size_t);
-    val = get_global(s, getName(), size, attrs.align, false, bid);
+    val = get_global(s, getName(), size, attrs.getAlign(), false, bid);
     s.getMemory().markByVal(bid);
   } else {
     auto name = getSMTName(child);

--- a/ir/value.cpp
+++ b/ir/value.cpp
@@ -203,7 +203,7 @@ StateValue Input::mkInput(State &s, const Type &ty, unsigned child) const {
   if (has_byval) {
     unsigned bid;
     expr size = expr::mkUInt(attrs.blockSize, bits_size_t);
-    val = get_global(s, getName(), size, attrs.getAlign(), false, bid);
+    val = get_global(s, getName(), size, attrs.align, false, bid);
     s.getMemory().markByVal(bid);
   } else {
     auto name = getSMTName(child);

--- a/llvm_util/llvm2alive.cpp
+++ b/llvm_util/llvm2alive.cpp
@@ -299,7 +299,7 @@ public:
 
       if (align) {
         attrs.set(FnAttrs::Align);
-        attrs.setAlign(align);
+        attrs.align = align;
       }
     }
 
@@ -353,7 +353,7 @@ public:
 
         assert(a);
         attr.set(ParamAttrs::Align);
-        attr.setAlign(a);
+        attr.align = a;
       }
 
       if (i.paramHasAttr(argidx, llvm::Attribute::ByVal)) {
@@ -362,7 +362,7 @@ public:
         attr.blockSize = DL().getTypeAllocSize(ty);
         if (!attr.has(ParamAttrs::Align)) {
           attr.set(ParamAttrs::Align);
-          attr.setAlign(DL().getABITypeAlignment(ty));
+          attr.align = DL().getABITypeAlignment(ty);
         }
       }
 
@@ -1015,7 +1015,7 @@ end:
         attrs.blockSize = DL().getTypeAllocSize(ty);
         if (!attrs.has(ParamAttrs::Align)) {
           attrs.set(ParamAttrs::Align);
-          attrs.setAlign(DL().getABITypeAlignment(ty));
+          attrs.align = DL().getABITypeAlignment(ty);
         }
         continue;
       }
@@ -1043,7 +1043,7 @@ end:
 
       case llvm::Attribute::Alignment:
         attrs.set(ParamAttrs::Align);
-        attrs.setAlign(attr.getAlignment()->value());
+        attrs.align = attr.getAlignment()->value();
         continue;
 
       case llvm::Attribute::NoUndef:
@@ -1112,7 +1112,7 @@ end:
       unsigned a = f.getAttribute(ridx, llvm::Attribute::Alignment)
                     .getAlignment()->value();
       attrs.set(FnAttrs::Align);
-      attrs.setAlign(a);
+      attrs.align = a;
     }
 
     // create all BBs upfront in topological order

--- a/llvm_util/llvm2alive.cpp
+++ b/llvm_util/llvm2alive.cpp
@@ -299,7 +299,7 @@ public:
 
       if (align) {
         attrs.set(FnAttrs::Align);
-        attrs.align = ilog2(align);
+        attrs.setAlign(align);
       }
     }
 
@@ -353,7 +353,7 @@ public:
 
         assert(a);
         attr.set(ParamAttrs::Align);
-        attr.align = ilog2(a);
+        attr.setAlign(a);
       }
 
       if (i.paramHasAttr(argidx, llvm::Attribute::ByVal)) {
@@ -362,7 +362,7 @@ public:
         attr.blockSize = DL().getTypeAllocSize(ty);
         if (!attr.has(ParamAttrs::Align)) {
           attr.set(ParamAttrs::Align);
-          attr.align = ilog2(DL().getABITypeAlignment(ty));
+          attr.setAlign(DL().getABITypeAlignment(ty));
         }
       }
 
@@ -1015,7 +1015,7 @@ end:
         attrs.blockSize = DL().getTypeAllocSize(ty);
         if (!attrs.has(ParamAttrs::Align)) {
           attrs.set(ParamAttrs::Align);
-          attrs.align = DL().getABITypeAlignment(ty);
+          attrs.setAlign(DL().getABITypeAlignment(ty));
         }
         continue;
       }
@@ -1043,7 +1043,7 @@ end:
 
       case llvm::Attribute::Alignment:
         attrs.set(ParamAttrs::Align);
-        attrs.align = ilog2(attr.getAlignment()->value());
+        attrs.setAlign(attr.getAlignment()->value());
         continue;
 
       case llvm::Attribute::NoUndef:
@@ -1112,7 +1112,7 @@ end:
       unsigned a = f.getAttribute(ridx, llvm::Attribute::Alignment)
                     .getAlignment()->value();
       attrs.set(FnAttrs::Align);
-      attrs.align = ilog2(a);
+      attrs.setAlign(a);
     }
 
     // create all BBs upfront in topological order

--- a/tools/transform.cpp
+++ b/tools/transform.cpp
@@ -676,8 +676,7 @@ static void calculateAndInitConstants(Transform &t) {
       if (!i)
         continue;
 
-      uint64_t align = i->hasAttribute(ParamAttrs::Align) ?
-          i->getAttributes().getAlign() : 1;
+      uint64_t align = i->getAttributes().align;
       if (i->hasAttribute(ParamAttrs::Dereferenceable)) {
         does_mem_access = true;
         uint64_t deref_bytes = i->getAttributes().derefBytes;

--- a/tools/transform.cpp
+++ b/tools/transform.cpp
@@ -677,7 +677,7 @@ static void calculateAndInitConstants(Transform &t) {
         continue;
 
       uint64_t align = i->hasAttribute(ParamAttrs::Align) ?
-          1ull << i->getAttributes().align : 1;
+          i->getAttributes().getAlign() : 1;
       if (i->hasAttribute(ParamAttrs::Dereferenceable)) {
         does_mem_access = true;
         uint64_t deref_bytes = i->getAttributes().derefBytes;


### PR DESCRIPTION
The recent two crashes are due to the inconsistent use of attr's align field.

The field is storing log(alignment), but ir/value.cpp was assuming the value was simply storing the alignment.

This PR changes attr's align field to store the original value
