### PR TITLE
fix container-overflow bugs detected by asan

### DIFF
--- a/ir/function.cpp
+++ b/ir/function.cpp
@@ -485,7 +485,7 @@ void Function::unroll(unsigned k) {
   while (!worklist.empty()) {
     auto [header, height, flag] = worklist.back();
     if (!flag) {
-      flag = true;
+      get<2>(worklist.back()) = flag = true;
       auto I = forest.find(header);
       if (I != forest.end()) {
         // process all non-leaf children first

--- a/ir/function.cpp
+++ b/ir/function.cpp
@@ -483,7 +483,7 @@ void Function::unroll(unsigned k) {
 
   // traverse each loop tree in post-order
   while (!worklist.empty()) {
-    auto &[header, height, flag] = worklist.back();
+    auto [header, height, flag] = worklist.back();
     if (!flag) {
       flag = true;
       auto I = forest.find(header);
@@ -964,8 +964,8 @@ void LoopAnalysis::getDepthFirstSpanningTree() {
   while(!worklist.empty()) {
     auto &[bb, flag] = worklist.back();
     if (flag) {
-      worklist.pop_back();
       last[number[bb]] = current - 1;
+      worklist.pop_back();
     } else {
       node[current] = bb;
       number[bb] = current++;


### PR DESCRIPTION
Compiling Alive2 with Debug mode & running `ninja check` shows a few failures due to container-overflow bugs.
(https://llvm.org/devmtg/2014-04/PDFs/LightningTalks/EuroLLVM%202014%20--%20container%20overflow.pdf )

There were two buggy places, both of which are:
```
auto &v = vector.back()
vector.pop_back()
use(v)
```

For LoopAnalysis::getDepthFirstSpanningTree, I moved the pop_back to the end of the if branch.
For Function::unroll, the function was quite complex, so I just tagged off `&`.