### PR TITLE
two new parallel managers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,7 +129,9 @@ set(UTIL_SRCS
   util/errors.cpp
   util/file.cpp
   util/parallel.cpp
-  util/parallel_jobserver.cpp
+  util/parallel_fifo.cpp
+  util/parallel_posix.cpp
+  util/parallel_null.cpp
   util/parallel_unrestricted.cpp
   util/sort.cpp
   util/stopwatch.cpp
@@ -213,6 +215,10 @@ add_executable(alive
                "tools/alive_parser.cpp"
               )
 target_link_libraries(alive PRIVATE ${ALIVE_LIBS})
+
+add_executable(alive-jobserver
+               "tools/alive-jobserver.cpp"
+              )
 
 #add_library(alive2 SHARED ${IR_SRCS} ${SMT_SRCS} ${TOOLS_SRCS} ${UTIL_SRCS} ${LLVM_UTIL_SRCS})
 

--- a/README.md
+++ b/README.md
@@ -120,25 +120,50 @@ $ $HOME/alive2/build/alive++ -O3 -c <src.cpp>
 ```
 
 The Clang plugin can optionally use multiple cores. To enable parallel
-translation validation, add the `-mllvm -tv-parallel-jobserver`
-command line options to Clang. In this mode, the Clang plugin uses the
-POSIX jobserver, a mechanism provided by GNU Make to provide global
-control over parallel execution of recursive make invocations. This
-mechanism will only work if GNU Make believes that clang is a
-recursive make command; tell it this by prefixing the `alivecc`
-command with a `+` character in your Makefile. Alas, Ninja does not
-provide a jobserver.
+translation validation, add the `-mllvm -tv-parallel-XXX` command line
+options to Clang, where XXX is one of three parallelism managers
+supported by Alive2. The first one (XXX=posix) uses the POSIX
+jobserver, a mechanism provided by GNU Make to provide global control
+over parallel execution of recursive make invocations. This mechanism
+will only work if GNU Make believes that clang is a recursive make
+command; tell it this by prefixing the `alivecc` command with a `+`
+character in your Makefile. Alas, Ninja does not provide a jobserver.
+The second parallelism manager (XXX=fifo) uses alive-jobserver, a new
+job server provided by Alive2. For details about how to use this
+program, please consult its help output by running it without any
+command line arguments. The third parallelism manager
+(XXX=unrestricted) does not restrict parallelism at all, but rather
+calls fork() freely. This is mainly intended for developer use; it
+tends to use a lot of RAM.
 
-Because parallel TV jobs complete out of order, Alive2's output will
-be garbled if you allow it to go to the terminal. Avoid this problem
-by always using the (`-mllvm -tv-report-dir=dir`) options for runs
-where Alive2 uses multiple cores. This tells Alive2 to place its
-output files into a specific directory.
+Use the `-mllvm -tv-report-dir=dir` to tell Alive2 to place its output
+files into a specific directory.
 
 The Clang plugin's output can be voluminous. To help control this, it
 supports an option to reduce the amount of output (`-mllvm
 -tv-succinct`).
 
+Our goal is for the `alivecc` and `alive++` compiler drivers to be
+drop-in replacements for `clang` and `clang++`. So, for example, they
+try to detect when they are being invoked as assemblers or linkers, in
+which case they do not load the Alive2 plugin. This means that some
+projects cannot be built if you manually specify command line options
+to Alive2, for example using `-DCMAKE_C_FLAGS=...`. Instead, you can
+tell `alivecc` and `alive++` what to do using a collection of
+environment variables that generally mirror the plugin's command line
+interface. For example:
+
+```
+ALIVECC_PARALLEL_UNRESTRICTED=1
+ALIVECC_PARALLEL_FIFO=1
+ALIVECC_PARALLEL_POSIX=1
+ALIVECC_DISABLE_UNDEF_INPUT=1
+ALIVECC_DISABLE_POISON_INPUT=1
+ALIVECC_SMT_TO=timeout in milliseconds
+ALIVECC_SUBPROCESS_TIMEOUT=timeout in seconds
+ALIVECC_OVERWRITE_REPORTS=1
+ALIVECC_REPORT_DIR=dir
+```
 
 Running the Standalone Translation Validation Tool (alive-tv)
 --------

--- a/scripts/alivecc.in
+++ b/scripts/alivecc.in
@@ -36,6 +36,18 @@ if (compiling()) {
         push @ARGV, ("-mllvm", "-tv-parallel-unrestricted");
     }
 
+    if (getenv("ALIVECC_PARALLEL_FIFO")) {
+        push @ARGV, ("-mllvm", "-tv-parallel-fifo");
+    }
+
+    if (getenv("ALIVECC_PARALLEL_POSIX")) {
+        push @ARGV, ("-mllvm", "-tv-parallel-posix");
+    }
+
+    if (getenv("ALIVECC_PARALLEL_NULL")) {
+        push @ARGV, ("-mllvm", "-tv-parallel-null");
+    }
+
     if (getenv("ALIVECC_DISABLE_UNDEF_INPUT")) {
         push @ARGV, ("-mllvm", "-tv-disable-undef-input");
     }

--- a/tools/alive-jobserver.cpp
+++ b/tools/alive-jobserver.cpp
@@ -1,0 +1,156 @@
+// Copyright (c) 2018-present The Alive2 Authors.
+// Distributed under the MIT license that can be found in the LICENSE file.
+
+#include <cassert>
+#include <csignal>
+#include <cstdlib>
+#include <errno.h>
+#include <fcntl.h>
+#include <iostream>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+using namespace std;
+
+// max_procs = min(Linux default fifo buffer size, OS X default fifo buffer size)
+static const int max_procs = 16384;
+
+static char fifo_filename[1024];
+
+static void count_tokens(int fd, int nprocs) {
+  int flags = fcntl(fd, F_GETFL, 0);
+  if (flags == -1) {
+    perror("alive-jobserver: fcntl");
+    exit(-1);
+  }
+  flags |= O_NONBLOCK;
+  int res = fcntl(fd, F_SETFL, flags);
+  if (res != 0) {
+    perror("alive-jobserver: fcntl");
+    exit(-1);
+  }
+  int toks = 0;
+  char c;
+  while (read(fd, &c, 1) != -1)
+    ++toks;
+  assert(errno == EWOULDBLOCK);
+  if (toks != nprocs) {
+    cerr << "alive-jobserver: expected " << nprocs
+         << " jobserver tokens "
+            "but instead it found "
+         << toks << "\n";
+    exit(-1);
+  }
+}
+
+static void remove_fifo() {
+  int res = unlink(fifo_filename);
+  if (res != 0) {
+    perror("unlink");
+    exit(-1);
+  }
+}
+
+static void sigint_handler(int) {
+  remove_fifo();
+  exit(-1);
+}
+
+static void usage() {
+  cerr << "usage: alive-jobserver -jN [command [args]]\n"
+          "where N is in 1.."
+       << max_procs
+       << "\n"
+          "\n"
+          "alive-jobserver supports two modes of operation:\n"
+          "\n"
+          "if a command is specified, the jobserver executes it, passing it\n"
+          "information about the jobserver fifo in an environment variable.\n"
+          "\n"
+          "if no command is specified, the jobserver hangs forever, and you\n"
+          "must manually use the ALIVE_JOBSERVER_FIFO environment variable\n"
+          "to pass this information to the Alive2 LLVM plugin.\n";
+  exit(-1);
+}
+
+int main(int argc, char *const argv[]) {
+  std::signal(SIGINT, sigint_handler);
+
+  if (argc < 2)
+    usage();
+  int nprocs = -1;
+  string_view arg(argv[1]);
+  if (arg.compare(0, 2, "-j") == 0 && arg.size() > 2)
+    nprocs = strtol(arg.substr(2).data(), nullptr, 10);
+  if (nprocs < 1 || nprocs > max_procs)
+    usage();
+
+  srand(getpid() + time(nullptr));
+  do {
+    sprintf(fifo_filename, "/tmp/alive2_fifo_%lx", (unsigned long)rand());
+  } while (access(fifo_filename, F_OK) == 0);
+
+  int res = mkfifo(fifo_filename, 0666);
+  if (res != 0) {
+    perror("alive-jobserver: mkfifo");
+    exit(-1);
+  }
+
+  int pipefd = open(fifo_filename, O_RDWR);
+  if (pipefd < 0) {
+    perror("alive-jobserver: open");
+    exit(-1);
+  }
+
+  for (int i = 0; i < nprocs; ++i) {
+    char c = 0;
+    res = write(pipefd, &c, 1);
+    if (res != 1) {
+      perror("alive-jobserver: write");
+      exit(-1);
+    }
+  }
+
+  if (argc == 2) {
+    cerr << "Alive2 jobserver is running.\n";
+    cerr << "to use it from a different shell:\n";
+    cerr << "\n";
+    cerr << "export ALIVE_JOBSERVER_FIFO=" << fifo_filename << "\n";
+    cerr << "export ALIVECC_PARALLEL_FIFO=1\n";
+    cerr << "\n";
+    cerr << "kill this jobserver using ^C when finished.\n";
+    while (true)
+      sleep(1000000);
+  } else {
+    std::fflush(nullptr);
+    pid_t pid = fork();
+    if (pid == -1) {
+      perror("alive-jobserver: fork");
+      exit(-1);
+    }
+    if (pid == 0) {
+      std::signal(SIGINT, SIG_DFL);
+      res = setenv("ALIVE_JOBSERVER_FIFO", fifo_filename, true);
+      if (res != 0) {
+        perror("setenv");
+        exit(-1);
+      }
+      res = setenv("ALIVECC_PARALLEL_FIFO", "1", true);
+      if (res != 0) {
+        perror("setenv");
+        exit(-1);
+      }
+      execvp(argv[2], &argv[2]);
+      perror("alive-jobserver: exec");
+      exit(-1);
+    }
+    wait(nullptr);
+  }
+
+  count_tokens(pipefd, nprocs);
+  remove_fifo();
+
+  return 0;
+}

--- a/util/parallel.cpp
+++ b/util/parallel.cpp
@@ -65,7 +65,7 @@ std::tuple<pid_t, std::ostream *, int> parallel::limitedFork() {
   /*
    * amortize cost of copying part of the output stringstream to a new
    * one by not doing this all that often
-   */ 
+   */
   if (index % 100 == 0)
     emitOutput();
 

--- a/util/parallel_fifo.cpp
+++ b/util/parallel_fifo.cpp
@@ -1,0 +1,57 @@
+// Copyright (c) 2018-present The Alive2 Authors.
+// Distributed under the MIT license that can be found in the LICENSE file.
+
+#include "util/compiler.h"
+#include "util/parallel.h"
+#include <cassert>
+#include <cstdlib>
+#include <cstring>
+#include <fcntl.h>
+#include <string>
+#include <sys/stat.h>
+#include <unistd.h>
+
+using namespace std;
+
+bool fifo::init() {
+  ENSURE(parallel::init());
+  auto fifo_filename = getenv("ALIVE_JOBSERVER_FIFO");
+  if (!fifo_filename)
+    return false;
+  pipe_fd = open(fifo_filename, O_RDWR);
+  if (pipe_fd < 0)
+    return false;
+  return true;
+}
+
+void fifo::getToken() {
+  ENSURE(read(pipe_fd, &token, 1) == 1);
+}
+
+void fifo::putToken() {
+  ENSURE(write(pipe_fd, &token, 1) == 1);
+}
+
+tuple<pid_t, ostream *, int> fifo::limitedFork() {
+  assert(pipe_fd != -1);
+  auto res = parallel::limitedFork();
+  // child now waits for a jobserver token
+  if (get<0>(res) == 0)
+    getToken();
+  return res;
+}
+
+void fifo::finishChild(bool is_timeout) {
+  parallel::finishChild(is_timeout);
+  putToken();
+}
+
+void fifo::finishParent() {
+  /*
+   * finishParent() basically just blocks -- we'll give up our
+   * parallel execution token until it returns
+   */
+  putToken();
+  parallel::finishParent();
+  getToken();
+}

--- a/util/parallel_null.cpp
+++ b/util/parallel_null.cpp
@@ -1,0 +1,18 @@
+// Copyright (c) 2018-present The Alive2 Authors.
+// Distributed under the MIT license that can be found in the LICENSE file.
+
+#include "util/parallel.h"
+
+bool null::init() {
+  return true;
+}
+
+std::tuple<pid_t, std::ostream *, int> null::limitedFork() {
+  static int nextPid = 0;
+  ++nextPid;
+  return {nextPid, nullptr, nextPid};
+}
+
+void null::finishChild(bool is_timeout) {}
+
+void null::finishParent() {}

--- a/util/parallel_posix.cpp
+++ b/util/parallel_posix.cpp
@@ -13,7 +13,7 @@
 
 using namespace std;
 
-bool jobServer::init() {
+bool posix::init() {
   ENSURE(parallel::init());
   auto env = getenv("MAKEFLAGS");
   if (!env)
@@ -77,7 +77,7 @@ bool jobServer::init() {
   return true;
 }
 
-void jobServer::getToken() {
+void posix::getToken() {
   if (nonblocking) {
     const struct timespec delay = {0, 10 * 1000 * 1000}; // 10 ms
     while (read(read_fd, &token, 1) != 1)
@@ -87,11 +87,11 @@ void jobServer::getToken() {
   }
 }
 
-void jobServer::putToken() {
+void posix::putToken() {
   ENSURE(write(write_fd, &token, 1) == 1);
 }
 
-tuple<pid_t, ostream *, int> jobServer::limitedFork() {
+tuple<pid_t, ostream *, int> posix::limitedFork() {
   assert(read_fd != -1 && write_fd != -1);
   auto res = parallel::limitedFork();
   // child now waits for a jobserver token
@@ -100,12 +100,12 @@ tuple<pid_t, ostream *, int> jobServer::limitedFork() {
   return res;
 }
 
-void jobServer::finishChild(bool is_timeout) {
+void posix::finishChild(bool is_timeout) {
   parallel::finishChild(is_timeout);
   putToken();
 }
 
-void jobServer::finishParent() {
+void posix::finishParent() {
   /*
    * every process forked by GNU make implicitly holds a single
    * jobserver token. here we temporarily return this token into the


### PR DESCRIPTION
first, a trivial one that doesn't actually call fork, it just drops
all TV work onto the floor. the intent is to make it easy to examine
our sequential critical path by ignoring everything else.

second, a new jobserver based on a named pipe. this ends up being
quite a lot easier and simpler than interacting with the GNU make
jobserver which has some gotchas.