### PR TITLE
this patch allows the clang plugin to speedup by running TV tasks in

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,6 +120,7 @@ set(UTIL_SRCS
   util/stopwatch.cpp
   util/symexec.cpp
   util/unionfind.cpp
+  util/parallel.cpp
 )
 
 add_library(util STATIC ${UTIL_SRCS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,11 +116,11 @@ set(UTIL_SRCS
   util/config.cpp
   util/errors.cpp
   util/file.cpp
+  util/parallel.cpp
   util/sort.cpp
   util/stopwatch.cpp
   util/symexec.cpp
   util/unionfind.cpp
-  util/parallel.cpp
 )
 
 add_library(util STATIC ${UTIL_SRCS})

--- a/README.md
+++ b/README.md
@@ -63,10 +63,6 @@ Alive2 should then be configured as follows:
 cmake -GNinja -DCMAKE_PREFIX_PATH=~/llvm/build -DBUILD_TV=1 -DCMAKE_BUILD_TYPE=Release ..
 ```
 
-If you want to use Alive2 as a clang plugin, add `-DCLANG_PLUGIN=1` to the
-cmake command.
-
-
 Translation validation of one or more LLVM passes transforming an IR file on Linux:
 ```
 ~/llvm/build/bin/opt -load $HOME/alive2/build/tv/tv.so -tv -instcombine -tv -o /dev/null foo.ll
@@ -93,13 +89,19 @@ Testing Time: 0.11s
   Expected Passes    : 1
 ```
 
-Translation validation of the LLVM unit tests:
+To run translation validation on all of the LLVM unit tests for
+IR-level transformations:
 
 ```
 ~/llvm/build/bin/llvm-lit -vv -Dopt=$HOME/alive2/build/opt-alive.sh ~/llvm/llvm/test/Transforms
 ```
 
-Running Alive2 as a Clang plugin:
+Running Alive2 as a Clang Plugin
+--------
+
+This plugin tries to validate every IR-level transformation performed
+by LLVM.  To build it, add `-DCLANG_PLUGIN=1` to the cmake
+command. Then, invoke the plugin like this:
 
 ```
 $ clang -O3 <src.c> -S -emit-llvm \
@@ -113,6 +115,21 @@ Or, more conveniently:
 $ $HOME/alive2/build/alivecc -O3 -c <src.c>
 $ $HOME/alive2/build/alive++ -O3 -c <src.cpp>
 ```
+
+The Clang plugin can optionally use multiple cores. To enable parallel
+translation validation, add the `-mllvm -tv-parallel` command line
+options to Clang. In this mode, the Clang plugin uses the POSIX
+jobserver, a mechanism provided by GNU Make to provide global control
+over parallel execution of recursive make invocations. This mechanism
+will only work if GNU Make believes that clang is a make command; tell
+it this by prefixing the `alivecc` command with a `+` character in
+your Makefile. Alas, Ninja does not provide a jobserver. **Parallel
+execution is still experimental, please avoid using it for now.**
+
+The Clang plugin's output can be voluminous. To help control this, it
+supports an option to reduce the amount of output (`-mllvm
+-tv-succinct`) and also an option to redirect most output into a
+collection of files (`-mllvm -tv-report-dir`).
 
 
 Running the Standalone Translation Validation Tool (alive-tv)
@@ -203,6 +220,10 @@ Summary:
   1 incorrect transformations
   0 errors
 ```
+
+Please keep in mind that do not have to compile Alive2 in order to try
+out alive-tv; it is available online: https://alive2.llvm.org/ce/
+
 
 Running the Standalone LLVM Execution Tool (alive-exec)
 --------

--- a/util/parallel.cpp
+++ b/util/parallel.cpp
@@ -1,0 +1,125 @@
+// Copyright (c) 2018-present The Alive2 Authors.
+// Distributed under the MIT license that can be found in the LICENSE file.
+
+#include <cassert>
+#include <cstdlib>
+#include <cstring>
+#include <fcntl.h>
+#include <iostream>
+#include <sys/wait.h>
+#include <unistd.h>
+
+static char jobserver_token;
+static int jobserver_read_fd = -1, jobserver_write_fd = -1;
+static int subprocesses = 0;
+static int max_subprocesses;
+
+namespace parallel {
+
+bool init(int _max_subprocesses) {
+  auto env = std::getenv("MAKEFLAGS");
+  if (!env)
+    return false;
+  auto sub = strstr(env, "jobserver-auth="); // new GNU make
+  if (!sub)
+    sub = strstr(env, "jobserver-fds="); // old GNU make
+  if (!sub)
+    return false;
+  int rfd, wfd;
+  int res = sscanf(sub, "jobserver-auth=%d,%d", &rfd, &wfd);
+  if (res != 2)
+    res = sscanf(sub, "jobserver-fds=%d,%d", &rfd, &wfd);
+  if (res != 2)
+    return false;
+  int flags = fcntl(rfd, F_GETFL, 0);
+  if (flags == -1)
+    return false;
+  flags &= ~O_NONBLOCK;
+  if (fcntl(rfd, F_SETFL, flags) == -1)
+    return false;
+  jobserver_read_fd = rfd;
+  jobserver_write_fd = wfd;
+  max_subprocesses = _max_subprocesses;
+  return true;
+}
+
+static void getToken() {
+  int res [[maybe_unused]] = read(jobserver_read_fd, &jobserver_token, 1);
+  assert(res == 1);
+}
+
+static void putToken() {
+  int res [[maybe_unused]] = write(jobserver_write_fd, &jobserver_token, 1);
+  assert(res == 1);
+}
+
+int limitedFork() {
+  assert(jobserver_read_fd != -1 && jobserver_write_fd != -1);
+  /*
+   * reap zombies
+   */
+  int status;
+  while (waitpid((pid_t)(-1), &status, WNOHANG) > 0) {
+    if (WIFEXITED(status))
+      --subprocesses;
+  }
+  /*
+   * if we have too many children already, wait for some to exit
+   */
+  while (subprocesses >= max_subprocesses) {
+    if (wait(&status) != -1 && WIFEXITED(status))
+      --subprocesses;
+  }
+  std::fflush(nullptr);
+  pid_t res = fork();
+  if (res == -1)
+    return -1;
+
+  // parent returns immediately
+  if (res != 0) {
+    ++subprocesses;
+    return res;
+  }
+
+  // child has to wait for a jobserver token
+  getToken();
+
+  return 0;
+}
+
+void finishChild() {
+  putToken();
+  exit(0);
+}
+
+void waitForAllChildren() {
+  /*
+   * every process forked by GNU make implicitly holds a single
+   * jobserver token. here we temporarily return this token into the
+   * pool while we're blocked waiting for children to finish. this is
+   * a bit of a violation of the jobserver protocol, but it helps
+   * prevent deadlock.
+   *
+   * to see the deadlock, consider a "make -j4". four clang processes
+   * are spawned by make, and they spawn some number of sub-processes
+   * for translation validation, all of which end up blocked waiting
+   * for jobserver tokens -- because there are none. then, all four
+   * clang processes end up here waiting for their children to finish,
+   * and we're stuck forever.
+   *
+   * giving this token back doesn't, strictly speaking, prevent
+   * deadlock, because it could be another clang that gets the token
+   * instead of a TV subprocess -- but this seems unlikely assuming
+   * the readers are queued in FIFO order.
+   */
+  putToken();
+  int status;
+  while (wait(&status) != -1) {
+    if (WIFEXITED(status))
+      --subprocesses;
+  }
+  assert(subprocesses == 0);
+  getToken();
+}
+
+} // namespace parallel

--- a/util/parallel.cpp
+++ b/util/parallel.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) 2018-present The Alive2 Authors.
 // Distributed under the MIT license that can be found in the LICENSE file.
 
+#include "util/compiler.h"
 #include <cassert>
 #include <cstdlib>
 #include <cstring>
@@ -44,13 +45,11 @@ bool init(int _max_subprocesses) {
 }
 
 static void getToken() {
-  int res [[maybe_unused]] = read(jobserver_read_fd, &jobserver_token, 1);
-  assert(res == 1);
+  ENSURE(read(jobserver_read_fd, &jobserver_token, 1) == 1);
 }
 
 static void putToken() {
-  int res [[maybe_unused]] = write(jobserver_write_fd, &jobserver_token, 1);
-  assert(res == 1);
+  ENSURE(write(jobserver_write_fd, &jobserver_token, 1) == 1);
 }
 
 int limitedFork() {

--- a/util/parallel.h
+++ b/util/parallel.h
@@ -1,0 +1,38 @@
+#pragma once
+
+// Copyright (c) 2018-present The Alive2 Authors.
+// Distributed under the MIT license that can be found in the LICENSE file.
+
+/*
+ * this could implement different parallel execution strategies,
+ * currently it only supports the POSIX jobserver
+ */
+
+namespace parallel {
+
+/*
+ * return true if the jobserver appears to be available, otherwise
+ * returns false, in which case none of the other functions should be
+ * called
+ */
+bool init(int _max_processes);
+
+/*
+ * called from parent, like fork() returns non-zero to parent and zero
+ * to child; does not fork until max_processes is respected and,
+ * additionally, blocks the child until a jobserver token is available
+ */
+int limitedFork();
+
+/*
+ * called from a child that has finished executing
+ */
+[[noreturn]] void finishChild();
+
+/*
+ * called from parent, returns when all child processes have
+ * terminated
+ */
+void waitForAllChildren();
+
+} // namespace parallel


### PR DESCRIPTION
subprocesses; it uses the GNU make jobserver to limit the number of
concurrently executing tasks.

http://make.mad-scientist.net/papers/jobserver-implementation/

MISSING IN THIS PR: getting the output straight. currently it is all jumbled together by concurrent processes. I will take care of that part next, but since the changes were getting largish I wanted to see about getting this merged first.