### PR TITLE
more work in benchmarking scripts

### DIFF
--- a/scripts/benchmark-clang-tv.in
+++ b/scripts/benchmark-clang-tv.in
@@ -15,15 +15,20 @@ EOM
 fi
 
 WORK=$1
+REPORTS=$WORK/reports
 
 # TODO give alivecc a mode where it doesn't invoke alive at all, so we
 # can test scripts like this more quickly and easily
 
-FLAGS='-mllvm -tv-parallel-unrestricted -mllvm -tv-disable-undef-input -mllvm -tv-smt-to=30000 -mllvm -tv-subprocess-timeout=600 -mllvm -tv-overwrite-reports'
-
 CORES=`nproc`
 
 ALIVECC=@CMAKE_BINARY_DIR@/alivecc
+
+export ALIVECC_OVERWRITE_REPORTS=1
+export ALIVECC_SUBPROCESS_TIMEOUT=600
+export ALIVECC_SMT_TO=30000
+export ALIVECC_DISABLE_UNDEF_INPUT=1
+export ALIVECC_PARALLEL_UNRESTRICTED=1
 
 mkdir $WORK || true
 cd $WORK
@@ -32,16 +37,18 @@ mkdir sources
 
 function check_bzip {
     # 16 minutes on John's 10-core machine
+    export ALIVECC_REPORT_DIR=$REPORTS/bzip
     cd $WORK/downloads
     wget -nc https://sourceware.org/pub/bzip2/bzip2-1.0.8.tar.gz
     cd ../sources
     tar xvf ../downloads/bzip2-1.0.8.tar.gz
     cd bzip2-1.0.8
-    time make -j$CORES CC="$ALIVECC $FLAGS -mllvm -tv-report-dir=$WORK/reports/bzip2" &> make.out
+    time make -j$CORES CC=$ALIVECC &> make.out
 }
 
 function check_gzip {
     # 16 minutes on John's 10-core machine
+    export ALIVECC_REPORT_DIR=$REPORTS/gzip
     cd $WORK/downloads
     wget -nc https://ftp.gnu.org/gnu/gzip/gzip-1.10.tar.xz
     cd ../sources
@@ -50,11 +57,12 @@ function check_gzip {
     mkdir build
     cd build
     ../configure
-    time make -j$CORES CC="$ALIVECC $FLAGS -mllvm -tv-report-dir=$WORK/reports/gzip" &> make.out
+    time make -j$CORES CC=$ALIVECC &> make.out
 }
 
 function check_libogg {
     # 33 minutes on John's 10-core machine
+    export ALIVECC_REPORT_DIR=$REPORTS/libogg
     cd $WORK/downloads
     wget -nc https://downloads.xiph.org/releases/ogg/libogg-1.3.4.tar.xz
     cd ../sources
@@ -63,32 +71,60 @@ function check_libogg {
     mkdir build
     cd build
     ../configure
-    time make -j$CORES CC="$ALIVECC $FLAGS -mllvm -tv-report-dir=$WORK/reports/libogg" &> make.out
+    time make -j$CORES CC=$ALIVECC &> make.out
 }
 
 function check_ph7 {
-    # 68 minutes on John's 10-core machine
+    # doesn't finish within 12 hours on John's machine -- we need to parallelize better!
+    export ALIVECC_REPORT_DIR=$REPORTS/ph7
     cd $WORK/downloads
     wget -nc http://www.symisc.net/downloads/ph7-amalgamation-2001004.zip
     cd ../sources
     mkdir ph7
     cd ph7
     unzip ../../downloads/ph7-amalgamation-2001004.zip
-    time $ALIVECC -O3 $FLAGS -mllvm -tv-report-dir=$WORK/reports/ph7 -c ph7.c &> make.out
+    time $ALIVECC -O3 -c ph7.c &> make.out
 }
 
 function check_sqlite {
     # doesn't finish within 24 hours on John's machine -- we need to parallelize better!
+    export ALIVECC_REPORT_DIR=$REPORTS/sqlite
     cd $WORK/downloads
     wget -nc https://www.sqlite.org/2020/sqlite-amalgamation-3340000.zip
     cd ../sources
     unzip ../downloads/sqlite-amalgamation-3340000.zip
     cd sqlite-amalgamation-3340000
-    time $ALIVECC -O3 $FLAGS -mllvm -tv-report-dir=$WORK/reports/sqlite -c sqlite3.c &> make.out
+    time $ALIVECC -O3 -c sqlite3.c &> make.out
+}
+
+function check_embench {
+    # 27.5 minutes on John's machine
+    export ALIVECC_REPORT_DIR=$REPORTS/embench
+    cd $WORK/sources
+    # FIXME -- grab a release, once they make one
+    git clone https://github.com/embench/embench-iot
+    cd embench-iot
+    time ./build_all.py --clean --arch native --chip default --board default --cc alivecc --timeout 999999 &> make.out
+}
+
+function check_musl {
+    # 57 minutes on John's machine
+    export ALIVECC_REPORT_DIR=$REPORTS/musl
+    cd $WORK/downloads
+    wget -nc https://musl.libc.org/releases/musl-1.2.1.tar.gz
+    cd ../sources
+    tar xvf ../downloads/musl-1.2.1.tar.gz
+    cd musl-1.2.1
+    mkdir build
+    cd build
+    ../configure CC=alivecc
+    time make -j$CORES &> make.out
 }
 
 check_bzip
 check_gzip
 check_libogg
-check_ph7
-check_sqlite
+#check_ph7
+#check_sqlite
+check_embench
+check_musl

--- a/scripts/benchmark-llvm-test-suite.in
+++ b/scripts/benchmark-llvm-test-suite.in
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o xtrace # can remove this later, for now it's nice to see commands
+
+if [ "$#" -ne 1 ]; then
+    cat << EOM
+Expected one command line argument: the name of an initially-empty working
+directory for sources, binaries, and reports.
+EOM
+    exit -1
+fi
+
+WORK=$1
+
+ALIVECC=@CMAKE_BINARY_DIR@/alivecc
+ALIVEPP=@CMAKE_BINARY_DIR@/alive++
+
+export ALIVECC_OVERWRITE_REPORTS=1
+export ALIVECC_SUBPROCESS_TIMEOUT=600
+export ALIVECC_SMT_TO=30000
+export ALIVECC_DISABLE_UNDEF_INPUT=1
+export ALIVECC_PARALLEL_UNRESTRICTED=1
+export ALIVECC_REPORT_DIR=$WORK/report
+
+cd $WORK
+git clone https://github.com/llvm/llvm-test-suite.git test-suite
+
+mkdir test-suite-build
+cd test-suite-build
+cmake -DCMAKE_C_COMPILER=$ALIVECC -DCMAKE_CXX_COMPILER=$ALIVEPP -C../test-suite/cmake/caches/O3.cmake ../test-suite -DTEST_SUITE_SUBDIRS=SingleSource
+
+# 8 GB
+ulimit -m 8388608 -v 8388608
+
+# intentionally limit make-level parallelism to < number of cores
+time make -j16

--- a/tv/CMakeLists.txt
+++ b/tv/CMakeLists.txt
@@ -16,8 +16,13 @@ configure_file(
   @ONLY
 )
 configure_file(
-  ${CMAKE_SOURCE_DIR}/scripts/benchmark_clang_tv.in
-  ${CMAKE_BINARY_DIR}/benchmark_clang_tv
+  ${CMAKE_SOURCE_DIR}/scripts/benchmark-clang-tv.in
+  ${CMAKE_BINARY_DIR}/benchmark-clang-tv
+  @ONLY
+)
+configure_file(
+  ${CMAKE_SOURCE_DIR}/scripts/benchmark-llvm-test-suite.in
+  ${CMAKE_BINARY_DIR}/benchmark-llvm-test-suite
   @ONLY
 )
 


### PR DESCRIPTION
add embench and musl -- they're interesting codes that take about the right amount of time

comment out ph7 and sqlite3 until we make things faster/more parallel

switch over to communicating with alivecc using environment variables
instead of command line options

add a second benchmarking script that tries to do TV for the
SingleSource part of the LLVM test-suite. this doesn't work yet and
will require a lot of CPU time once it does work (this dir is like
300,000 lines of code) but I think it's the rigth direction for us.