### PR TITLE
add get_outs/set_outs

### DIFF
--- a/llvm_util/llvm2alive.cpp
+++ b/llvm_util/llvm2alive.cpp
@@ -103,6 +103,7 @@ class llvm2alive_ : public llvm::InstVisitor<llvm2alive_, unique_ptr<Instr>> {
   vector<llvm::Instruction*> i_constexprs;
   const vector<string_view> &gvnamesInSrc;
   vector<tuple<Phi*, llvm::PHINode*, unsigned>> todo_phis;
+  ostream *out;
 
   using RetTy = unique_ptr<Instr>;
 
@@ -159,7 +160,7 @@ class llvm2alive_ : public llvm::InstVisitor<llvm2alive_, unique_ptr<Instr>> {
 public:
   llvm2alive_(llvm::Function &f, const llvm::TargetLibraryInfo &TLI,
               const vector<string_view> &gvnamesInSrc)
-      : f(f), TLI(TLI), gvnamesInSrc(gvnamesInSrc) {}
+      : f(f), TLI(TLI), gvnamesInSrc(gvnamesInSrc), out(&get_outs()) {}
 
   ~llvm2alive_() {
     for (auto &inst : i_constexprs) {
@@ -1246,7 +1247,6 @@ unsigned omit_array_size = -1;
 
 
 initializer::initializer(ostream &os, const llvm::DataLayout &DL) {
-  out = &os;
   init_llvm_utils(os, DL);
 }
 

--- a/llvm_util/utils.cpp
+++ b/llvm_util/utils.cpp
@@ -429,6 +429,14 @@ void init_llvm_utils(ostream &os, const llvm::DataLayout &dataLayout) {
   DL = &dataLayout;
 }
 
+std::ostream& get_outs() {
+  return *out;
+}
+
+void set_outs(std::ostream &os) {
+  out = &os;
+}
+
 void reset_state(Function &f) {
   current_fn = &f;
   value_cache.clear();

--- a/llvm_util/utils.h
+++ b/llvm_util/utils.h
@@ -50,5 +50,9 @@ PRINT(llvm::Value)
 #undef PRINT
 
 void init_llvm_utils(std::ostream &os, const llvm::DataLayout &DL);
+
+std::ostream& get_outs();
+void set_outs(std::ostream &);
+
 void reset_state(IR::Function &f);
 }


### PR DESCRIPTION
I'm sorry for the delay, I had a few things that had to be done today.

This is a super small patch that adds getter/setter for `out` that can be used to change ostream that is used by llvm2alive.cpp .

I think `initializer` does not require ostream argument anymore, but it is left unchanged because it needs updates in tv.