### PR TITLE
factor out bid-based nonlocal block analysis

### DIFF
--- a/ir/memory.cpp
+++ b/ir/memory.cpp
@@ -35,13 +35,12 @@ using namespace util;
 
 //--- Functions for non-local block analysis based on bid ---//
 
-// If include_tgtonly is false, bid cannot be the global vars existing in target
-// only
-static bool nonlocal_is_globalvar(unsigned bid, bool include_tgtonly) {
-  if (bid < has_null_block)
-    return false;
-  return bid < has_null_block + num_globals_src ||
-         (include_tgtonly && num_nonlocals_src <= bid && bid < num_nonlocals);
+// If include_tgt is true, return true if bid is a global var existing in target
+// only as well
+static bool nonlocal_is_globalvar(unsigned bid, bool include_tgt) {
+  bool srcglb = has_null_block <= bid && bid < has_null_block + num_globals_src;
+  bool tgtglb = num_nonlocals_src <= bid && bid < num_nonlocals;
+  return srcglb || (include_tgt && tgtglb);
 }
 
 static bool nonlocal_is_constglb(unsigned bid) {

--- a/ir/memory.cpp
+++ b/ir/memory.cpp
@@ -73,14 +73,7 @@ static bool always_noread(unsigned bid) {
 
 // bid: nonlocal block id
 static bool always_nowrite(unsigned bid) {
-  bool flag = bid <  num_consts_src + has_null_block ||
-              bid >= num_nonlocals_src + num_extra_nonconst_tgt;
-
-  // If a block cannot be read, it cannot be written as well
-  assert(!always_noread(bid) || flag);
-
-  // TODO: fncall mem cannot be accessed with loads and stores.
-  return flag;
+  return always_noread(bid) || is_constglb(bid);
 }
 
 

--- a/ir/memory.cpp
+++ b/ir/memory.cpp
@@ -1119,7 +1119,7 @@ void Memory::syncWithSrc(const Memory &src) {
 }
 
 void Memory::markByVal(unsigned bid) {
-  assert(nonlocal_is_globalvar(bid, true));
+  assert(nonlocal_is_globalvar(bid, false));
   byval_blks.emplace_back(bid);
 }
 


### PR DESCRIPTION
This breaks the symmetry of fncall's extra block and other nonlocals (the detail is sent as a mail separately)