### PR TITLE
Resolve unit test failures after LLVM's switch to NPM

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ by LLVM.  Invoke the plugin like this:
 
 ```
 $ clang -O3 <src.c> -S -emit-llvm \
-  -fpass-plugin=$HOME/alive2/build/tv/tv.so -fexperimental-new-pass-manager \
+  -fpass-plugin=$HOME/alive2/build/tv/tv.so \
   -Xclang -load -Xclang $HOME/alive2/build/tv/tv.so
 ```
 

--- a/scripts/alivecc.in
+++ b/scripts/alivecc.in
@@ -97,7 +97,6 @@ if (compiling()) {
     }
 
     push @ARGV, "-fpass-plugin=@CMAKE_BINARY_DIR@/tv/${TV_SHAREDLIB}";
-    push @ARGV, "-fexperimental-new-pass-manager";
     push @ARGV, ("-Xclang", "-load", "-Xclang", "@CMAKE_BINARY_DIR@/tv/${TV_SHAREDLIB}");
 }
 

--- a/scripts/opt-alive.sh.in
+++ b/scripts/opt-alive.sh.in
@@ -40,7 +40,10 @@ for arg in $@; do
       set -- "$@" "$arg"
     fi
   else
-    if [[ $arg == "-enable-new-pm" ]]; then
+    # opt enables NPM by default.
+    if [[ $arg == "-enable-new-pm=0" ]]; then
+      NPM_TV=0
+    else
       NPM_TV=1
     fi
     set -- "$@" "$arg"

--- a/tests/opt-tv/legacypm.opt.ll
+++ b/tests/opt-tv/legacypm.opt.ll
@@ -1,0 +1,7 @@
+; TEST-ARGS: -instcombine -enable-new-pm=0
+
+define i32 @test(i32 %x) {
+  %v = add i32 %x, 1
+  %w = sub i32 %v, 1
+  ret i32 %w
+}

--- a/tests/opt-tv/npm-Os.opt.ll
+++ b/tests/opt-tv/npm-Os.opt.ll
@@ -5,4 +5,4 @@ define i32 @f() {
 }
 
 ; src and tgt are identical, but opt-alive should not validate anything
-; CHECK-NOT: Transformation
+; CHECK-NOT: Transformation seems

--- a/tests/opt-tv/simple.opt.ll
+++ b/tests/opt-tv/simple.opt.ll
@@ -1,0 +1,15 @@
+; TEST-ARGS: -sroa -instsimplify
+
+define i32 @f(i1 %cond) {
+  %p = alloca i32
+  br i1 %cond, label %A, label %B
+A:
+  store i32 1, i32* %p
+  br label %EXIT
+B:
+  store i32 2, i32* %p
+  br label %EXIT
+EXIT:
+  %v = load i32, i32* %p
+  ret i32 %v
+}


### PR DESCRIPTION
This is a patch to resolve the failures on my machine after NPM switch is enabled (https://github.com/AliveToolkit/alive2/issues/666#issuecomment-778779487).
After the NPM switch, all pass names in opt's command line arguments are parsed and passed into NPM (unless `-enable-new-pm=0` is given). For example, running `opt -tv -instcombine -tv` lookups `tv` and `instcombine` new passes.

This again causes a nasty problem that happened before (https://github.com/AliveToolkit/alive2/commit/c6d4b33daa177d64ab4b5947253dedd7dd61ac65 ). 
opt calls alive2's `registerPipelineParsingCallback("tv")` with dummy extra arguments to investigate whether `-tv` is a module-level pass or not.
This is problematic because our `registerPipelineParsingCallback("tv")` is not *idempotent*.
It adds `TVInitPass` in the first `registerPipelineParsingCallback` call only; the second call won't register TVInitPass.
Also, each call increments `TVNewPass::num_tv_pass_created++`, which is bad if it was a dummy call.

To resolve this, this patch makes `registerPipelineParsingCallback` idempotent.
To do this,

(1) I removed `TVInitPass`, and let simply the first run() of TV pass do the initialization.

(2) I made the TV pass instance do the reference counting at its constructor and destructor. If the number of references becomes zero, finalization is done.


Note that 
- This patch should not affect tests with opt + legacy pass manager.
- This patch affects clang tv because `TVInitPass` is removed; Now it starts validation earlier than before! In the past, there were a few passes like ForceFunctionAttr run before TVInitPass, and they couldn't be checked.