### PR TITLE
support llvm.trap

### DIFF
--- a/llvm_util/llvm2alive.cpp
+++ b/llvm_util/llvm2alive.cpp
@@ -874,7 +874,7 @@ end:
     {
       FnAttrs attrs;
       attrs.set(FnAttrs::NoReturn);
-      attrs.set(FnAttrs::NoRead);
+      attrs.set(FnAttrs::NoWrite);
       return make_unique<FnCall>(*llvm_type2alive(i.getType()),
                                  "", "#trap", move(attrs));
     }

--- a/llvm_util/llvm2alive.cpp
+++ b/llvm_util/llvm2alive.cpp
@@ -870,6 +870,14 @@ end:
         return error(i);
       RETURN_IDENTIFIER(make_unique<Free>(*b, false));
     }
+    case llvm::Intrinsic::trap:
+    {
+      FnAttrs attrs;
+      attrs.set(FnAttrs::NoReturn);
+      attrs.set(FnAttrs::NoRead);
+      return make_unique<FnCall>(*llvm_type2alive(i.getType()),
+                                 "", "#trap", move(attrs));
+    }
 
     // do nothing intrinsics
     case llvm::Intrinsic::dbg_addr:

--- a/tests/alive-tv/trap-and-plainfn-distinct-rev.srctgt.ll
+++ b/tests/alive-tv/trap-and-plainfn-distinct-rev.srctgt.ll
@@ -1,0 +1,15 @@
+define void @src() {
+; trap and any readnone noreturn function should not be considered equivalent
+  call void @plain_fn() noreturn readnone
+  unreachable
+}
+
+define void @tgt() {
+  call void @llvm.trap()
+  unreachable
+}
+
+declare void @plain_fn()
+declare void @llvm.trap()
+
+; ERROR: Source is more defined than target

--- a/tests/alive-tv/trap-and-plainfn-distinct.srctgt.ll
+++ b/tests/alive-tv/trap-and-plainfn-distinct.srctgt.ll
@@ -1,0 +1,15 @@
+define void @src() {
+  call void @llvm.trap()
+  unreachable
+}
+
+define void @tgt() {
+; trap and any readnone noreturn function should not be considered equivalent
+  call void @plain_fn() noreturn readnone
+  unreachable
+}
+
+declare void @plain_fn()
+declare void @llvm.trap()
+
+; ERROR: Source is more defined than target

--- a/tests/alive-tv/trap-and-plainfn-distinct2-rev.srctgt.ll
+++ b/tests/alive-tv/trap-and-plainfn-distinct2-rev.srctgt.ll
@@ -1,0 +1,15 @@
+define void @src() {
+; trap and any readonly noreturn function should not be considered equivalent
+  call void @plain_fn() noreturn readonly
+  unreachable
+}
+
+define void @tgt() {
+  call void @llvm.trap()
+  unreachable
+}
+
+declare void @plain_fn()
+declare void @llvm.trap()
+
+; ERROR: Source is more defined than target

--- a/tests/alive-tv/trap-and-plainfn-distinct2.srctgt.ll
+++ b/tests/alive-tv/trap-and-plainfn-distinct2.srctgt.ll
@@ -1,0 +1,15 @@
+define void @src() {
+  call void @llvm.trap()
+  unreachable
+}
+
+define void @tgt() {
+; trap and any readonly noreturn function should not be considered equivalent
+  call void @plain_fn() noreturn readonly
+  unreachable
+}
+
+declare void @plain_fn()
+declare void @llvm.trap()
+
+; ERROR: Source is more defined than target

--- a/tests/alive-tv/trap-and-plainfn-distinct3-rev.srctgt.ll
+++ b/tests/alive-tv/trap-and-plainfn-distinct3-rev.srctgt.ll
@@ -1,0 +1,16 @@
+define void @src() {
+; trap and any function should not be considered equivalent
+  call void @plain_fn()
+; NOTE: due to issue #375, using unreachable here will unexpectedly make this test pass, because since plain_fn always returns.
+  ret void
+}
+
+define void @tgt() {
+  call void @llvm.trap()
+  ret void
+}
+
+declare void @plain_fn()
+declare void @llvm.trap()
+
+; ERROR: Source is more defined than target

