### PR TITLE
add option to limit number of bits used for GEP offsets

### DIFF
--- a/tests/alive-tv/ptr-arithmetic-fail.srctgt.ll
+++ b/tests/alive-tv/ptr-arithmetic-fail.srctgt.ll
@@ -1,0 +1,58 @@
+; TEST-ARGS: -max-offset-in-bits=8
+; ERROR: Value mismatch
+
+define i4 @src(i8* %src, i8* %lower, i8* %upper, i8 %N, i8 %step) {
+entry:
+  %src.end = getelementptr inbounds i8, i8* %src, i8 %N
+  %cmp.src.start = icmp ult i8* %src, %lower
+  %cmp.src.end = icmp uge i8* %src.end, %upper
+  %or.precond.0 = or i1 %cmp.src.start, %cmp.src.end
+  br i1 %or.precond.0, label %trap.bb, label %step.check
+
+trap.bb:
+  ret i4 2
+
+step.check:
+  %step.pos = icmp uge i8 %step, 0
+  %step.ult.N = icmp ult i8 %step, %N
+  %and.step = and i1 %step.pos, %step.ult.N
+  br i1 %and.step, label %ptr.check, label %exit
+
+ptr.check:
+  %src.step = getelementptr inbounds i8, i8* %src, i8 %step
+  %cmp.step.start = icmp ult i8* %src.step, %lower
+  %cmp.step.end = icmp uge i8* %src.step, %upper
+  %or.check = or i1 %cmp.step.start, %cmp.step.end
+  br i1 %or.check, label %trap.bb, label %exit
+
+exit:
+  ret i4 3
+}
+
+define i4 @tgt(i8* %src, i8* %lower, i8* %upper, i8 %N, i8 %step) {
+entry:
+  %src.end = getelementptr inbounds i8, i8* %src, i8 %N
+  %cmp.src.start = icmp ult i8* %src, %lower
+  %cmp.src.end = icmp uge i8* %src.end, %upper
+  %or.precond.0 = or i1 %cmp.src.start, %cmp.src.end
+  br i1 %or.precond.0, label %trap.bb, label %step.check
+
+trap.bb:
+  ret i4 2
+
+step.check:
+  %step.pos = icmp uge i8 %step, 0
+  %step.ult.N = icmp ult i8 %step, %N
+  %and.step = and i1 %step.pos, %step.ult.N
+  br i1 %and.step, label %ptr.check, label %exit
+
+ptr.check:
+  %src.step = getelementptr inbounds i8, i8* %src, i8 %step
+  %cmp.step.start = icmp ult i8* %src.step, %lower
+  %cmp.step.end = icmp uge i8* %src.step, %upper
+  %or.check = or i1 false, false
+  br i1 %or.check, label %trap.bb, label %exit
+
+exit:
+  ret i4 3
+}

--- a/tools/alive-tv.cpp
+++ b/tools/alive-tv.cpp
@@ -56,6 +56,12 @@ static llvm::cl::opt<bool> opt_disable_poison("disable-poison-input",
     llvm::cl::init(false), llvm::cl::cat(opt_alive),
     llvm::cl::desc("Assume inputs are not poison (default=false)"));
 
+static llvm::cl::opt<size_t> opt_max_offset_in_bits(
+    "max-offset-in-bits", llvm::cl::init(64), llvm::cl::cat(opt_alive),
+    llvm::cl::desc("Upper bound for the maximum pointer offset in bits.  Note "
+                   "that this may impact correctness, if values involved in "
+                   "offset computations exceed the maximum."));
+
 static llvm::cl::opt<bool> opt_se_verbose(
     "se-verbose", llvm::cl::desc("Symbolic execution verbose mode"),
      llvm::cl::cat(opt_alive), llvm::cl::init(false));
@@ -352,6 +358,7 @@ convenient way to demonstrate an existing optimizer bug.
   config::debug = opt_debug;
   config::src_unroll_cnt = opt_src_unrolling_factor;
   config::tgt_unroll_cnt = opt_tgt_unrolling_factor;
+  config::max_offset_bits = opt_max_offset_in_bits;
 
   if (opt_smt_log)
     smt::start_logging();

--- a/tools/transform.cpp
+++ b/tools/transform.cpp
@@ -888,6 +888,7 @@ static void calculateAndInitConstants(Transform &t) {
     = ilog2_ceil(add_saturate(max(max_gep_src, max_gep_tgt), max_access_size),
                  true) + 1;
   bits_for_offset = min(round_up(max_geps, 4), (uint64_t)t.src.bitsPtrOffset());
+  bits_for_offset = min(bits_for_offset, config::max_offset_bits);
 
   // we need an extra bit because 1st bit of size is always 0
   bits_size_t = ilog2_ceil(max_alloc_size, true);

--- a/tv/tv.cpp
+++ b/tv/tv.cpp
@@ -161,6 +161,12 @@ llvm::cl::opt<unsigned> opt_tgt_unrolling_factor(
     llvm::cl::desc("Unrolling factor for tgt function (default=0)"),
     llvm::cl::cat(TVOptions), llvm::cl::init(0));
 
+llvm::cl::opt<size_t> opt_max_offset_in_bits(
+    "tv-max-offset-in-bits", llvm::cl::init(64), llvm::cl::cat(TVOptions),
+    llvm::cl::desc("Upper bound for the maximum pointer offset in bits.   Note "
+                   "that this may impact correctness, if values involved in "
+                   "offset computations exceed the maximum."));
+
 llvm::cl::opt<bool> parallel_tv_unrestricted(
     "tv-parallel-unrestricted",
     llvm::cl::desc("Distribute TV load across cores without any throttling; "
@@ -492,6 +498,7 @@ struct TVPass final : public llvm::ModulePass {
     config::debug = opt_debug;
     config::src_unroll_cnt = opt_src_unrolling_factor;
     config::tgt_unroll_cnt = opt_tgt_unrolling_factor;
+    config::max_offset_bits = opt_max_offset_in_bits;
     llvm_util::omit_array_size = opt_omit_array_size;
 
     llvm_util_init.emplace(*out, module.getDataLayout());

--- a/util/config.cpp
+++ b/util/config.cpp
@@ -17,6 +17,7 @@ bool disable_undef_input = false;
 bool debug = false;
 unsigned src_unroll_cnt = 0;
 unsigned tgt_unroll_cnt = 0;
+unsigned max_offset_bits = 64;
 
 ostream &dbg() {
   return *debug_os;

--- a/util/config.h
+++ b/util/config.h
@@ -21,6 +21,11 @@ extern unsigned src_unroll_cnt;
 
 extern unsigned tgt_unroll_cnt;
 
+// The maximum number of bits to use for offset computations. Note that this may
+// impact correctness, if values involved in offset computations exceed the
+// maximum.
+extern unsigned max_offset_bits;
+
 std::ostream &dbg();
 void set_debug(std::ostream &os);
 


### PR DESCRIPTION
This patch adds a max_gep_offset config option, to limit the maximum
value assumed for GEP offsets. This effectively provides an option to
limit the width of pointer arithmetic, which in turn speeds up
verification of programs using a lot of pointer arithmetic.

For regular arithmetic, a common advice is to limit the width of integer
types, but there is no easy way to  do the same thing for pointers. The
new option allows limiting the width of pointer arithmetic globally.

This should not impact soundness & completeness, unless the input
program has pointer arithmetic that does not fit in the specified width
(e.g. has a GEP that uses an offset outside the max range). So the users
of the option should think carefully when using the option.

Perhaps there is also a way to verify that the chosen value is not too
small?