### PR TITLE
fix issue #582: crash in basicblock duplication

### DIFF
--- a/ir/function.cpp
+++ b/ir/function.cpp
@@ -435,6 +435,8 @@ cloneBB(Function &F, const BasicBlock &BB, const char *suffix,
         if (copies.back().second == phi) {
           newbb.rauw(*phi, *const_cast<Value*>(val));
           copies.pop_back();
+          if (copies.empty())
+            vmap.erase(val);
           break;
         }
       }

--- a/tests/alive-tv/loops/issue582.srctgt.ll
+++ b/tests/alive-tv/loops/issue582.srctgt.ll
@@ -1,0 +1,24 @@
+; TEST-ARGS: -src-unroll=2
+
+@a = global i32 0, align 4
+define void @src() {
+entry:
+  br label %for.cond
+for.cond:                                         ; preds = %for.cond, %entry
+  %0 = load i32, i32* @a, align 4
+  %tobool.not = icmp eq i32 %0, 0
+  br i1 %tobool.not, label %for.cond1, label %for.cond
+for.cond1:                                        ; preds = %for.cond, %for.inc
+  %c.0 = phi i32 [ %add, %for.inc ], [ undef, %for.cond ]
+  %tobool2.not = icmp eq i32 %c.0, 0
+  br i1 %tobool2.not, label %for.cond.cleanup, label %for.inc
+for.cond.cleanup:                                 ; preds = %for.cond1
+  ret void
+for.inc:                                          ; preds = %for.cond1
+  %add = add nsw i32 %c.0, %0
+  br label %for.cond1
+}
+
+define void @tgt() {
+  ret void
+}


### PR DESCRIPTION
When dealing with multi-entering phi without loop carried dependencies, if the copies is empty after copies.pop_back(), we need also erase the key (val) from the vmap. If we don't erase, vmap would contain keys with empty values. L403 would be reachable for such keys. Since calling back() on an empty vector is UB, dereferencing the result leads to the crash listed in issue #582.

https://github.com/AliveToolkit/alive2/blob/e58c28cc61798140151d1fcd4064616740c71559/ir/function.cpp#L403

