### PR TITLE
add noexcept to move constructors

### DIFF
--- a/smt/expr.h
+++ b/smt/expr.h
@@ -71,7 +71,7 @@ class expr {
 public:
   expr() : ptr(0) {}
 
-  expr(expr &&other) : ptr(0) {
+  expr(expr &&other) noexcept : ptr(0) {
     std::swap(ptr, other.ptr);
   }
 

--- a/smt/solver.h
+++ b/smt/solver.h
@@ -26,7 +26,7 @@ class Model {
   friend class Result;
 
 public:
-  Model(Model &&other) : m(0) {
+  Model(Model &&other) noexcept : m(0) {
     std::swap(other.m, m);
   }
 


### PR DESCRIPTION
This helps certain STL operations like `vector<expr>::push_back` to efficiently move elements to a newly allocated memory (rather than copy) when the container needs to be resized.
Without noexcept, push_back needs to copy its elements to give a strong exception guarantee (meaning that push_back should rollback to the previous state if it failed).

Move constructors at exprs.h wasn't updated because their element types are not guaranteed to have noexcept move constructors (yet).

Ref: https://stackoverflow.com/questions/20517259/why-vector-access-operators-are-not-specified-as-noexcept/20521414#20521414