### PR TITLE
support gettimeofday, access

### DIFF
--- a/llvm_util/known_fns.cpp
+++ b/llvm_util/known_fns.cpp
@@ -72,6 +72,14 @@ known_call(llvm::CallInst &i, const llvm::TargetLibraryInfo &TLI,
     RETURN_UNKNOWN();
 
   switch (libfn) {
+  case llvm::LibFunc_access:
+    ret_and_args_no_undef();
+    attrs.set(FnAttrs::NoThrow);
+    attrs.set(FnAttrs::NoFree);
+    set_param(0, ParamAttrs::NoCapture);
+    set_param(0, ParamAttrs::ReadOnly);
+    RETURN_KNOWN_ATTRS();
+
   case llvm::LibFunc_memset: // void* memset(void *ptr, int val, size_t bytes)
     BB.addInstr(make_unique<Memset>(*args[0], *args[1], *args[2], 1));
     RETURN_KNOWN(make_unique<UnaryOp>(*ty, value_name(i), *args[0],
@@ -190,6 +198,14 @@ known_call(llvm::CallInst &i, const llvm::TargetLibraryInfo &TLI,
     attrs.set(FnAttrs::NoThrow);
     set_param(0, ParamAttrs::NoCapture);
     set_param(3, ParamAttrs::NoCapture);
+    RETURN_KNOWN_ATTRS();
+
+  case llvm::LibFunc_gettimeofday:
+    ret_and_args_no_undef();
+    attrs.set(FnAttrs::NoThrow);
+    attrs.set(FnAttrs::NoFree);
+    set_param(0, ParamAttrs::NoCapture);
+    set_param(1, ParamAttrs::NoCapture);
     RETURN_KNOWN_ATTRS();
 
   case llvm::LibFunc_perror:

--- a/tests/alive-tv/libcalls/access.srctgt.ll
+++ b/tests/alive-tv/libcalls/access.srctgt.ll
@@ -1,0 +1,22 @@
+define i8 @src([12 x i8] %pathstr) {
+  %path = alloca [12 x i8]
+  store [12 x i8] %pathstr, [12 x i8]* %path
+
+  %path.i8 = bitcast [12 x i8]* %path to i8*
+  call i32 @access(i8* %path.i8, i32 0) ; F_OK
+  %v = load i8, i8* %path.i8
+  ret i8 %v
+}
+
+define i8 @tgt([12 x i8] %pathstr) {
+  %path = alloca [12 x i8]
+  store [12 x i8] %pathstr, [12 x i8]* %path
+
+  %path.i8 = bitcast [12 x i8]* %path to i8*
+  %v = load i8, i8* %path.i8
+
+  call i32 @access(i8* %path.i8, i32 0) ; F_OK
+  ret i8 %v
+}
+
+declare i32 @access(i8*, i32)

--- a/tests/alive-tv/libcalls/gettimeofday.srctgt.ll
+++ b/tests/alive-tv/libcalls/gettimeofday.srctgt.ll
@@ -1,0 +1,16 @@
+%struct.timeval = type { i64, i64 }
+%struct.timezone = type { i32, i32 }
+
+declare dso_local i32 @gettimeofday(%struct.timeval*, i8*)
+
+define i32 @src(%struct.timeval* %tv, i8* %tz) {
+  %res = call i32 @gettimeofday(%struct.timeval* %tv, i8* %tz)
+  ret i32 %res
+}
+
+define i32 @tgt(%struct.timeval* %tv, i8* %tz) {
+  %res = call i32 @gettimeofday(%struct.timeval* %tv, i8* %tz)
+  ret i32 %res
+}
+
+; CHECK: nocapture


### PR DESCRIPTION
access: frequently used by sqlite3 (2nd)
```
declare noundef i32 @access(i8* nocapture noundef readonly, i32 noundef) nofree nounwind
```
gettimeofday: frequently used by SingleSource+Microbenchmarks (5th)
```
declare noundef i32 @gettimeofday(%opaque* nocapture noundef, i8* nocapture noundef) nofree nounwind
```

LLVM does not have optimizations that use these.