### PR TITLE
run only the MicroBenchmarks and SingleSource dirs

### DIFF
--- a/scripts/benchmark-llvm-test-suite.in
+++ b/scripts/benchmark-llvm-test-suite.in
@@ -15,7 +15,7 @@ fi
 WORK=$1
 
 ALIVECC=@CMAKE_BINARY_DIR@/alivecc
-ALIVEPP=@CMAKE_BINARY_DIR@/alive++
+ALIVEPP=@LLVM_BINARY_DIR@/bin/clang++
 
 export ALIVECC_OVERWRITE_REPORTS=1
 export ALIVECC_SUBPROCESS_TIMEOUT=600
@@ -29,10 +29,12 @@ git clone https://github.com/llvm/llvm-test-suite.git test-suite
 
 mkdir test-suite-build
 cd test-suite-build
-cmake -DCMAKE_C_COMPILER=$ALIVECC -DCMAKE_CXX_COMPILER=$ALIVEPP -C../test-suite/cmake/caches/O3.cmake ../test-suite -DTEST_SUITE_SUBDIRS=SingleSource
+cmake -DCMAKE_C_COMPILER=$ALIVECC -DCMAKE_CXX_COMPILER=$ALIVEPP -C../test-suite/cmake/caches/O3.cmake ../test-suite -DTEST_SUITE_SUBDIRS="MicroBenchmarks;SingleSource"
 
-# 8 GB
-ulimit -m 8388608 -v 8388608
+# 7 GB
+ulimit -m 7000000 -v 7000000
 
 # intentionally limit make-level parallelism to < number of cores
 time make -j16
+
+echo Normal termination.


### PR DESCRIPTION
only compile C code with alive2, for C++ just use clang++

this configuration takes about 15 minutes on my group's big 128-thread machine