--- a/tests/alive-tv/trap-and-plainfn-distinct3-rev.srctgt.ll
+++ b/tests/alive-tv/trap-and-plainfn-distinct3-rev.srctgt.ll
@@ -1,13 +1,13 @@
 define void @src() {
 ; trap and any function should not be considered equivalent
   call void @plain_fn()
-; NOTE: due to issue #375, using unreachable here will unexpectedly make this test pass, because since plain_fn always returns.
+; NOTE: due to issue #375, using unreachable here will unexpectedly make this test pass, because plain_fn always returns.
   ret void
 }
 
 define void @tgt() {
   call void @llvm.trap()
-  ret void
+  unreachable
 }
 
 declare void @plain_fn()

--- a/tests/alive-tv/trap-and-plainfn-distinct3.srctgt.ll
+++ b/tests/alive-tv/trap-and-plainfn-distinct3.srctgt.ll
@@ -1,0 +1,15 @@
+define void @src() {
+  call void @llvm.trap()
+  unreachable
+}
+
+define void @tgt() {
+; trap and any function should not be considered equivalent
+  call void @plain_fn()
+  unreachable
+}
+
+declare void @plain_fn()
+declare void @llvm.trap()
+
+; ERROR: Source is more defined than target

--- a/tests/alive-tv/trap.srctgt.ll
+++ b/tests/alive-tv/trap.srctgt.ll
@@ -1,0 +1,12 @@
+define void @src(i8* %dummyptr) {
+  call void @llvm.trap()
+  store i8 0, i8* %dummyptr
+  ret void
+}
+
+define void @tgt(i8* %dummyptr) {
+  call void @llvm.trap()
+  unreachable
+}
+
+declare void @llvm.trap()

--- a/tests/alive-tv/trap2.srctgt.ll
+++ b/tests/alive-tv/trap2.srctgt.ll
@@ -1,0 +1,11 @@
+define void @src() {
+  store i8 0, i8* null
+  ret void
+}
+
+define void @tgt() {
+  call void @llvm.trap()
+  unreachable
+}
+
+declare void @llvm.trap()

--- a/tests/alive-tv/trap3.srctgt.ll
+++ b/tests/alive-tv/trap3.srctgt.ll
@@ -1,0 +1,15 @@
+define void @src(i8* %ptr) {
+  store i8 0, i8* %ptr
+  call void @llvm.trap()
+  unreachable
+}
+
+define void @tgt(i8* %ptr) {
+  store i8 1, i8* %ptr
+  call void @llvm.trap()
+  unreachable
+}
+
+declare void @llvm.trap()
+
+; ERROR: Source is more defined than target

--- a/tests/alive-tv/trap4.srctgt.ll
+++ b/tests/alive-tv/trap4.srctgt.ll
@@ -1,0 +1,13 @@
+define void @src(i8* %ptr) {
+  call void @llvm.trap()
+  unreachable
+}
+
+define void @tgt(i8* %ptr) {
+  unreachable
+}
+
+
+declare void @llvm.trap()
+
+; ERROR: Source is more defined than target


### PR DESCRIPTION
This PR uses a function call to encode llvm.trap.

The benefit of encoding it as a function call is that it is easy to check refinement of llvm.trap and other no-return function calls.
I found that it becomes a bit non-trivial for me to do without function call encoding (for example, simply making it do `state.addNoReturn()` will allow the refinement).
We already have a nice framework that works really well for encoding the equivalence of function calls using UB.

A limitation of this encoding is that we can't impose `call llvm.trap()` to never have UB.
It can introduce false positive in theory (because llvm.trap has more behavior than people's thought), but.. I couldn't come up with an example that has false positive.

