### PR TITLE
clang tv: fix a use-after-free bug

### DIFF
--- a/tv/tv.cpp
+++ b/tv/tv.cpp
@@ -204,13 +204,14 @@ struct TVPass final : public llvm::FunctionPass {
     });
 
     llvm::TargetLibraryInfo *TLI = nullptr;
+    llvm::TargetLibraryInfoImpl TLIImpl;
     unique_ptr<llvm::TargetLibraryInfo> TLI_holder;
     if (is_clangtv) {
       // When used as a clang plugin, this is run as a plain function rather
       // than a registered pass, so getAnalysis() cannot be used.
-      TLI_holder
-        = make_unique<llvm::TargetLibraryInfo>(llvm::TargetLibraryInfoImpl(
-           llvm::Triple(F.getParent()->getTargetTriple())), &F);
+      TLIImpl = llvm::TargetLibraryInfoImpl(
+          llvm::Triple(F.getParent()->getTargetTriple()));
+      TLI_holder = make_unique<llvm::TargetLibraryInfo>(TLIImpl, &F);
       TLI = TLI_holder.get();
     } else {
       TLI = &getAnalysis<llvm::TargetLibraryInfoWrapperPass>().getTLI(F);


### PR DESCRIPTION
The TargetLibraryInfoImpl temporary object passed to the constructor of TargetLibraryInfo is destroyed after the constructor is finished.
This causes use-after-free at llvm2alive calls afterward.

Adding John's reduced code as a unit test requires passing
```
-isysroot `xcrun --show-sdk-path`
```
to clang on Mac because the test is including a header file.
I'll add this test after the alivecc script is updated.