### PR TITLE
add support for opt new pass manager unit tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,8 +104,7 @@ Running Alive2 as a Clang Plugin
 --------
 
 This plugin tries to validate every IR-level transformation performed
-by LLVM.  To build it, add `-DCLANG_PLUGIN=1` to the cmake
-command. Then, invoke the plugin like this:
+by LLVM.  Invoke the plugin like this:
 
 ```
 $ clang -O3 <src.c> -S -emit-llvm \

--- a/scripts/opt-alive.sh.in
+++ b/scripts/opt-alive.sh.in
@@ -19,12 +19,13 @@ for arg in $@; do
   if [[ $arg == "-passes="* ]]; then
     passes=${arg#-passes=}
     passes_new=`@CMAKE_SOURCE_DIR@/scripts/rewritepass.py @LLVM_BINARY_DIR@/bin/opt $passes`
-    firstpass_level=`echo "$passes_new" | cut -d " " -f1`
-    passes_new=`echo "$passes_new" | cut -d " " -f2-`
+    firstpass_level=`echo $passes_new | cut -d " " -f1`
+    passes_new=`echo $passes_new | cut -d " " -f2-`
     if [[ ( $firstpass_level = "module" ) || ( $firstpass_level = "cgscc" ) ]]
-      set -- "$@" "-passes=module(tv),$passes_new,module(tv)"
-    else
+    then
       set -- "$@" "$arg"
+    else
+      set -- "$@" "-passes=module(tv),$passes_new,module(tv)"
     fi
   else
     set -- "$@" "$arg"

--- a/scripts/opt-alive.sh.in
+++ b/scripts/opt-alive.sh.in
@@ -18,8 +18,14 @@ for arg in $@; do
   shift
   if [[ $arg == "-passes="* ]]; then
     passes=${arg#-passes=}
-    passes_new=`@CMAKE_BINARY_DIR@/../scripts/rewritepass.py @LLVM_BINARY_DIR@/bin/opt $passes`
-    set -- "$@" "-passes=module(tv),$passes_new,module(tv)"
+    passes_new=`@CMAKE_SOURCE_DIR@/scripts/rewritepass.py @LLVM_BINARY_DIR@/bin/opt $passes`
+    firstpass_level=`echo "$passes_new" | cut -d " " -f1`
+    passes_new=`echo "$passes_new" | cut -d " " -f2-`
+    if [[ $firstpass_level != "module" ]]; then
+      set -- "$@" "-passes=module(tv),$passes_new,module(tv)"
+    else
+      set -- "$@" "$arg"
+    fi
   else
     set -- "$@" "$arg"
   fi

--- a/scripts/opt-alive.sh.in
+++ b/scripts/opt-alive.sh.in
@@ -13,6 +13,7 @@ set -e
 PASSES="-passes= argpromotion deadargelim globalopt hotcoldsplit inline ipconstprop ipsccp mergefunc partial-inliner tbaa loop-extract extract-blocks safe-stack place-safepoints attributor function-attrs metarenamer sample-profile lowertypetests extract-blocks openmpopt prune-eh tailcallelim -Os -Oz -O1 -O2 -O3"
 
 TV="-tv"
+NPM_TV=0
 for arg in $@; do
   # update the -passes argument only.
   shift
@@ -26,6 +27,7 @@ for arg in $@; do
       set -- "$@" "$arg"
     else
       set -- "$@" "-passes=module(tv),$passes_new,module(tv)"
+      NPM_TV=1
     fi
   else
     set -- "$@" "$arg"
@@ -56,4 +58,9 @@ if [[ @FOR_ALIVE2_TEST@ == 0 ]]; then
   TV_SMT_TO=-tv-smt-to=10000
   TV_SMT_STATS=-tv-smt-stats
 fi
-$TIMEOUT @LLVM_BINARY_DIR@/bin/opt -load=@CMAKE_BINARY_DIR@/tv/$TV_SHAREDLIB -load-pass-plugin=@CMAKE_BINARY_DIR@/tv/$TV_SHAREDLIB -tv-exit-on-error $TV $@ $TV $TV_SMT_TO $TV_REPORT_DIR $TV_SMT_STATS
+NPM_PLUGIN=""
+# Without this guard, passes like default<Os> invokes whole-pass validation
+if [[ $NPM_TV == 1 ]]; then
+  NPM_PLUGIN="-load-pass-plugin=@CMAKE_BINARY_DIR@/tv/$TV_SHAREDLIB"
+fi
+$TIMEOUT @LLVM_BINARY_DIR@/bin/opt -load=@CMAKE_BINARY_DIR@/tv/$TV_SHAREDLIB  $NPM_PLUGIN -tv-exit-on-error $TV $@ $TV $TV_SMT_TO $TV_REPORT_DIR $TV_SMT_STATS

--- a/scripts/opt-alive.sh.in
+++ b/scripts/opt-alive.sh.in
@@ -27,7 +27,7 @@ for arg in $@; do
     then
       set -- "$@" "$arg"
     else
-      set -- "$@" "-passes=module(tv),$passes_new,module(tv)"
+      set -- "$@" "-passes=tv,$passes_new,tv"
       NPM_TV=1
     fi
   else

--- a/scripts/opt-alive.sh.in
+++ b/scripts/opt-alive.sh.in
@@ -21,7 +21,7 @@ for arg in $@; do
     passes_new=`@CMAKE_SOURCE_DIR@/scripts/rewritepass.py @LLVM_BINARY_DIR@/bin/opt $passes`
     firstpass_level=`echo "$passes_new" | cut -d " " -f1`
     passes_new=`echo "$passes_new" | cut -d " " -f2-`
-    if [[ $firstpass_level != "module" ]]; then
+    if [[ ( $firstpass_level = "module" ) || ( $firstpass_level = "cgscc" ) ]]
       set -- "$@" "-passes=module(tv),$passes_new,module(tv)"
     else
       set -- "$@" "$arg"

--- a/scripts/opt-alive.sh.in
+++ b/scripts/opt-alive.sh.in
@@ -14,6 +14,15 @@ PASSES="-passes= argpromotion deadargelim globalopt hotcoldsplit inline ipconstp
 
 TV="-tv"
 for arg in $@; do
+  # update the -passes argument only.
+  shift
+  if [[ $arg == "-passes="* ]]; then
+    passes=${arg#-passes=}
+    passes_new=`@CMAKE_BINARY_DIR@/../scripts/rewritepass.py @LLVM_BINARY_DIR@/bin/opt $passes`
+    set -- "$@" "-passes=module(tv),$passes_new,module(tv)"
+  else
+    set -- "$@" "$arg"
+  fi
   for p in $PASSES; do
     if [[ $arg == *"$p"* ]]; then
       TV=""
@@ -40,4 +49,4 @@ if [[ @FOR_ALIVE2_TEST@ == 0 ]]; then
   TV_SMT_TO=-tv-smt-to=10000
   TV_SMT_STATS=-tv-smt-stats
 fi
-$TIMEOUT @LLVM_BINARY_DIR@/bin/opt -load=@CMAKE_BINARY_DIR@/tv/$TV_SHAREDLIB -tv-exit-on-error $TV $@ $TV $TV_SMT_TO $TV_REPORT_DIR $TV_SMT_STATS
+$TIMEOUT @LLVM_BINARY_DIR@/bin/opt -load=@CMAKE_BINARY_DIR@/tv/$TV_SHAREDLIB -load-pass-plugin=@CMAKE_BINARY_DIR@/tv/$TV_SHAREDLIB -tv-exit-on-error $TV $@ $TV $TV_SMT_TO $TV_REPORT_DIR $TV_SMT_STATS

--- a/scripts/opt-alive.sh.in
+++ b/scripts/opt-alive.sh.in
@@ -11,6 +11,7 @@ set -e
 # metarenamer: anonymizes function names
 # sample-profile: inlines functions
 PASSES="-passes= argpromotion deadargelim globalopt hotcoldsplit inline ipconstprop ipsccp mergefunc partial-inliner tbaa loop-extract extract-blocks safe-stack place-safepoints attributor function-attrs metarenamer sample-profile lowertypetests extract-blocks openmpopt prune-eh tailcallelim -Os -Oz -O1 -O2 -O3"
+PASSREGISTRY="@LLVM_BUILD_MAIN_SRC_DIR@/lib/Passes/PassRegistry.def"
 
 TV="-tv"
 NPM_TV=0
@@ -19,7 +20,7 @@ for arg in $@; do
   shift
   if [[ $arg == "-passes="* ]]; then
     passes=${arg#-passes=}
-    passes_new=`@CMAKE_SOURCE_DIR@/scripts/rewritepass.py @LLVM_BINARY_DIR@/bin/opt $passes`
+    passes_new=`@CMAKE_SOURCE_DIR@/scripts/rewritepass.py "$PASSREGISTRY" $passes`
     firstpass_level=`echo $passes_new | cut -d " " -f1`
     passes_new=`echo $passes_new | cut -d " " -f2-`
     if [[ ( $firstpass_level = "module" ) || ( $firstpass_level = "cgscc" ) ]]

--- a/scripts/rewritepass.py
+++ b/scripts/rewritepass.py
@@ -35,6 +35,8 @@ for k in levels:
   if passes[0].startswith(k + "("):
     firstp_level = k
     break
+if passes[0].startswith("loop-mssa("):
+  firstp_level = "loop"
 
 for i in ["s", "z", "0", "1", "2", "3"]:
   if passes[0] == "default<O" + i + ">":
@@ -81,6 +83,5 @@ if firstp_level != "module":
   for p in level_ancestors[firstp_level]:
     prefix = p + "(" + prefix
     suffix = suffix + ")"
-
 
 print(firstp_level + " " + prefix + ",".join(passes) + suffix)

--- a/scripts/rewritepass.py
+++ b/scripts/rewritepass.py
@@ -1,0 +1,94 @@
+#!/usr/bin/python3
+import sys
+import os
+
+if len(sys.argv) != 3:
+  print("Use: %s <opt path> <passes>" % sys.argv[0])
+  exit(1)
+
+optpath = sys.argv[1]
+passes = sys.argv[2].strip("'\"").split(',')
+plen = len(passes)
+
+level_ancestors = {
+  "module":[],
+  "cgscc":["module"],
+  "function":["module"],
+      # don't use module(cgscc(function(...)), use module(function(...))
+      # the former one results in a different output.
+      # e.g. llvm/test/Transforms/LoopVectorize/reduction-order.ll
+  "loop":["function", "module"]
+}
+
+"""
+PassBuilder.cpp states that:
+  As a special shortcut, if the very first pass is not
+  a module pass (as a module pass manager is), this will automatically form
+  the shortest stack of pass managers that allow inserting that first pass.
+Build the stack of pass managers by invoking opt with the first pass and
+parsing its error message.
+"""
+i = 0
+firstp = passes[i]
+if firstp.find("<") != -1 or firstp.find("(") != -1:
+  # make p complete by concatenating tokens until the corresponding ">"
+  # and ")" are found
+  par = par2 = 0
+  ps = []
+  while i < plen:
+    ps.append(passes[i])
+    par  += passes[i].count("(") - passes[i].count(")")
+    par2 += passes[i].count("<") - passes[i].count(">")
+    if par == 0 and par2 == 0:
+      break
+    i = i + 1
+  firstp = ",".join(ps)
+
+
+# 'opt -passes=..' does not generate the message we want if one of these passes
+# is used.
+unsupported_module_passes = [
+  "function-import",
+  "pgo-instr-use",
+  "insert-gcov-profiling",
+  "sample-profile"
+]
+
+firstp_level = None
+if firstp not in unsupported_module_passes:
+  # get the level of the first pass by invoking opt and parsing the output
+  # message.
+  optparam = '-passes="%s,module(globalopt)" -disable-output 2>&1' % firstp
+  output = os.popen('echo "" | "%s" %s' %
+                    (optpath, optparam)).read()
+  lines = output.strip().split("\n")
+  assert(len(lines) == 1)
+  if lines[0] != "":
+    msg = "invalid use of 'module' pass as ";
+    assert(lines[0].find(msg) != -1), \
+          "unknown output from opt: " + lines[0] + ", optparam: " + optparam
+
+    # level_str becomes e.g. "function pipeline"
+    level_str = lines[0][lines[0].find(msg) + len(msg):]
+    # get "function"
+    firstp_level = level_str.split()[0]
+    assert(firstp_level in level_ancestors)
+
+i = i + 1
+res = [firstp] + passes[i:]
+
+prefix = ""
+suffix = ""
+
+if firstp_level:
+  if not firstp.startswith(firstp_level):
+    # don't print "function(function(passes))"
+    prefix = firstp_level + "("
+    suffix = ")"
+
+  for p in level_ancestors[firstp_level]:
+    prefix = p + "(" + prefix
+    suffix = suffix + ")"
+
+
+print(prefix + ",".join(res) + suffix)

--- a/scripts/rewritepass.py
+++ b/scripts/rewritepass.py
@@ -11,7 +11,6 @@ passes = sys.argv[2].strip("'\"").split(',')
 plen = len(passes)
 
 level_ancestors = {
-  "module":[],
   "cgscc":["module"],
   "function":["module"],
       # don't use module(cgscc(function(...)), use module(function(...))
@@ -54,7 +53,7 @@ unsupported_module_passes = [
   "sample-profile"
 ]
 
-firstp_level = None
+firstp_level = "module"
 if firstp not in unsupported_module_passes:
   # get the level of the first pass by invoking opt and parsing the output
   # message.
@@ -73,6 +72,8 @@ if firstp not in unsupported_module_passes:
     # get "function"
     firstp_level = level_str.split()[0]
     assert(firstp_level in level_ancestors)
+  else:
+    firstp_level = "module"
 
 i = i + 1
 res = [firstp] + passes[i:]
@@ -80,7 +81,7 @@ res = [firstp] + passes[i:]
 prefix = ""
 suffix = ""
 
-if firstp_level:
+if firstp_level != "module":
   if not firstp.startswith(firstp_level):
     # don't print "function(function(passes))"
     prefix = firstp_level + "("
@@ -91,4 +92,4 @@ if firstp_level:
     suffix = suffix + ")"
 
 
-print(prefix + ",".join(res) + suffix)
+print(firstp_level + " " + prefix + ",".join(res) + suffix)

--- a/scripts/rewritepass.py
+++ b/scripts/rewritepass.py
@@ -49,7 +49,6 @@ if firstp.find("<") != -1 or firstp.find("(") != -1:
 unsupported_module_passes = [
   "function-import",
   "pgo-instr-use",
-  "insert-gcov-profiling",
   "sample-profile"
 ]
 

--- a/scripts/rewritepass.py
+++ b/scripts/rewritepass.py
@@ -3,14 +3,16 @@ import sys
 import os
 
 if len(sys.argv) != 3:
-  print("Use: %s <opt path> <passes>" % sys.argv[0])
+  print("Use: %s <PassRegistry.def path> <passes>" % sys.argv[0])
   exit(1)
 
-optpath = sys.argv[1]
+passregpath = sys.argv[1]
 passes = sys.argv[2].strip("'\"").split(',')
 plen = len(passes)
 
+levels = ["module", "cgscc", "function", "loop"]
 level_ancestors = {
+  "module":[],
   "cgscc":["module"],
   "function":["module"],
       # don't use module(cgscc(function(...)), use module(function(...))
@@ -24,64 +26,54 @@ PassBuilder.cpp states that:
   As a special shortcut, if the very first pass is not
   a module pass (as a module pass manager is), this will automatically form
   the shortest stack of pass managers that allow inserting that first pass.
-Build the stack of pass managers by invoking opt with the first pass and
-parsing its error message.
+Build the stack of pass managers by finding the first pass from PassRegistry.def
 """
-i = 0
-firstp = passes[i]
-if firstp.find("<") != -1 or firstp.find("(") != -1:
-  # make p complete by concatenating tokens until the corresponding ">"
-  # and ")" are found
-  par = par2 = 0
-  ps = []
-  while i < plen:
-    ps.append(passes[i])
-    par  += passes[i].count("(") - passes[i].count(")")
-    par2 += passes[i].count("<") - passes[i].count(">")
-    if par == 0 and par2 == 0:
-      break
-    i = i + 1
-  firstp = ",".join(ps)
 
+firstp_level = None
+# If the level is explicitly given, use it
+for k in levels:
+  if passes[0].startswith(k + "("):
+    firstp_level = k
+    break
 
-# 'opt -passes=..' does not generate the message we want if one of these passes
-# is used.
-unsupported_module_passes = [
-  "function-import",
-  "pgo-instr-use",
-  "sample-profile"
-]
-
-firstp_level = "module"
-if firstp not in unsupported_module_passes:
-  # get the level of the first pass by invoking opt and parsing the output
-  # message.
-  optparam = '-passes="%s,module(globalopt)" -disable-output 2>&1' % firstp
-  output = os.popen('echo "" | "%s" %s' %
-                    (optpath, optparam)).read()
-  lines = output.strip().split("\n")
-  assert(len(lines) == 1)
-  if lines[0] != "":
-    msg = "invalid use of 'module' pass as ";
-    assert(lines[0].find(msg) != -1), \
-          "unknown output from opt: " + lines[0] + ", optparam: " + optparam
-
-    # level_str becomes e.g. "function pipeline"
-    level_str = lines[0][lines[0].find(msg) + len(msg):]
-    # get "function"
-    firstp_level = level_str.split()[0]
-    assert(firstp_level in level_ancestors)
-  else:
+for i in ["s", "z", "0", "1", "2", "3"]:
+  if passes[0] == "default<O" + i + ">":
     firstp_level = "module"
+    break
 
-i = i + 1
-res = [firstp] + passes[i:]
+if firstp_level == None:
+  # ask PassRegistry.def
+  firstpass = passes[0]
+  if passes[0].startswith("require<"):
+    firstpass = passes[0][len("require<"):]
+  firstpass = firstpass.replace("(", ",").replace("<",",").replace(">",",") \
+                       .replace(";", ",").split(",")[0]
+
+  # There are passes like "verify", which can be either function or module
+  # level. We should allow them
+  found_levels = dict()
+  prefixes = ["MODULE_", "CGSCC_", "FUNCTION_", "LOOP_"]
+  for l in open(passregpath, "r").readlines():
+    if l.find(firstpass) == -1:
+      continue
+    for i in range(0, len(prefixes)):
+      if l.startswith(prefixes[i]):
+        found_levels[levels[i]] = True
+
+  if "module" in found_levels and len(found_levels) == 1:
+    # precisely a module level pass
+    firstp_level = "module"
+  else:
+    for i in range(1, len(prefixes)): # can be non-module (ex: verify)
+      if levels[i] in found_levels:
+        firstp_level = levels[i]
+        break
 
 prefix = ""
 suffix = ""
 
 if firstp_level != "module":
-  if not firstp.startswith(firstp_level):
+  if not passes[0].startswith(firstp_level):
     # don't print "function(function(passes))"
     prefix = firstp_level + "("
     suffix = ")"
@@ -91,4 +83,4 @@ if firstp_level != "module":
     suffix = suffix + ")"
 
 
-print(firstp_level + " " + prefix + ",".join(res) + suffix)
+print(firstp_level + " " + prefix + ",".join(passes) + suffix)

--- a/scripts/rewritepass.py
+++ b/scripts/rewritepass.py
@@ -8,7 +8,6 @@ if len(sys.argv) != 3:
 
 passregpath = sys.argv[1]
 passes = sys.argv[2].strip("'\"").split(',')
-plen = len(passes)
 
 levels = ["module", "cgscc", "function", "loop"]
 level_ancestors = {

--- a/scripts/rewritepass.py
+++ b/scripts/rewritepass.py
@@ -39,8 +39,12 @@ if passes[0].startswith("loop-mssa("):
   firstp_level = "loop"
 
 for i in ["s", "z", "0", "1", "2", "3"]:
-  if passes[0] == "default<O" + i + ">":
-    firstp_level = "module"
+  for pipeline in ["default", "thinlto-pre-link", "thinlto", "lto-pre-link",
+                   "lto"]:
+    if passes[0] == "%s<O%s>" % (pipeline, i):
+      firstp_level = "module"
+      break
+  if firstp_level != None:
     break
 
 if firstp_level == None:
@@ -56,7 +60,7 @@ if firstp_level == None:
   found_levels = dict()
   prefixes = ["MODULE_", "CGSCC_", "FUNCTION_", "LOOP_"]
   for l in open(passregpath, "r").readlines():
-    if l.find(firstpass) == -1:
+    if l.find('"%s"' % firstpass) == -1 and l.find('"%s<' % firstpass) == -1:
       continue
     for i in range(0, len(prefixes)):
       if l.startswith(prefixes[i]):

--- a/scripts/rewritepass.py
+++ b/scripts/rewritepass.py
@@ -47,6 +47,10 @@ for i in ["s", "z", "0", "1", "2", "3"]:
   if firstp_level != None:
     break
 
+# PassBuilder.cpp: isCGSCCPassName()
+if passes[0].startswith("devirt<") or passes[0].startswith("repeat<"):
+  firstp_level = "cgscc"
+
 if firstp_level == None:
   # ask PassRegistry.def
   firstpass = passes[0]

--- a/tests/opt-tv/npm-Os.opt.ll
+++ b/tests/opt-tv/npm-Os.opt.ll
@@ -1,0 +1,8 @@
+; TEST-ARGS: -passes=default<Os>
+
+define i32 @f() {
+  ret i32 1
+}
+
+; src and tgt are identical, but opt-alive hould not validate anything
+; CHECK-NOT: Transformation

--- a/tests/opt-tv/npm-Os.opt.ll
+++ b/tests/opt-tv/npm-Os.opt.ll
@@ -4,5 +4,5 @@ define i32 @f() {
   ret i32 1
 }
 
-; src and tgt are identical, but opt-alive hould not validate anything
+; src and tgt are identical, but opt-alive should not validate anything
 ; CHECK-NOT: Transformation

--- a/tests/opt-tv/npm-globalopt.opt.ll
+++ b/tests/opt-tv/npm-globalopt.opt.ll
@@ -1,0 +1,10 @@
+; TEST-ARGS: -passes=globalopt
+
+@x = constant i32 0
+define i32 @f() {
+  %v = load i32, i32* @x
+  ret i32 %v
+}
+
+; src and tgt are identical, but opt-alive hould not validate anything
+; CHECK-NOT: Transformation

--- a/tests/opt-tv/npm-globalopt.opt.ll
+++ b/tests/opt-tv/npm-globalopt.opt.ll
@@ -1,10 +1,8 @@
 ; TEST-ARGS: -passes=globalopt
 
-@x = constant i32 0
 define i32 @f() {
-  %v = load i32, i32* @x
-  ret i32 %v
+  ret i32 1
 }
 
-; src and tgt are identical, but opt-alive hould not validate anything
+; src and tgt are identical, but opt-alive should not validate anything
 ; CHECK-NOT: Transformation

--- a/tests/opt-tv/npm-lu.opt.ll
+++ b/tests/opt-tv/npm-lu.opt.ll
@@ -1,0 +1,24 @@
+; TEST-ARGS: -passes='loop(unswitch<nontrivial>)' -tv-src-unroll=2 -tv-tgt-unroll=2
+
+define i32 @test(i1 %cond) {
+entry:
+  br label %loop
+loop:
+  %i = phi i32 [0, %entry], [%i.next, %loop.end]
+  br i1 %cond, label %bb1, label %bb2
+bb1:
+  call void @f()
+  br label %loop.end
+bb2:
+  call void @g()
+  br label %loop.end
+loop.end:
+  %i.next = add i32 %i, 1
+  %cmp = icmp eq i32 %i.next, 2
+  br i1 %cmp, label %exit, label %loop
+exit:
+  ret i32 0
+}
+
+declare void @f()
+declare void @g()

--- a/tests/opt-tv/npm-lu2.opt.ll
+++ b/tests/opt-tv/npm-lu2.opt.ll
@@ -1,0 +1,24 @@
+; TEST-ARGS: -passes='unswitch<nontrivial>' -tv-src-unroll=2 -tv-tgt-unroll=2
+
+define i32 @test(i1 %cond) {
+entry:
+  br label %loop
+loop:
+  %i = phi i32 [0, %entry], [%i.next, %loop.end]
+  br i1 %cond, label %bb1, label %bb2
+bb1:
+  call void @f()
+  br label %loop.end
+bb2:
+  call void @g()
+  br label %loop.end
+loop.end:
+  %i.next = add i32 %i, 1
+  %cmp = icmp eq i32 %i.next, 2
+  br i1 %cmp, label %exit, label %loop
+exit:
+  ret i32 0
+}
+
+declare void @f()
+declare void @g()

--- a/tests/opt-tv/npm-verify.opt.ll
+++ b/tests/opt-tv/npm-verify.opt.ll
@@ -1,0 +1,15 @@
+; TEST-ARGS: -passes=verify,sroa,verify
+
+define i32 @f(i1 %cond) {
+  %p = alloca i32
+  br i1 %cond, label %A, label %B
+A:
+  store i32 1, i32* %p
+  br label %EXIT
+B:
+  store i32 2, i32* %p
+  br label %EXIT
+EXIT:
+  %v = load i32, i32* %p
+  ret i32 %v
+}

--- a/tests/opt-tv/npm.opt.ll
+++ b/tests/opt-tv/npm.opt.ll
@@ -1,0 +1,15 @@
+; TEST-ARGS: -passes=sroa,instsimplify
+
+define i32 @f(i1 %cond) {
+  %p = alloca i32
+  br i1 %cond, label %A, label %B
+A:
+  store i32 1, i32* %p
+  br label %EXIT
+B:
+  store i32 2, i32* %p
+  br label %EXIT
+EXIT:
+  %v = load i32, i32* %p
+  ret i32 %v
+}

--- a/tests/opt-tv/npm2.opt.ll
+++ b/tests/opt-tv/npm2.opt.ll
@@ -1,0 +1,15 @@
+; TEST-ARGS: -passes="sroa,simplifycfg"
+
+define i32 @f(i1 %cond) {
+  %p = alloca i32
+  br i1 %cond, label %A, label %B
+A:
+  store i32 1, i32* %p
+  br label %EXIT
+B:
+  store i32 2, i32* %p
+  br label %EXIT
+EXIT:
+  %v = load i32, i32* %p
+  ret i32 %v
+}

--- a/tests/opt-tv/npm3.opt.ll
+++ b/tests/opt-tv/npm3.opt.ll
@@ -1,0 +1,15 @@
+; TEST-ARGS: -passes='sroa,simplifycfg'
+
+define i32 @f(i1 %cond) {
+  %p = alloca i32
+  br i1 %cond, label %A, label %B
+A:
+  store i32 1, i32* %p
+  br label %EXIT
+B:
+  store i32 2, i32* %p
+  br label %EXIT
+EXIT:
+  %v = load i32, i32* %p
+  ret i32 %v
+}

--- a/tv/CMakeLists.txt
+++ b/tv/CMakeLists.txt
@@ -7,9 +7,6 @@ endif()
 
 if (CLANG_PLUGIN)
   message(STATUS "Clang plugin support enabled")
-  set_target_properties(tv PROPERTIES
-      COMPILE_FLAGS "-DCLANG_PLUGIN"
-  )
   configure_file(
     ${CMAKE_SOURCE_DIR}/scripts/alivecc.in
     ${CMAKE_BINARY_DIR}/alivecc

--- a/tv/CMakeLists.txt
+++ b/tv/CMakeLists.txt
@@ -5,26 +5,21 @@ else()
   add_llvm_library(tv MODULE tv.cpp)
 endif()
 
-if (CLANG_PLUGIN)
-  message(STATUS "Clang plugin support enabled")
-  configure_file(
-    ${CMAKE_SOURCE_DIR}/scripts/alivecc.in
-    ${CMAKE_BINARY_DIR}/alivecc
-    @ONLY
-  )
-  configure_file(
-    ${CMAKE_SOURCE_DIR}/scripts/alivecc.in
-    ${CMAKE_BINARY_DIR}/alive++
-    @ONLY
-  )
-  configure_file(
-    ${CMAKE_SOURCE_DIR}/scripts/benchmark_clang_tv.in
-    ${CMAKE_BINARY_DIR}/benchmark_clang_tv
-    @ONLY
-  )
-else()
-  message(STATUS "Skipping Clang plugin")
-endif()
+configure_file(
+  ${CMAKE_SOURCE_DIR}/scripts/alivecc.in
+  ${CMAKE_BINARY_DIR}/alivecc
+  @ONLY
+)
+configure_file(
+  ${CMAKE_SOURCE_DIR}/scripts/alivecc.in
+  ${CMAKE_BINARY_DIR}/alive++
+  @ONLY
+)
+configure_file(
+  ${CMAKE_SOURCE_DIR}/scripts/benchmark_clang_tv.in
+  ${CMAKE_BINARY_DIR}/benchmark_clang_tv
+  @ONLY
+)
 
 target_link_libraries(tv PRIVATE ${ALIVE_LIBS_LLVM} ${Z3_LIBRARIES}
   $<$<AND:$<CXX_COMPILER_ID:GNU>,$<VERSION_LESS:$<CXX_COMPILER_VERSION>,9.0>>:stdc++fs>)

--- a/tv/tv.cpp
+++ b/tv/tv.cpp
@@ -204,7 +204,11 @@ unsigned initialized = 0;
 bool showed_stats = false;
 bool report_dir_created = false;
 bool has_failure = false;
+// If is_clangtv is true, tv should exit with zero
 bool is_clangtv = false;
+// If it is from new pass manager, tv-io-nobuiltin should be ignored & TLI
+// should be created from outside
+bool is_from_npm = false;
 fs::path opt_report_parallel_dir;
 unique_ptr<parallel> parallelMgr;
 stringstream parent_ss;
@@ -232,7 +236,8 @@ string get_random_str() {
 struct TVPass final : public llvm::FunctionPass {
   static char ID;
   bool skip_verify = false;
-  bool encode_io_fns_as_unknown = false;
+  // Use TLI_override if it is set
+  llvm::TargetLibraryInfo *TLI_override = nullptr;
 
   TVPass() : FunctionPass(ID) {}
 
@@ -249,15 +254,12 @@ struct TVPass final : public llvm::FunctionPass {
     });
 
     llvm::TargetLibraryInfo *TLI = nullptr;
-    llvm::TargetLibraryInfoImpl TLIImpl;
-    unique_ptr<llvm::TargetLibraryInfo> TLI_holder;
-    if (is_clangtv) {
-      // When used as a clang plugin, this is run as a plain function rather
-      // than a registered pass, so getAnalysis() cannot be used.
-      TLIImpl = llvm::TargetLibraryInfoImpl(
-          llvm::Triple(F.getParent()->getTargetTriple()));
-      TLI_holder = make_unique<llvm::TargetLibraryInfo>(TLIImpl, &F);
-      TLI = TLI_holder.get();
+    if (is_from_npm) {
+      // When used as a clang plugin or from the new pass manager, this is run
+      // as a plain function rather than a registered pass, so getAnalysis()
+      // cannot be used.
+      assert(TLI_override);
+      TLI = TLI_override;
     } else {
       TLI = &getAnalysis<llvm::TargetLibraryInfoWrapperPass>().getTLI(F);
     }
@@ -523,9 +525,9 @@ llvm::RegisterPass<TVPass> X("tv", "Translation Validator", false, false);
 
 
 
-#ifdef CLANG_PLUGIN
-/// Classes and functions for running translation validation on clang
-/// Uses new pass manager's callback.
+/// Classes and functions for running translation validation on clang or
+/// opt with new pass manager
+/// Clang plugin uses new pass manager's callback.
 
 struct TVInitPass : public llvm::PassInfoMixin<TVInitPass> {
   llvm::PreservedAnalyses run(llvm::Module &M,
@@ -537,12 +539,16 @@ struct TVInitPass : public llvm::PassInfoMixin<TVInitPass> {
 
 struct TVFinalizePass : public llvm::PassInfoMixin<TVFinalizePass> {
   static bool finalized;
-  llvm::PreservedAnalyses run(llvm::Function &F,
-                              llvm::FunctionAnalysisManager &FAM) {
+  static void finalize(llvm::Module &M) {
     if (!finalized) {
       finalized = true;
-      TVPass().doFinalization(*F.getParent());
+      TVPass().doFinalization(M);
     }
+  }
+
+  llvm::PreservedAnalyses run(llvm::Module &M,
+                              llvm::ModuleAnalysisManager &MAM) {
+    finalize(M);
     return llvm::PreservedAnalyses::all();
   }
 };
@@ -568,10 +574,15 @@ const llvm::Module * unwrapModule(llvm::Any IR) {
   llvm_unreachable("Unknown IR unit");
 }
 
+
 const char* skip_pass_list[] = {
   "{anonymous}::TVInitPass",
-  "ModuleToFunctionPassAdaptor<{anonymous}::TVFinalizePass>",
+  "{anonymous}::TVFinalizePass",
+  "AlwaysInlinerPass",
   "ArgumentPromotionPass",
+  "AttributorCGSCCPass",
+  "AttributorPass",
+  "BlockExtractorPass",
   "DeadArgumentEliminationPass",
   "EliminateAvailableExternallyPass",
   "EntryExitInstrumenterPass",
@@ -580,9 +591,12 @@ const char* skip_pass_list[] = {
   "InferFunctionAttrsPass", // IPO
   "InlinerPass",
   "IPSCCPPass",
+  "MetaRenamerPass",
   "ModuleInlinerWrapperPass",
   "OpenMPOptPass",
+  "PartialInlinerPass",
   "PostOrderFunctionAttrsPass", // IPO
+  "SampleProfileLoaderPass" // IPO
 };
 
 bool do_skip(const llvm::StringRef &pass0) {
@@ -591,6 +605,74 @@ bool do_skip(const llvm::StringRef &pass0) {
                 [&](auto skip) { return pass == skip; });
 }
 
+struct TVNewPass : public llvm::PassInfoMixin<TVNewPass> {
+  static bool skip_tv;
+  static string pass_name;
+  // The number of TVNewPass created.
+  static unsigned num_tv_pass_created;
+  bool print_pass_name = false;
+
+
+  llvm::PreservedAnalyses run(llvm::Module &M,
+                              llvm::ModuleAnalysisManager &AM) {
+    auto &FAM = AM.getResult<llvm::FunctionAnalysisManagerModuleProxy>(M)
+                  .getManager();
+    auto get_TLI = [&FAM](llvm::Function &F) {
+      return &FAM.getResult<llvm::TargetLibraryAnalysis>(F);
+    };
+    run(M, get_TLI);
+    return llvm::PreservedAnalyses::all();
+  }
+
+  void run(llvm::Module &M,
+           function<llvm::TargetLibraryInfo*(llvm::Function&)> get_TLI) {
+    // Check TVFinalizePass::finalized again because TVNewPass can be
+    // called after TVFinalizePass registered by
+    // registerOptimizerLastEPCallback.
+    // It can happen when a default pipeline (O3, O2, ...) is used.
+    if (TVFinalizePass::finalized)
+      return;
+
+    static int count = 0;
+    if (!out) {
+      // TVInitPass is not called yet.
+      // This can happen at very early passes, such as
+      // ForceFunctionAttrsPass.
+      skip_tv = false;
+      return;
+    }
+
+    count++;
+    if (print_pass_name) {
+      // print_pass_name is set only when running clang tv
+      *out << "-- " << count << ". " << pass_name
+           << (skip_tv ? " : Skipping\n" : "\n");
+    }
+
+    TVPass tv;
+    tv.skip_verify = skip_tv;
+
+    for (auto &F: M) {
+      tv.TLI_override = get_TLI(F);
+
+      // If skip_pass is true, this updates fns map only.
+      tv.runOnFunction(F);
+    }
+
+    skip_tv = false;
+    if (count == num_tv_pass_created) {
+      // If it is clang tv, num_tv_pass_created should be zero.
+      assert(!is_clangtv);
+      TVFinalizePass::finalize(M);
+    }
+  }
+};
+
+bool TVNewPass::skip_tv = false;
+string TVNewPass::pass_name;
+unsigned TVNewPass::num_tv_pass_created = 0;
+
+
 // Entry point for this plugin
 extern "C" ::llvm::PassPluginLibraryInfo LLVM_ATTRIBUTE_WEAK
 llvmGetPassPluginInfo() {
@@ -598,49 +680,72 @@ llvmGetPassPluginInfo() {
     LLVM_PLUGIN_API_VERSION, "Alive2 Translation Validation", "",
     [](llvm::PassBuilder &PB) {
       is_clangtv = true;
+      PB.registerPipelineParsingCallback(
+          [](llvm::StringRef Name,
+             llvm::ModulePassManager &MPM,
+             llvm::ArrayRef<llvm::PassBuilder::PipelineElement>) {
+          static bool first_tv = true;
+          if (Name != "tv")
+            return false;
+
+          is_from_npm = true;
+          if (first_tv) {
+            // Assume that this plugin is loaded from opt when tv pass is
+            // explicitly given as an argument
+            is_clangtv = false;
+            first_tv = false;
+            MPM.addPass(TVInitPass());
+            MPM.addPass(TVNewPass());
+          } else {
+            MPM.addPass(TVNewPass());
+            // Finalization is done by the last TVNewPass
+          }
+          TVNewPass::num_tv_pass_created++;
+          return true;
+        });
+      // These two register*EPCallbacks are called when 'default' pipelines
+      // such as O2, O3 are used.
       PB.registerPipelineStartEPCallback(
           [](llvm::ModulePassManager &MPM,
              llvm::PassBuilder::OptimizationLevel) {
+            is_from_npm = true;
             MPM.addPass(TVInitPass());
           });
       PB.registerOptimizerLastEPCallback(
           [](llvm::ModulePassManager &MPM,
              llvm::PassBuilder::OptimizationLevel) {
-            MPM.addPass(createModuleToFunctionPassAdaptor(TVFinalizePass()));
+            MPM.addPass(TVFinalizePass());
           });
       auto f = [](llvm::StringRef P, llvm::Any IR,
                   const llvm::PreservedAnalyses &PA) {
-        static int count = 0;
-        if (!out) {
-          // TVInitPass is not called yet.
-          // This can happen at very early passes, such as
-          // ForceFunctionAttrsPass.
-          return;
-        }
-
         if (TVFinalizePass::finalized)
           return;
 
-        bool skip_pass = do_skip(P);
-        *out << "-- " << ++count << ". " << P.str()
-             << (skip_pass ? " : Skipping\n" : "\n");
+        TVNewPass::pass_name = P.str();
+        TVNewPass::skip_tv |= do_skip(TVNewPass::pass_name);
 
-        TVPass tv;
-        tv.skip_verify = skip_pass;
-        // For I/O known calls like printf, it is fine to regard them as valid
-        // 'unknown calls' except when it is InstCombine.
-        tv.encode_io_fns_as_unknown = P != "InstCombinePass" &&
-                                      P != "AggressiveInstCombinePass";
+        if (!is_clangtv)
+          return;
 
-        auto M = const_cast<llvm::Module *>(unwrapModule(IR));
-        for (auto &F: *M)
-          // If skip_pass is true, this updates fns map only.
-          tv.runOnFunction(F);
+        // If it is clang tv, validate each pass
+        TVNewPass tv;
+        tv.print_pass_name = true;
+
+        llvm::TargetLibraryInfoImpl TLIImpl;
+        unique_ptr<llvm::TargetLibraryInfo> TLI_holder;
+
+        auto get_TLI = [&](llvm::Function &F) {
+          TLIImpl = llvm::TargetLibraryInfoImpl(
+              llvm::Triple(F.getParent()->getTargetTriple()));
+          TLI_holder = make_unique<llvm::TargetLibraryInfo>(TLIImpl, &F);
+          return TLI_holder.get();
+        };
+
+        tv.run(*const_cast<llvm::Module *>(unwrapModule(IR)), get_TLI);
       };
       PB.getPassInstrumentationCallbacks()->registerAfterPassCallback(move(f));
     }
   };
 }
-#endif
 
 }

--- a/tv/tv.cpp
+++ b/tv/tv.cpp
@@ -206,8 +206,8 @@ bool report_dir_created = false;
 bool has_failure = false;
 // If is_clangtv is true, tv should exit with zero
 bool is_clangtv = false;
-// If it is from new pass manager, tv-io-nobuiltin should be ignored & TLI
-// should be created from outside
+// If the new pass manager is used, TLI should be created from either NPM's
+// analyzer or a direct call to TLI's constructor
 bool is_from_npm = false;
 fs::path opt_report_parallel_dir;
 unique_ptr<parallel> parallelMgr;

--- a/tv/tv.cpp
+++ b/tv/tv.cpp
@@ -683,11 +683,9 @@ llvmGetPassPluginInfo() {
             is_clangtv = false;
             first_tv = false;
             MPM.addPass(TVInitPass());
-            MPM.addPass(TVNewPass());
-          } else {
-            MPM.addPass(TVNewPass());
-            // Finalization is done by the last TVNewPass
           }
+          MPM.addPass(TVNewPass());
+          // Finalization is done by the last TVNewPass
           TVNewPass::num_tv_pass_created++;
           return true;
         });

--- a/tv/tv.cpp
+++ b/tv/tv.cpp
@@ -690,7 +690,11 @@ llvmGetPassPluginInfo() {
           return true;
         });
       // These two register*EPCallbacks are called when 'default' pipelines
-      // such as O2, O3 are used.
+      // such as O2, O3 are used by either opt or clang.
+      // For clang -O2, these are needed. For opt, these are currently redundant
+      // because we don't support e.g. opt -passes="tv,default<O2>,tv".
+      // But there is no way to distinguish which one (clang vs. opt) is invoked
+      // so simply always add these.
       PB.registerPipelineStartEPCallback(
           [](llvm::ModulePassManager &MPM,
              llvm::PassBuilder::OptimizationLevel) {

--- a/tv/tv.cpp
+++ b/tv/tv.cpp
@@ -578,11 +578,7 @@ const llvm::Module * unwrapModule(llvm::Any IR) {
 const char* skip_pass_list[] = {
   "{anonymous}::TVInitPass",
   "{anonymous}::TVFinalizePass",
-  "AlwaysInlinerPass",
   "ArgumentPromotionPass",
-  "AttributorCGSCCPass",
-  "AttributorPass",
-  "BlockExtractorPass",
   "DeadArgumentEliminationPass",
   "EliminateAvailableExternallyPass",
   "EntryExitInstrumenterPass",
@@ -591,12 +587,9 @@ const char* skip_pass_list[] = {
   "InferFunctionAttrsPass", // IPO
   "InlinerPass",
   "IPSCCPPass",
-  "MetaRenamerPass",
   "ModuleInlinerWrapperPass",
   "OpenMPOptPass",
-  "PartialInlinerPass",
   "PostOrderFunctionAttrsPass", // IPO
-  "SampleProfileLoaderPass" // IPO
 };
 
 bool do_skip(const llvm::StringRef &pass0) {

--- a/tv/tv.cpp
+++ b/tv/tv.cpp
@@ -622,7 +622,7 @@ struct TVNewPass : public llvm::PassInfoMixin<TVNewPass> {
     if (TVFinalizePass::finalized)
       return;
 
-    static int count = 0;
+    static unsigned count = 0;
     if (!out) {
       // TVInitPass is not called yet.
       // This can happen at very early passes, such as
@@ -631,7 +631,7 @@ struct TVNewPass : public llvm::PassInfoMixin<TVNewPass> {
       return;
     }
 
-    count++;
+    ++count;
     if (print_pass_name) {
       // print_pass_name is set only when running clang tv
       *out << "-- " << count << ". " << pass_name


### PR DESCRIPTION
This PR resolves #330 .

LLVM unit test results (I ran tests that contain `-passes=` only)
New failures:
```
Transforms/InstCombine/infinite-loop-postdom.ll (tv interacts with ‘print’ pass)
Transforms/LoopRotate/pr35210.ll (it checks the list of optimization passes)
Transforms/MergeICmps/X86/pair-int32-int32.ll (related to memcmp’s semantics)
Transforms/SimpleLoopUnswitch/nontrivial-unswitch.ll (loop switch)
Transforms/SimpleLoopUnswitch/trivial-unswitch.ll (and -> conditional branch)
```
Unknown assertion failure:
```
Transforms/Attributor/align.ll 
# I think this is a bug in llvm2alive.cpp… I’ll look into this
```
(failures from the tests that use legacy pass managers are excluded)