### PR TITLE
shufflevector should rewrite undef per element

### DIFF
--- a/ir/instr.cpp
+++ b/ir/instr.cpp
@@ -3333,16 +3333,11 @@ StateValue ShuffleVector::toSMT(State &s) const {
   auto sz = vty->numElementsConst();
   vector<StateValue> vals;
 
-  const StateValue *vect1 = nullptr;
-  const StateValue *vect2 = nullptr;
-
   for (auto m : mask) {
     if (m >= 2 * sz) {
       vals.emplace_back(UndefValue(vty->getChild(0)).toSMT(s).value, true);
     } else {
-      auto &vect = m < sz ? vect1 : vect2;
-      if (!vect)
-        vect = &s[m < sz ? *v1 : *v2];
+      auto *vect = &s[m < sz ? *v1 : *v2];
       vals.emplace_back(vty->extract(*vect, m % sz));
     }
   }

--- a/tests/alive-tv/shufflevec-undef.srctgt.ll
+++ b/tests/alive-tv/shufflevec-undef.srctgt.ll
@@ -1,0 +1,11 @@
+define <2 x i32> @src(i32 %a) {
+  %ie = insertelement <2 x i32> poison, i32 %a, i32 0
+  %ret = shufflevector <2 x i32> %ie, <2 x i32> poison, <2 x i32> <i32 0, i32 0>
+  ret <2 x i32> %ret
+}
+
+define <2 x i32> @tgt(i32 %a) {
+  %ie = insertelement <2 x i32> poison, i32 %a, i32 0
+  %ret = insertelement <2 x i32> %ie, i32 %a, i32 1
+  ret <2 x i32> %ret
+}


### PR DESCRIPTION
Transforms/Scalarizer/order-bug.ll is failing because shufflevector isn't rewriting undef per element
A reduced example:
```
define <2 x i32> @src(i32 %a) {
  %ie = insertelement <2 x i32> poison, i32 %a, i32 0
  %ret = shufflevector <2 x i32> %ie, <2 x i32> poison, <2 x i32> <i32 0, i32 0>
  ; It should be allowed that %ret[0] and %ret[1] may have undef value independently
  ret <2 x i32> %ret
}

 define <2 x i32> @tgt(i32 %a) {
  %ie = insertelement <2 x i32> poison, i32 %a, i32 0
  %ret = insertelement <2 x i32> %ie, i32 %a, i32 1
  ret <2 x i32> %ret
}
```

Note that the ongoing shufflevector semantics patch is orthogonal to this fix because all masks are non-undef.