### PR TITLE
consider fncall param aligns when calculating access size

### DIFF
--- a/ir/instr.cpp
+++ b/ir/instr.cpp
@@ -1579,6 +1579,14 @@ FnCall::ByteAccessInfo FnCall::getByteAccessInfo() const {
       uint64_t b = gcd(arg.second.derefBytes, arg.second.align);
       bytesize = bytesize ? gcd(bytesize, b) : b;
     }
+    // Pointer arguments without dereferenceable attr don't contribute to the
+    // byte size.
+    // call f(* dereferenceable(n) align m %p, * %q) is equivalent to a dummy
+    // load followed by a function call:
+    //   load i<8*n> %p, align m
+    //   call f(* %p, * %q)
+    // f(%p, %q) does not contribute to the bytesize. After bytesize is fixed,
+    // function calls update a memory with the granularity.
   }
   if (!has_deref) {
     // No dereferenceable attribute

--- a/tests/alive-tv/opt-memory/deref-align-callee.srctgt.ll
+++ b/tests/alive-tv/opt-memory/deref-align-callee.srctgt.ll
@@ -1,0 +1,16 @@
+; TEST-ARGS: -dbg
+
+declare void @f(i32*)
+
+define void @src(i32* dereferenceable(4) align 4 %p) {
+  call void @f(i32* dereferenceable(4) %p)
+  ret void
+}
+
+define void @tgt(i32* dereferenceable(4) align 4 %p) {
+  call void @f(i32* dereferenceable(4) %p)
+  ret void
+}
+
+
+; CHECK: min_access_size: 1

--- a/tests/alive-tv/opt-memory/deref-align-callee2.srctgt.ll
+++ b/tests/alive-tv/opt-memory/deref-align-callee2.srctgt.ll
@@ -1,0 +1,17 @@
+; TEST-ARGS: -dbg
+
+declare dereferenceable(8) align 4 i32* @f()
+
+define void @src() {
+  %r = call i32* @f()
+  store i32 0, i32* %r, align 4
+  ret void
+}
+
+define void @tgt() {
+  %r = call i32* @f()
+  store i32 0, i32* %r, align 4
+  ret void
+}
+
+; CHECK: min_access_size: 4


### PR DESCRIPTION
This PR resolves #480 .