### PR TITLE
add unit test support for opt plugin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -187,11 +187,19 @@ if (BUILD_TV)
   endif()
   message(STATUS "Compiling translation validation plugin")
   add_subdirectory(tv)
+  set(FOR_ALIVE2_TEST 0)
   configure_file(
     ${CMAKE_SOURCE_DIR}/scripts/opt-alive.sh.in
     ${CMAKE_BINARY_DIR}/opt-alive.sh
     @ONLY
   )
+  set(FOR_ALIVE2_TEST 1)
+  configure_file(
+    ${CMAKE_SOURCE_DIR}/scripts/opt-alive.sh.in
+    ${CMAKE_BINARY_DIR}/opt-alive-test.sh
+    @ONLY
+  )
+  unset(FOR_ALIVE2_TEST)
 else()
   message(STATUS "Skipping translation validation plugin")
 endif()

--- a/scripts/opt-alive.sh.in
+++ b/scripts/opt-alive.sh.in
@@ -37,4 +37,15 @@ else
   # Linux, Cygwin/Msys, or Win32?
   TV_SHAREDLIB=tv.so
 fi
-timeout 1000 @LLVM_BINARY_DIR@/bin/opt -load=@CMAKE_BINARY_DIR@/tv/$TV_SHAREDLIB -tv-exit-on-error $TV $@ $TV -tv-smt-to=10000 -tv-report-dir=@CMAKE_BINARY_DIR@/logs -tv-smt-stats $IO_NOBUILTIN
+
+TV_REPORT_DIR=""
+TIMEOUT=""
+TV_SMT_TO=""
+TV_SMT_STATS=""
+if [[ @FOR_ALIVE2_TEST@ == 0 ]]; then
+  TV_REPORT_DIR=@CMAKE_BINARY_DIR@/logs
+  TIMEOUT=timeout 1000
+  TV_SMT_TO="-tv-smt-to=10000"
+  TV_SMT_STATS=-tv-smt-stats
+fi
+$TIMEOUT @LLVM_BINARY_DIR@/bin/opt -load=@CMAKE_BINARY_DIR@/tv/$TV_SHAREDLIB -tv-exit-on-error $TV $@ $TV $TV_SMT_TO $TV_REPORT_DIR $TV_SMT_STATS $IO_NOBUILTIN

--- a/scripts/opt-alive.sh.in
+++ b/scripts/opt-alive.sh.in
@@ -44,8 +44,8 @@ TV_SMT_TO=""
 TV_SMT_STATS=""
 if [[ @FOR_ALIVE2_TEST@ == 0 ]]; then
   TV_REPORT_DIR=@CMAKE_BINARY_DIR@/logs
-  TIMEOUT=timeout 1000
-  TV_SMT_TO="-tv-smt-to=10000"
+  TIMEOUT="timeout 1000"
+  TV_SMT_TO=-tv-smt-to=10000
   TV_SMT_STATS=-tv-smt-stats
 fi
 $TIMEOUT @LLVM_BINARY_DIR@/bin/opt -load=@CMAKE_BINARY_DIR@/tv/$TV_SHAREDLIB -tv-exit-on-error $TV $@ $TV $TV_SMT_TO $TV_REPORT_DIR $TV_SMT_STATS $IO_NOBUILTIN

--- a/tests/lit/lit/formats/alive2test.py
+++ b/tests/lit/lit/formats/alive2test.py
@@ -64,7 +64,7 @@ class Alive2Test(TestFormat):
           not os.path.isdir(filepath) and \
           (filename.endswith('.opt') or filename.endswith('.src.ll') or
            filename.endswith('.srctgt.ll') or filename.endswith('.c') or
-           filename.endswith('.cpp')):
+           filename.endswith('.cpp') or filename.endswith('.opt.ll')):
         yield lit.Test.Test(testSuite, path_in_suite + (filename,), localConfig)
 
 
@@ -83,6 +83,12 @@ class Alive2Test(TestFormat):
       if not os.path.isfile('alive-tv'):
         return lit.Test.UNSUPPORTED, ''
 
+    opt_tv = test.endswith('.opt.ll')
+    if opt_tv:
+      cmd = ['./opt-alive-test.sh', '-disable-output']
+      if not os.path.isfile('opt-alive-test.sh'):
+        return lit.Test.UNSUPPORTED, ''
+
     clang_tv = test.endswith('.c') or test.endswith('.cpp')
     if clang_tv:
       execpath = './%s' % ("alivecc" if test.endswith('.c')
@@ -92,7 +98,7 @@ class Alive2Test(TestFormat):
       if not os.path.isfile(execpath):
         return lit.Test.UNSUPPORTED, ''
 
-    if not alive_tv_1 and not alive_tv_2 and not clang_tv:
+    if not alive_tv_1 and not alive_tv_2 and not clang_tv and not opt_tv:
       cmd = ['./alive', '-smt-to:20000']
 
     input = readFile(test)

--- a/tests/opt-tv/printf.opt.ll
+++ b/tests/opt-tv/printf.opt.ll
@@ -1,0 +1,11 @@
+; TEST-ARGS: -instcombine
+@.str = constant [3 x i8] c"a\0A\00", align 1
+
+define void @f() {
+  call i32 (i8*, ...) @printf(i8* getelementptr inbounds ([3 x i8], [3 x i8]* @.str, i64 0, i64 0))
+  ret void
+}
+
+declare i32 @printf(i8*, ...)
+
+; ERROR: Invalid expr

--- a/tests/opt-tv/test.opt.ll
+++ b/tests/opt-tv/test.opt.ll
@@ -1,0 +1,7 @@
+; TEST-ARGS: -instcombine
+
+define i32 @test(i32 %x) {
+  %v = add i32 %x, 1
+  %w = sub i32 %v, 1
+  ret i32 %w
+}


### PR DESCRIPTION
This PR resolves #95 : adds support for running lit testing with the opt Alive2 plugin.