### PR TITLE
this is a rewrite of alivecc in perl

### DIFF
--- a/scripts/alivecc.in
+++ b/scripts/alivecc.in
@@ -1,25 +1,88 @@
-#!/bin/bash
+#!/usr/bin/env perl
 
-set -e
+use warnings;
+use strict;
+use autodie;
+use File::Basename;
 
-COMPILER=`basename "$0"`
+sub compiling() {
+    foreach my $arg (@ARGV) {
+        return 1
+            if ($arg =~ /\.c$|\.cpp$|\.CC$|\.c\+\+$|\.cc$|\.cxx$|\.C$|\.c\+$/);
+    }
+    return 0;
+}
 
-if [ $COMPILER = "alivecc" ]; then
-  EXE=clang
-elif [ $COMPILER = "alive++" ]; then
-  EXE=clang++
-else
-  echo "Unexpected invocation as $COMPILER";
-  exit -1
-fi
+my %whitelist;
+sub getenv($) {
+    (my $e) = @_;
+    die "oops buggy alivecc '$e'" unless $e =~ /^ALIVECC_/;
+    $whitelist{$e} = 1;
+    return undef unless exists($ENV{$e});
+    return $ENV{$e};
+}
 
-if [[ "$OSTYPE" == "darwin"* ]]; then
-  # Mac
-  TV_SHAREDLIB=tv.dylib
-else
-  # Linux, Cygwin/Msys, or Win32?
-  TV_SHAREDLIB=tv.so
-fi
-@LLVM_BINARY_DIR@/bin/$EXE \
-  -fpass-plugin=@CMAKE_BINARY_DIR@/tv/$TV_SHAREDLIB -fexperimental-new-pass-manager \
-  -Xclang -load -Xclang @CMAKE_BINARY_DIR@/tv/$TV_SHAREDLIB $*
+if ($0 =~ /alivecc$/) {
+    unshift @ARGV, "@LLVM_BINARY_DIR@/bin/clang";
+} elsif ($0 =~ /alive\+\+$/) {
+    unshift @ARGV, "@LLVM_BINARY_DIR@/bin/clang++";
+} else {
+    die "Unexpected invocation as '$0'";
+}
+
+if (compiling()) {
+
+    if (getenv("ALIVECC_PARALLEL_UNRESTRICTED")) {
+        push @ARGV, ("-mllvm", "-tv-parallel-unrestricted");
+    }
+
+    if (getenv("ALIVECC_DISABLE_UNDEF_INPUT")) {
+        push @ARGV, ("-mllvm", "-tv-disable-undef-input");
+    }
+
+    if (getenv("ALIVECC_DISABLE_POISON_INPUT")) {
+        push @ARGV, ("-mllvm", "-tv-disable-poison-input");
+    }
+
+    if (my $to = getenv("ALIVECC_SMT_TO")) {
+        push @ARGV, ("-mllvm", "-tv-smt-to=".$to);
+    }
+
+    if (my $to = getenv("ALIVECC_SUBPROCESS_TIMEOUT")) {
+        push @ARGV, ("-mllvm", "-tv-subprocess-timeout=".$to);
+    }
+
+    if (getenv("ALIVECC_OVERWRITE_REPORTS")) {
+        push @ARGV, ("-mllvm", "-tv-overwrite-reports");
+    }
+
+    if (my $dir = getenv("ALIVECC_REPORT_DIR")) {
+        push @ARGV, ("-mllvm", "-tv-report-dir=".$dir);
+    }
+
+    # sanity check: make sure we intercepted all environment variables
+    # of the form ALIVECC_*
+    foreach my $e (keys %ENV) {
+        next unless $e =~ /^ALIVECC_/;
+        die "unexpected alivecc environment variable '${e}'"
+            unless $whitelist{$e};
+    }
+    
+    # Alive2 doesn't yet understand TBAA info
+    push @ARGV, "-fno-strict-aliasing";
+
+    my $TV_SHAREDLIB;
+    if ($^O =~ /darwin*/) {
+        # Mac
+        $TV_SHAREDLIB = "tv.dylib";
+    } else {
+        # Linux, Cygwin/Msys, or Win32?
+        $TV_SHAREDLIB = "tv.so";
+    }
+
+    push @ARGV, "-fpass-plugin=@CMAKE_BINARY_DIR@/tv/${TV_SHAREDLIB}";
+    push @ARGV, "-fexperimental-new-pass-manager";
+    push @ARGV, ("-Xclang", "-load", "-Xclang", "@CMAKE_BINARY_DIR@/tv/${TV_SHAREDLIB}");
+}
+
+exec @ARGV;


### PR DESCRIPTION
I promise to maintain this code for the foreseeable future

this adds some functionality
that would be pretty cumbersome in bash. first, try to detect being
invoked as something other than a compiler (linker, assembler, ...)
and then don't load the alive2 plugin, which would cause problems
because it then fails to intercept our command line arguments, causing
some build systems to error out.

second, we now communicate our wishes to alivecc using environment
variables. this simplifies build system interactions since we no
longer have to try to override CFLAGS, which doesn't uniformly work
across packages. additionally, overriding CFLAGS is fragile when clang
gets invoked as a linker/assembler, again causing problems.

I didn't add a very large set of flags, only the ones I'm using commonly right now, but I'm happy to add more on request

this environment approach has worked well in souper: we can use it to build basically any program that can be compiled by LLVM, so I expect it'll work for us here too.