### PR TITLE
Load ptr's partial order reduction should consider non_poison into account

### DIFF
--- a/ir/memory.cpp
+++ b/ir/memory.cpp
@@ -1995,7 +1995,7 @@ StateValue Memory::load(const Pointer &ptr, const Type &type, set<expr> &undef,
           for (unsigned i = num_nonlocals_src; i < numNonlocals(); ++i) {
             I->second.setMayAlias(false, i);
           }
-          state->addPre(islocal || bid.ule(*max_bid) ||
+          state->addPre(!val.non_poison || islocal || bid.ule(*max_bid) ||
                         (num_extra_nonconst_tgt ? bid.uge(num_nonlocals_src)
                                                 : false));
         }

--- a/tests/alive-tv/memory/issue651-2.srctgt.ll
+++ b/tests/alive-tv/memory/issue651-2.srctgt.ll
@@ -1,0 +1,32 @@
+; POR should consider poison-ness
+
+declare void @g()
+@p = global i64 0
+
+define void @src(i1 noundef %cond, i8** noundef %ptr) {
+entry:
+  call void @g()
+  store i64 undef, i64* @p, align 8
+  br i1 %cond, label %cleanup, label %if.end
+
+if.end:
+  load i8*, i8** %ptr, align 8
+  br label %cleanup
+
+cleanup:
+  ret void
+}
+
+define void @tgt(i1 noundef %cond, i8** noundef %ptr) {
+entry:
+  call void @g()
+  store i64 undef, i64* @p, align 8
+  br i1 %cond, label %cleanup, label %if.end
+
+if.end:
+  load i8*, i8** %ptr, align 8
+  br label %cleanup
+
+cleanup:
+  ret void
+}

--- a/tests/alive-tv/memory/issue651.srctgt.ll
+++ b/tests/alive-tv/memory/issue651.srctgt.ll
@@ -1,0 +1,44 @@
+; POR should consider poison-ness
+
+declare i32* @g()
+
+; identical
+define void @src(i32** %p1, i32* %p2, i32** %p3, i32*) {
+entry:
+  load i32*, i32** %p1, align 8
+  %cond1 = icmp eq i32* undef, %p2
+  br i1 %cond1, label %if.then, label %exit
+exit:
+  ret void
+
+if.then:
+  %.1 = load i32, i32* %p2, align 8
+  %cond2 = icmp eq i32 %.1, 0
+  br i1 %cond2, label %if.then2, label %if.end2
+if.then2:
+  call i32* @g()
+  br label %if.end2
+if.end2:
+  %i = load i32*, i32** %p3, align 8
+  ret void
+}
+
+define void @tgt(i32** %p1, i32* %p2, i32** %p3, i32*) {
+entry:
+  load i32*, i32** %p1, align 8
+  %cond1 = icmp eq i32* undef, %p2
+  br i1 %cond1, label %if.then, label %exit
+exit:
+  ret void
+
+if.then:
+  %.1 = load i32, i32* %p2, align 8
+  %cond2 = icmp eq i32 %.1, 0
+  br i1 %cond2, label %if.then2, label %if.end2
+if.then2:
+  call i32* @g()
+  br label %if.end2
+if.end2:
+  %i = load i32*, i32** %p3, align 8
+  ret void
+}


### PR DESCRIPTION
When load returns a pointer, the pointer's bid is to be POR-ed.

However, if the returned pointer was poison, its bid has a bogus value. The POR condition should take this into account.