### PR TITLE
tv shouldn't run if NPM is disabled or has tailcallelim

### DIFF
--- a/scripts/opt-alive.sh.in
+++ b/scripts/opt-alive.sh.in
@@ -33,8 +33,10 @@ for arg in $@; do
     passes=${arg/-*passes=/}
     passes_new=`@CMAKE_SOURCE_DIR@/scripts/rewritepass.py "$PASSREGISTRY" $passes`
     firstpass_level=`echo $passes_new | cut -d "(" -f1`
+    # tailcallelim is a function pass but unsupported by Alive2
     if [[ $SKIP_TV == 0 &&
-        $firstpass_level != "module" && $firstpass_level != "cgscc" ]]; then
+        $firstpass_level != "module" && $firstpass_level != "cgscc" &&
+        $passes != *"tailcallelim"* && $NPM_TV -eq 1 ]]; then
       set -- "$@" "-passes=module(tv),$passes_new,module(tv)"
     else
       # Module/CGSCC-level passes shouldn't invoke tv


### PR DESCRIPTION
This resolves two regressions: Transforms/TailCallElim/opt-remarks-recursion.ll and Transforms/LoopUnrollAndJam/unroll-and-jam.ll .

opt-remarks-recursion.ll: tailcallelim is a function-level pass but unsupported by Alive2. I added a check for this.
unroll-and-jam.ll: it has tbaa enabled but still `module(tv)` was being added to -passes. We should check whether NPM is already set to 0 when adding `module(tv)`.