### PR TITLE
Add syntactic equality check to alive-tv

### DIFF
--- a/tests/alive-tv/params/dbg.src.ll
+++ b/tests/alive-tv/params/dbg.src.ll
@@ -2,6 +2,7 @@
 
 define i16 @test(i16) {
   %v = add i16 %0, %0
+  add i16 0, 0 ; dummy
   ret i16 %v
 }
 

--- a/tests/lit/lit/formats/alive2test.py
+++ b/tests/lit/lit/formats/alive2test.py
@@ -34,7 +34,7 @@ def is_timeout(str):
   return str.find('ERROR: Timeout') > 0
 
 def id_check(fn, cmd, args):
-  out, err, exitCode = executeCommand(cmd + args)
+  out, err, exitCode = executeCommand(cmd + args + ["-always-verify"])
   str = out + err
   if not is_timeout(str) and (exitCode != 0 or str.find(ok_string) < 0):
     raise Exception(fn + ' identity check fail: ' + str)

--- a/tools/alive-tv.cpp
+++ b/tools/alive-tv.cpp
@@ -28,6 +28,7 @@
 
 #include <fstream>
 #include <iostream>
+#include <sstream>
 #include <utility>
 
 using namespace tools;
@@ -115,6 +116,12 @@ static llvm::cl::opt<bool> opt_debug(
 static llvm::cl::opt<bool> opt_print_dot(
     "dot",
     llvm::cl::desc("Alive: print .dot files of each function"),
+    llvm::cl::cat(opt_alive), llvm::cl::init(false));
+
+static llvm::cl::opt<bool> opt_always_verify(
+    "always-verify",
+    llvm::cl::desc("Alive: verify the pair even if they are syntactically"
+                   " equivalent"),
     llvm::cl::cat(opt_alive), llvm::cl::init(false));
 
 static llvm::cl::opt<bool> opt_smt_stats(
@@ -304,6 +311,17 @@ static void compareFunctions(llvm::Function &F1, llvm::Function &F2,
   if (opt_print_dot) {
     Func1->writeDot("src");
     Func2->writeDot("tgt");
+  }
+
+  if (!opt_always_verify) {
+    stringstream ss1, ss2;
+    Func1->print(ss1);
+    Func2->print(ss2);
+    if (ss1.str() == ss2.str()) {
+      cout << "Transformation seems to be correct! (syntactically equal)\n\n";
+      ++goodCount;
+      return;
+    }
   }
 
   smt_init->reset();


### PR DESCRIPTION
As clang-tv does, this patch makes alive-tv omit pairs having equivalent Alive2 IRs.
If `-always-verify` is given, alive-tv verifies it even if they are equivalent. This is used by Alive2 unit tests.