### PR TITLE
give us a turned-off-by-default global mechanism for timing out a lon…

### DIFF
--- a/util/parallel_jobserver.cpp
+++ b/util/parallel_jobserver.cpp
@@ -103,7 +103,6 @@ tuple<pid_t, ostream *, int> jobServer::limitedFork() {
 void jobServer::finishChild() {
   writeToParent();
   putToken();
-  exit(0);
 }
 
 void jobServer::waitForAllChildren() {

--- a/util/parallel_unrestricted.cpp
+++ b/util/parallel_unrestricted.cpp
@@ -14,7 +14,6 @@ std::tuple<pid_t, std::ostream *, int> unrestricted::limitedFork() {
 
 void unrestricted::finishChild() {
   writeToParent();
-  exit(0);
 }
 
 void unrestricted::waitForAllChildren() {


### PR DESCRIPTION
…g TV job, but only when it's run as a subprocess by the LLVM plugin

I made this mechanism print the same thing as the other timeout mechanism, not 100% certain that's the correct decision since people may be curious which timeout is getting triggered. but this seems safest and ensures that our existing results-processing scripts will understand what occurred.