### PR TITLE
run TV from our LLVM plugin in parallel by forking. provide two

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,6 +128,8 @@ set(UTIL_SRCS
   util/config.cpp
   util/errors.cpp
   util/file.cpp
+  util/parallel_jobserver.cpp
+  util/parallel_unrestricted.cpp
   util/sort.cpp
   util/stopwatch.cpp
   util/symexec.cpp

--- a/scripts/fix_report_files.in
+++ b/scripts/fix_report_files.in
@@ -1,0 +1,32 @@
+#!/usr/bin/env perl
+# Copyright (c) 2018-present The Alive2 Authors.
+# Distributed under the MIT license that can be found in the LICENSE file.
+
+use warnings;
+use strict;
+use autodie;
+
+foreach my $file (@ARGV) {
+    print "processing '${file}'\n";
+    my $output = "";
+    my @todelete = ();
+    open my $inf, "<$file" or die;
+    while (my $line = <$inf>) {
+        if ($line =~ /^include\(\"(.+)\"\)$/) {
+            my $temp = $1;
+            push @todelete, $temp;
+            open my $inf2, "<$temp" or die;
+            while (my $line2 = <$inf2>) {
+                $output .= $line2;
+            }
+            close $inf2;
+        } else {
+            $output .= $line;
+        }
+    }
+    close $inf;
+    open my $outf, ">$file" or die;
+    print $outf $output;
+    close $outf;
+    unlink(@todelete);
+}

--- a/tv/CMakeLists.txt
+++ b/tv/CMakeLists.txt
@@ -20,6 +20,11 @@ if (CLANG_PLUGIN)
     ${CMAKE_BINARY_DIR}/alive++
     @ONLY
   )
+  configure_file(
+    ${CMAKE_SOURCE_DIR}/scripts/fix_report_files.in
+    ${CMAKE_BINARY_DIR}/fix_report_files
+    @ONLY
+  )
 else()
   message(STATUS "Skipping Clang plugin")
 endif()

--- a/tv/tv.cpp
+++ b/tv/tv.cpp
@@ -204,6 +204,8 @@ bool is_clangtv = false;
 fs::path opt_report_parallel_dir;
 const char *parallel_subdir = "tmp_parallel";
 unique_ptr<parallel> parallelMgr;
+default_random_engine re;
+uniform_int_distribution<unsigned> rand;
 
 struct TVPass final : public llvm::FunctionPass {
   static char ID;
@@ -275,8 +277,6 @@ struct TVPass final : public llvm::FunctionPass {
       return false;
 
     if (parallelMgr) {
-      default_random_engine re;
-      uniform_int_distribution<unsigned> rand;
       random_device rd;
       re.seed(rd());      
       string newname;
@@ -387,8 +387,6 @@ struct TVPass final : public llvm::FunctionPass {
     fnsToVerify.insert(opt_funcs.begin(), opt_funcs.end());
 
     if (!report_dir_created && !opt_report_dir.empty()) {
-      default_random_engine re;
-      uniform_int_distribution<unsigned> rand;
       static bool seeded = false;
 
       if (!seeded) {

--- a/tv/tv.cpp
+++ b/tv/tv.cpp
@@ -125,7 +125,7 @@ llvm::cl::opt<bool> opt_disable_undef_input(
     llvm::cl::desc("Alive: Assume function input cannot be undef"),
     llvm::cl::cat(TVOptions), llvm::cl::init(false));
 
-llvm::cl::list<std::string>
+llvm::cl::list<string>
     opt_funcs("tv-func",
               llvm::cl::desc("Name of functions to verify (without @)"),
               llvm::cl::cat(TVOptions), llvm::cl::ZeroOrMore,
@@ -184,7 +184,7 @@ llvm::cl::opt<int> max_subprocesses(
 struct FnInfo {
   Function fn;
   unsigned order;
-  std::string fn_tostr;
+  string fn_tostr;
 };
 
 ostream *out;
@@ -203,7 +203,7 @@ bool has_failure = false;
 bool is_clangtv = false;
 fs::path opt_report_parallel_dir;
 const char *parallel_subdir = "tmp_parallel";
-std::unique_ptr<parallel> parallelMgr;
+unique_ptr<parallel> parallelMgr;
 
 struct TVPass final : public llvm::FunctionPass {
   static char ID;
@@ -279,7 +279,7 @@ struct TVPass final : public llvm::FunctionPass {
       uniform_int_distribution<unsigned> rand;
       random_device rd;
       re.seed(rd());      
-      std::string newname;
+      string newname;
       fs::path path;
       if (report_dir_created) {
         // NB there's a low-probability toctou race here
@@ -371,15 +371,15 @@ struct TVPass final : public llvm::FunctionPass {
       return false;
 
     if (parallel_tv_jobserver) {
-      parallelMgr = std::make_unique<jobServer>();
+      parallelMgr = make_unique<jobServer>();
     } else if (parallel_tv_unrestricted) {
-      parallelMgr = std::make_unique<unrestricted>();
+      parallelMgr = make_unique<unrestricted>();
     }
 
     if (parallelMgr) {
       if (!parallelMgr->init(max_subprocesses)) {
-        std::cerr << "WARNING: Parallel execution of Alive2 Clang plugin is "
-          "unavailable, sorry\n";
+        cerr << "WARNING: Parallel execution of Alive2 Clang plugin is "
+                "unavailable, sorry\n";
         parallelMgr.reset();
       }
     }

--- a/tv/tv.cpp
+++ b/tv/tv.cpp
@@ -1,12 +1,13 @@
 // Copyright (c) 2018-present The Alive2 Authors.
 // Distributed under the MIT license that can be found in the LICENSE file.
 
-#include "llvm_util/llvm2alive.h"
 #include "ir/memory.h"
+#include "llvm_util/llvm2alive.h"
 #include "smt/smt.h"
 #include "smt/solver.h"
 #include "tools/transform.h"
 #include "util/config.h"
+#include "util/parallel.h"
 #include "util/stopwatch.h"
 #include "util/version.h"
 #include "llvm/ADT/Any.h"
@@ -162,6 +163,24 @@ llvm::cl::opt<unsigned> opt_tgt_unrolling_factor(
     llvm::cl::desc("Unrolling factor for tgt function (default=0)"),
     llvm::cl::cat(TVOptions), llvm::cl::init(0));
 
+llvm::cl::opt<bool> parallel_tv_jobserver(
+    "tv-parallel-jobserver",
+    llvm::cl::desc("Distribute TV load across cores (requires GNU Make, "
+                   "please see README.md, default=false)"),
+    llvm::cl::cat(TVOptions), llvm::cl::init(false));
+
+llvm::cl::opt<bool> parallel_tv_unrestricted(
+    "tv-parallel-unrestricted",
+    llvm::cl::desc("Distribute TV load across cores without any throttling; "
+                   "use this very carefully, if at all (default=false)"),
+    llvm::cl::cat(TVOptions), llvm::cl::init(false));
+
+llvm::cl::opt<int> max_subprocesses(
+    "tv-max-subprocesses",
+    llvm::cl::desc("Maximum children this clang instance will have at any time "
+                   "(default=128)"),
+    llvm::cl::cat(TVOptions), llvm::cl::init(128));
+
 struct FnInfo {
   Function fn;
   unsigned order;
@@ -182,7 +201,9 @@ bool showed_stats = false;
 bool report_dir_created = false;
 bool has_failure = false;
 bool is_clangtv = false;
-
+fs::path opt_report_parallel_dir;
+const char *parallel_subdir = "tmp_parallel";
+std::unique_ptr<parallel> parallelMgr;
 
 struct TVPass final : public llvm::FunctionPass {
   static char ID;
@@ -253,6 +274,50 @@ struct TVPass final : public llvm::FunctionPass {
     if (first || skip_verify)
       return false;
 
+    if (parallelMgr) {
+      default_random_engine re;
+      uniform_int_distribution<unsigned> rand;
+      random_device rd;
+      re.seed(rd());      
+      std::string newname;
+      fs::path path;
+      if (report_dir_created) {
+        // NB there's a low-probability toctou race here
+        do {
+          newname = "tmp_" + to_string(rand(re)) + ".txt";
+          path = opt_report_parallel_dir / newname;
+        } while (fs::exists(path));
+      }
+
+      out_file.flush();
+      pid_t res = parallelMgr->limitedFork();
+
+      if (res == -1)
+        llvm::report_fatal_error("fork() failed");
+
+      // parent returns to LLVM immediately
+      if (res != 0) {
+        if (report_dir_created)
+          *out << "include(" << path << ")\n";
+        return false;
+      }
+
+      if (report_dir_created) {
+        // child writes to the new file now
+        out_file.close();
+        out_file = ofstream(path);
+        if (!out_file.is_open()) {
+          cerr << "Alive2: Couldn't open report file!" << endl;
+          exit(1);
+        }
+      }
+    }
+
+    /*
+     * from here, we must not return back to LLVM if parallelMgr
+     * is non-null; instead we call parallelMgr->finishChild()
+     */
+
     if (is_clangtv)
       I->second.fn.setFnCallValidFlag(encode_io_fns_as_unknown);
 
@@ -273,7 +338,7 @@ struct TVPass final : public llvm::FunctionPass {
       if (!types) {
         *out << "Transformation doesn't verify!\n"
                 "ERROR: program doesn't type check!\n\n";
-        return false;
+        goto done;
       }
       assert(types.hasSingleTyping());
     }
@@ -288,19 +353,42 @@ struct TVPass final : public llvm::FunctionPass {
     }
 
     // Regenerate tgt because preprocessing may have changed it
-    I->second.fn = *llvm2alive(F, *TLI);
-    return false;
+    if (!parallelMgr)
+      I->second.fn = *llvm2alive(F, *TLI);
+
+  done:
+    if (parallelMgr) {
+      llvm_util_init.reset();
+      smt_init.reset();
+      parallelMgr->finishChild();
+    } else {
+      return false;
+    }
   }
 
   bool doInitialization(llvm::Module &module) override {
     if (initialized++)
       return false;
 
+    if (parallel_tv_jobserver) {
+      parallelMgr = std::make_unique<jobServer>();
+    } else if (parallel_tv_unrestricted) {
+      parallelMgr = std::make_unique<unrestricted>();
+    }
+
+    if (parallelMgr) {
+      if (!parallelMgr->init(max_subprocesses)) {
+        std::cerr << "WARNING: Parallel execution of Alive2 Clang plugin is "
+          "unavailable, sorry\n";
+        parallelMgr.reset();
+      }
+    }
+
     fnsToVerify.insert(opt_funcs.begin(), opt_funcs.end());
 
     if (!report_dir_created && !opt_report_dir.empty()) {
-      static default_random_engine re;
-      static uniform_int_distribution<unsigned> rand;
+      default_random_engine re;
+      uniform_int_distribution<unsigned> rand;
       static bool seeded = false;
 
       if (!seeded) {
@@ -309,18 +397,35 @@ struct TVPass final : public llvm::FunctionPass {
         seeded = true;
       }
 
-      fs::create_directories(opt_report_dir.getValue());
+      try {
+        fs::create_directories(opt_report_dir.getValue());
+      } catch (...) {
+        cerr << "Alive2: Couldn't create report directory!" << endl;
+        exit(1);
+      }
       auto &source_file = module.getSourceFileName();
       fs::path fname = source_file.empty() ? "alive.txt" : source_file;
       fname.replace_extension(".txt");
       fs::path path = fs::path(opt_report_dir.getValue()) / fname.filename();
 
       if (!opt_overwrite_reports) {
+        // NB there's a low-probability toctou race here
         do {
           auto newname = fname.stem();
           newname += "_" + to_string(rand(re)) + ".txt";
           path.replace_filename(newname);
         } while (fs::exists(path));
+      }
+
+      if (parallelMgr) {
+        opt_report_parallel_dir = fs::absolute(
+            fs::path(opt_report_dir.getValue()) / parallel_subdir);
+        try {
+          fs::create_directories(opt_report_parallel_dir);
+        } catch (...) {
+          cerr << "Alive2: Couldn't create report subdirectory!" << endl;
+          exit(1);
+        }
       }
 
       out_file = ofstream(path);
@@ -378,6 +483,9 @@ struct TVPass final : public llvm::FunctionPass {
   }
 
   bool doFinalization(llvm::Module&) override {
+    if (parallelMgr)
+      parallelMgr->waitForAllChildren();
+
     if (!showed_stats) {
       showed_stats = true;
       if (opt_smt_stats)

--- a/util/parallel.h
+++ b/util/parallel.h
@@ -1,0 +1,63 @@
+#pragma once
+
+// Copyright (c) 2018-present The Alive2 Authors.
+// Distributed under the MIT license that can be found in the LICENSE file.
+
+#include <sys/types.h>
+
+class parallel {
+public:
+  virtual ~parallel() {};
+  
+  /*
+   * must be called before any other methods are used, and this object
+   * must not be subsequently used if init() returns false
+   */
+  virtual bool init(int max_subprocesses) = 0;
+
+  /*
+   * called from parent; like fork(), returns non-zero to parent and
+   * zero to child; does not fork until max_processes is respected
+   * and, additionally, may throttle the child using e.g. the POSIX
+   * jobserver
+   */
+  virtual pid_t limitedFork() = 0;
+
+  /*
+   * called from a child that has finished executing
+   */
+  [[noreturn]] virtual void finishChild() = 0;
+
+  /*
+   * called from parent, returns when all child processes have
+   * terminated
+   */
+  virtual void waitForAllChildren() = 0;
+};
+
+class jobServer final : public parallel {
+  char token;
+  int read_fd = -1, write_fd = -1;
+  int subprocesses = 0;
+  int max_subprocesses;
+  bool nonblocking = false;
+  pid_t parent_pid = -1;
+  void getToken();
+  void putToken();
+public:
+  bool init(int max_subprocesses) override;
+  pid_t limitedFork() override;
+  void finishChild() override;
+  void waitForAllChildren() override;
+};
+
+class unrestricted final : public parallel {
+  int subprocesses = 0;
+  pid_t parent_pid = -1;
+  int max_subprocesses;
+public:
+  bool init(int max_subprocesses) override;
+  pid_t limitedFork() override;
+  void finishChild() override;
+  void waitForAllChildren() override;
+};

--- a/util/parallel_jobserver.cpp
+++ b/util/parallel_jobserver.cpp
@@ -1,0 +1,174 @@
+// Copyright (c) 2018-present The Alive2 Authors.
+// Distributed under the MIT license that can be found in the LICENSE file.
+
+#include "util/compiler.h"
+#include "util/parallel.h"
+#include <cassert>
+#include <cstdlib>
+#include <cstring>
+#include <fcntl.h>
+#include <iostream>
+#include <sys/stat.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+bool jobServer::init(int _max_subprocesses) {
+  auto env = std::getenv("MAKEFLAGS");
+  if (!env)
+    return false;
+  auto sub = strstr(env, "jobserver-auth="); // new GNU make
+  if (!sub)
+    sub = strstr(env, "jobserver-fds="); // old GNU make
+  if (!sub)
+    return false;
+  int rfd, wfd;
+  int res = sscanf(sub, "jobserver-auth=%d,%d", &rfd, &wfd);
+  if (res != 2)
+    res = sscanf(sub, "jobserver-fds=%d,%d", &rfd, &wfd);
+  if (res != 2)
+    return false;
+
+  /*
+   * this is a bit of hacky error protection for the very real
+   * possibility that GNU Make closed the jobserver pipe fds when
+   * exec'ing us, and then LLVM has already opened files corresponding
+   * to these descriptors. here we simply make sure that both fds
+   * correspond to pipe ends, which is at least somewhat unlikely to
+   * be true for arbitrary fds. this is a workaround for a fundamental
+   * flaw in the jobserver protocol. the GNU make maintainers are
+   * aware of this but have not solved it yet.
+   */
+  struct stat statbuf;
+  res = fstat(rfd, &statbuf);
+  if (res != 0 || !S_ISFIFO(statbuf.st_mode))
+    return false;
+  res = fstat(wfd, &statbuf);
+  if (res != 0 || !S_ISFIFO(statbuf.st_mode))
+    return false;
+
+  /*
+   * next issue is that the read file descriptor for the jobserver may
+   * or may not be non-blocking, and we're not allowed to set it to
+   * the behavior that want (blocking) because the non-blocking flag
+   * is part of the file instance (shared by many processes) and not a
+   * property of our private file descriptor.
+   *
+   * if the read fd is non-blocking, we have two workarounds:
+   *
+   * - if /proc/self/fd/N is available (on Linux), open it in the
+   *   default, blocking mode -- this works because we get a fresh
+   *   file instance
+   *
+   * - otherwise, remember that the fd is non-blocking and backoff to
+   *   a 100 Hz polling loop, which should be often enough to get good
+   *   CPU utilization and seldom enough to not generate a huge amount
+   *   of overhead. this should only happen on OS X.
+   */
+  int flags = fcntl(rfd, F_GETFL, 0);
+  if (flags == -1)
+    return false;
+  if (flags & O_NONBLOCK) {
+    char fn[256];
+    sprintf(fn, "/proc/self/fd/%d", rfd);
+    int newfd = open(fn, O_RDONLY);
+    if (newfd == -1)
+      nonblocking = true;
+    else
+      rfd = newfd;
+  }
+
+  parent_pid = getpid();
+  read_fd = rfd;
+  write_fd = wfd;
+  max_subprocesses = _max_subprocesses;
+  return true;
+}
+
+void jobServer::getToken() {
+  if (nonblocking) {
+    const struct timespec delay = {0, 10 * 1000 * 1000};
+    while (read(read_fd, &token, 1) != 1)
+      nanosleep(&delay, 0);
+  } else {
+    ENSURE(read(read_fd, &token, 1) == 1);
+  }
+}
+
+void jobServer::putToken() {
+  ENSURE(write(write_fd, &token, 1) == 1);
+}
+
+pid_t jobServer::limitedFork() {
+  assert(getpid() == parent_pid);
+  assert(read_fd != -1 && write_fd != -1);
+  /*
+   * reap zombies
+   */
+  int status;
+  while (waitpid((pid_t)(-1), &status, WNOHANG) > 0) {
+    if (WIFEXITED(status))
+      --subprocesses;
+  }
+  /*
+   * if we have too many children already, wait for some to exit
+   */
+  while (subprocesses >= max_subprocesses) {
+    if (wait(&status) != -1 && WIFEXITED(status))
+      --subprocesses;
+  }
+  std::fflush(nullptr);
+  pid_t res = fork();
+  if (res == -1)
+    return -1;
+
+  // parent returns immediately
+  if (res != 0) {
+    ++subprocesses;
+    return res;
+  }
+
+  // child has to wait for a jobserver token
+  getToken();
+
+  return 0;
+}
+
+void jobServer::finishChild() {
+  assert(getpid() != parent_pid);
+  putToken();
+  exit(0);
+}
+
+void jobServer::waitForAllChildren() {
+  assert(getpid() == parent_pid);
+  /*
+   * every process forked by GNU make implicitly holds a single
+   * jobserver token. here we temporarily return this token into the
+   * pool while we're blocked waiting for children to finish. this is
+   * a bit of a violation of the jobserver protocol, but it helps
+   * prevent deadlock.
+   *
+   * to see the deadlock, consider a "make -j4". four clang processes
+   * are spawned by make, and they spawn some number of sub-processes
+   * for translation validation, all of which end up blocked waiting
+   * for jobserver tokens -- because there are none. then, all four
+   * clang processes end up here waiting for their children to finish,
+   * and we're stuck forever.
+   *
+   * giving this token back doesn't, strictly speaking, prevent
+   * deadlock, because it could be another clang that gets the token
+   * instead of a TV subprocess -- but this seems unlikely assuming
+   * the readers are queued in FIFO order.
+   */
+  putToken();
+  int status;
+  while (wait(&status) != -1) {
+    if (WIFEXITED(status))
+      --subprocesses;
+  }
+  getToken();
+  if (subprocesses != 0) {
+    std::cerr << "Alive2: Expected 0 subprocesses but have " << subprocesses
+              << "\n";
+  }
+}

--- a/util/parallel_unrestricted.cpp
+++ b/util/parallel_unrestricted.cpp
@@ -1,0 +1,60 @@
+// Copyright (c) 2018-present The Alive2 Authors.
+// Distributed under the MIT license that can be found in the LICENSE file.
+
+#include "util/compiler.h"
+#include "util/parallel.h"
+#include <cassert>
+#include <cstdlib>
+#include <cstring>
+#include <fcntl.h>
+#include <iostream>
+#include <sys/wait.h>
+#include <unistd.h>
+
+bool unrestricted::init(int _max_subprocesses) {
+  parent_pid = getpid();
+  max_subprocesses = _max_subprocesses;
+  return true;
+}
+
+pid_t unrestricted::limitedFork() {
+  assert(getpid() == parent_pid);
+  /*
+   * reap zombies
+   */
+  int status;
+  while (waitpid((pid_t)(-1), &status, WNOHANG) > 0) {
+    if (WIFEXITED(status))
+      --subprocesses;
+  }
+  /*
+   * if we have too many children already, wait for some to exit
+   */
+  while (subprocesses >= max_subprocesses) {
+    if (wait(&status) != -1 && WIFEXITED(status))
+      --subprocesses;
+  }
+  std::fflush(nullptr);
+  auto res = fork();
+  if (res > 0)
+    ++subprocesses;
+  return res;
+}
+
+void unrestricted::finishChild() {
+  assert(getpid() != parent_pid);
+  exit(0);
+}
+
+void unrestricted::waitForAllChildren() {
+  assert(getpid() == parent_pid);
+  int status;
+  while (wait(&status) != -1) {
+    if (WIFEXITED(status))
+      --subprocesses;
+  }
+  if (subprocesses != 0) {
+    std::cerr << "Alive2: expected zero remaining children but we have "
+              << subprocesses << "\n";
+  }
+}


### PR DESCRIPTION
parallelism managers: one that just forks in uncontrolled fashion (for
testing and debugging -- don't run it on large inputs) and another
that uses the jobserver from GNU make to limit parallelism.

when output in not directed to a report directory, it all just gets
blatted to the terminal in mixed-up fashion by all the different
proceses. when output is directed to a report directory, it goes to a
lot of little individual files and then a utility fix_report_files
stitches it all back together.