### PR TITLE
Add support for dereferenceable_or_null

### DIFF
--- a/ir/attrs.cpp
+++ b/ir/attrs.cpp
@@ -26,8 +26,10 @@ ostream& operator<<(ostream &os, const ParamAttrs &attr) {
     os << "align(" << attr.align << ") ";
   if (attr.has(ParamAttrs::Returned))
     os << "returned ";
-if (attr.has(ParamAttrs::NoAlias))
+  if (attr.has(ParamAttrs::NoAlias))
     os << "noalias ";
+  if (attr.has(ParamAttrs::DereferenceableOrNull))
+    os << "dereferenceable_or_null(" << attr.derefOrNullBytes << ") ";
   return os;
 }
 
@@ -59,11 +61,14 @@ ostream& operator<<(ostream &os, const FnAttrs &attr) {
     os << " noalias";
   if (attr.has(FnAttrs::WillReturn))
     os << " willreturn";
+  if (attr.has(FnAttrs::DereferenceableOrNull))
+    os << " dereferenceable_or_null(" << attr.derefOrNullBytes << ')';
   return os;
 }
 
 bool ParamAttrs::undefImpliesUB() const {
-  bool ub = has(NoUndef) || has(Dereferenceable) || has(ByVal);
+  bool ub = has(NoUndef) || has(Dereferenceable) || has(ByVal) ||
+            has(DereferenceableOrNull);
   assert(!ub || poisonImpliesUB());
   return ub;
 }
@@ -79,11 +84,12 @@ uint64_t ParamAttrs::getDerefBytes() const {
 }
 
 bool FnAttrs::poisonImpliesUB() const {
-  return has(Dereferenceable) || has(NoUndef) || has(NNaN);
+  return has(Dereferenceable) || has(NoUndef) || has(NNaN) ||
+         has(DereferenceableOrNull);
 }
 
 bool FnAttrs::undefImpliesUB() const {
-  bool ub = has(NoUndef) || has(Dereferenceable);
+  bool ub = has(NoUndef) || has(Dereferenceable) || has(DereferenceableOrNull);
   assert(!ub || poisonImpliesUB());
   return ub;
 }

--- a/ir/attrs.h
+++ b/ir/attrs.h
@@ -14,11 +14,12 @@ public:
   enum Attribute { None = 0, NonNull = 1<<0, ByVal = 1<<1, NoCapture = 1<<2,
                    NoRead = 1<<3, NoWrite = 1<<4, Dereferenceable = 1<<5,
                    NoUndef = 1<<6, Align = 1<<7, Returned = 1<<8,
-                   NoAlias = 1<<9 };
+                   NoAlias = 1<<9, DereferenceableOrNull = 1<<10 };
 
   ParamAttrs(unsigned bits = None) : bits(bits) {}
 
   uint64_t derefBytes; // Dereferenceable
+  uint64_t derefOrNullBytes; // DereferenceableOrNull
   unsigned blockSize;  // exact block size for e.g. byval args
   unsigned align = 1;
 
@@ -27,7 +28,8 @@ public:
 
   // Returns true if it's UB for the argument to be poison / have a poison elem.
   bool poisonImpliesUB() const
-  { return has(Dereferenceable) || has(NoUndef) || has(ByVal); }
+  { return has(Dereferenceable) || has(NoUndef) || has(ByVal) ||
+           has(DereferenceableOrNull); }
 
    // Returns true if it is UB for the argument to be (partially) undef.
   bool undefImpliesUB() const;
@@ -46,7 +48,8 @@ public:
                    ArgMemOnly = 1 << 2, NNaN = 1 << 3, NoReturn = 1 << 4,
                    Dereferenceable = 1 << 5, NonNull = 1 << 6,
                    NoFree = 1 << 7, NoUndef = 1 << 8, Align = 1 << 9,
-                   NoThrow = 1 << 10, NoAlias = 1 << 11, WillReturn = 1 << 12 };
+                   NoThrow = 1 << 10, NoAlias = 1 << 11, WillReturn = 1 << 12,
+                   DereferenceableOrNull = 1 << 13 };
 
   FnAttrs(unsigned bits = None) : bits(bits) {}
 
@@ -54,6 +57,7 @@ public:
   void set(Attribute a) { bits |= (unsigned)a; }
 
   uint64_t derefBytes; // Dereferenceable
+  uint64_t derefOrNullBytes; // DereferenceableOrNull
   unsigned align = 1;
 
   // Returns true if returning poison or an aggregate having a poison is UB

--- a/ir/instr.cpp
+++ b/ir/instr.cpp
@@ -1617,17 +1617,17 @@ FnCall::ByteAccessInfo FnCall::getByteAccessInfo() const {
   // If bytesize is zero, this call does not participate in byte encoding.
   uint64_t bytesize = 0;
 
-#define UPDATE(attr)                                     \
-  if (true) {                                            \
-    uint64_t sz = 0;                                     \
-    if (attr.has(decay<decltype(attr)>::type::Dereferenceable))       \
-      sz = attr.derefBytes;                              \
-    if (attr.has(decay<decltype(attr)>::type::DereferenceableOrNull)) \
-      sz = gcd(sz, attr.derefOrNullBytes);               \
-    /* Without align, nothing is guaranteed about the bytesize */ \
-    sz = gcd(sz, retattr.align);                         \
-    bytesize = bytesize ? gcd(bytesize, sz) : sz;        \
-  }
+#define UPDATE(attr)                                                   \
+  do {                                                                 \
+    uint64_t sz = 0;                                                   \
+    if (attr.has(decay<decltype(attr)>::type::Dereferenceable))        \
+      sz = attr.derefBytes;                                            \
+    if (attr.has(decay<decltype(attr)>::type::DereferenceableOrNull))  \
+      sz = gcd(sz, attr.derefOrNullBytes);                             \
+    /* Without align, nothing is guaranteed about the bytesize */      \
+    sz = gcd(sz, retattr.align);                                       \
+    bytesize = bytesize ? gcd(bytesize, sz) : sz;                      \
+  } while (0)
 
   auto &retattr = getAttributes();
   UPDATE(retattr);

--- a/ir/instr.cpp
+++ b/ir/instr.cpp
@@ -1624,6 +1624,7 @@ FnCall::ByteAccessInfo FnCall::getByteAccessInfo() const {
       sz = attr.derefBytes;                              \
     if (attr.has(decay<decltype(attr)>::type::DereferenceableOrNull)) \
       sz = gcd(sz, attr.derefOrNullBytes);               \
+    /* Without align, nothing is guaranteed about the bytesize */ \
     sz = gcd(sz, retattr.align);                         \
     bytesize = bytesize ? gcd(bytesize, sz) : sz;        \
   }

--- a/ir/value.cpp
+++ b/ir/value.cpp
@@ -220,16 +220,24 @@ StateValue Input::mkInput(State &s, const Type &ty, unsigned child) const {
 
   // Some attributes generate poison rather than raise UB
   expr np_from_attr(true);
+  {
+    Pointer p(s.getMemory(), val);
 
-  if (hasAttribute(ParamAttrs::NonNull))
-    np_from_attr = Pointer(s.getMemory(), val).isNonZero();
+    if (hasAttribute(ParamAttrs::NonNull))
+      np_from_attr = p.isNonZero();
 
-  if (hasAttribute(ParamAttrs::Dereferenceable) ||
-      hasAttribute(ParamAttrs::ByVal))
-    s.addUB(Pointer(s.getMemory(), val)
-              .isDereferenceable(attrs.getDerefBytes(), attrs.align, false));
-  else if (hasAttribute(ParamAttrs::Align))
-    np_from_attr &= Pointer(s.getMemory(), val).isAligned(attrs.align);
+    bool hasDeref = hasAttribute(ParamAttrs::Dereferenceable) ||
+                    hasAttribute(ParamAttrs::ByVal);
+    bool hasDerefOrNull = hasAttribute(ParamAttrs::DereferenceableOrNull);
+    if (hasDeref || hasDerefOrNull) {
+      if (hasDeref)
+        s.addUB(p.isDereferenceable(attrs.getDerefBytes(), attrs.align));
+      if (hasDerefOrNull)
+        s.addUB(p.isDereferenceable(attrs.derefOrNullBytes, attrs.align)() ||
+                !p.isNonZero());
+    } else if (hasAttribute(ParamAttrs::Align))
+      np_from_attr &= p.isAligned(attrs.align);
+  }
 
   if (attrs.poisonImpliesUB()) {
     s.addUB(move(np_from_attr));

--- a/ir/value.cpp
+++ b/ir/value.cpp
@@ -220,7 +220,7 @@ StateValue Input::mkInput(State &s, const Type &ty, unsigned child) const {
 
   // Some attributes generate poison rather than raise UB
   expr np_from_attr(true);
-  {
+  if (ty.isPtrType()) {
     Pointer p(s.getMemory(), val);
 
     if (hasAttribute(ParamAttrs::NonNull))

--- a/llvm_util/llvm2alive.cpp
+++ b/llvm_util/llvm2alive.cpp
@@ -1103,6 +1103,11 @@ public:
         attrs.derefBytes = attr.getDereferenceableBytes();
         continue;
 
+      case llvm::Attribute::DereferenceableOrNull:
+        attrs.set(ParamAttrs::DereferenceableOrNull);
+        attrs.derefOrNullBytes = attr.getDereferenceableOrNullBytes();
+        continue;
+
       case llvm::Attribute::Alignment:
         attrs.set(ParamAttrs::Align);
         attrs.align = attr.getAlignment()->value();

--- a/tests/alive-tv/attrs/dereferenceable_or_null-callsite.srctgt.ll
+++ b/tests/alive-tv/attrs/dereferenceable_or_null-callsite.srctgt.ll
@@ -1,0 +1,13 @@
+define void @src(i32* %p) {
+  call void @f(i32* dereferenceable_or_null(4) %p)
+  ret void
+}
+
+define void @tgt(i32* %p) {
+  call void @f(i32* dereferenceable(4) %p)
+  ret void
+}
+
+declare void @f(i32*)
+
+; ERROR: Source is more defined than target

--- a/tests/alive-tv/attrs/dereferenceable_or_null.srctgt.ll
+++ b/tests/alive-tv/attrs/dereferenceable_or_null.srctgt.ll
@@ -1,0 +1,9 @@
+define i32* @src(i32* dereferenceable_or_null(4) %p) {
+  ret i32* %p
+}
+
+define i32* @tgt(i32* dereferenceable(4) %p) {
+  ret i32* %p
+}
+
+; ERROR: Source is more defined than target

--- a/tests/alive-tv/attrs/dereferenceable_or_null2.srctgt.ll
+++ b/tests/alive-tv/attrs/dereferenceable_or_null2.srctgt.ll
@@ -1,0 +1,7 @@
+define i32* @src(i32* dereferenceable(4) %p) {
+  ret i32* %p
+}
+
+define i32* @tgt(i32* dereferenceable_or_null(4) %p) {
+  ret i32* %p
+}

--- a/tests/alive-tv/attrs/dereferenceable_or_null3.srctgt.ll
+++ b/tests/alive-tv/attrs/dereferenceable_or_null3.srctgt.ll
@@ -1,0 +1,13 @@
+define void @src(i32* dereferenceable_or_null(4) %p) {
+  ret void
+}
+
+define void @tgt(i32* dereferenceable_or_null(4) %p) {
+  %c = icmp eq i32* %p, null
+  br i1 %c, label %NOP, label %DEREFERENCE
+NOP:
+  ret void
+DEREFERENCE:
+  load i32, i32* %p, align 1
+  ret void
+}

--- a/tests/alive-tv/attrs/dereferenceable_or_null4.srctgt.ll
+++ b/tests/alive-tv/attrs/dereferenceable_or_null4.srctgt.ll
@@ -1,0 +1,10 @@
+define void @src(i32* dereferenceable_or_null(4) %p) {
+  ret void
+}
+
+define void @tgt(i32* dereferenceable_or_null(4) %p) {
+  load i32, i32* %p, align 1
+  ret void
+}
+
+; ERROR: Source is more defined than target

--- a/tests/alive-tv/attrs/dereferenceable_or_null5.srctgt.ll
+++ b/tests/alive-tv/attrs/dereferenceable_or_null5.srctgt.ll
@@ -1,0 +1,8 @@
+define void @src(i32* dereferenceable_or_null(4) dereferenceable(2) %p) {
+  ret void
+}
+
+define void @tgt(i32* dereferenceable_or_null(4) dereferenceable(2) %p) {
+  load i32, i32* %p, align 1
+  ret void
+}

--- a/tests/alive-tv/attrs/dereferenceable_or_null6.srctgt.ll
+++ b/tests/alive-tv/attrs/dereferenceable_or_null6.srctgt.ll
@@ -1,0 +1,8 @@
+define void @src(i32* dereferenceable_or_null(4) nonnull %p) {
+  ret void
+}
+
+define void @tgt(i32* dereferenceable_or_null(4) nonnull %p) {
+  load i32, i32* %p, align 1
+  ret void
+}

--- a/tools/transform.cpp
+++ b/tools/transform.cpp
@@ -753,9 +753,9 @@ static void calculateAndInitConstants(Transform &t) {
         max_access_size = max(max_access_size, deref_bytes);
       }
       if (i->hasAttribute(ParamAttrs::DereferenceableOrNull)) {
-        // Optimization: unless explicitly compared with a null pointer, assume
-        // that the pointer can never be null.
-        // Hence, nullptr_is_used doesn't need to be updated.
+        // Optimization: unless explicitly compared with a null pointer, don't
+        // set nullptr_is_used to true.
+        // Null constant pointer will set nullptr_is_used to true anyway.
         // Note that dereferenceable_or_null implies num_ptrinputs > 0,
         // which may turn has_null_block on.
         does_mem_access = true;

--- a/tools/transform.cpp
+++ b/tools/transform.cpp
@@ -752,6 +752,14 @@ static void calculateAndInitConstants(Transform &t) {
         uint64_t deref_bytes = i->getAttributes().derefBytes;
         max_access_size = max(max_access_size, deref_bytes);
       }
+      if (i->hasAttribute(ParamAttrs::DereferenceableOrNull)) {
+        // Optimization: unless explicitly compared with a null pointer, assume
+        // that the pointer can never be null.
+        // Hence, nullptr_is_used doesn't need to be updated.
+        does_mem_access = true;
+        uint64_t deref_bytes = i->getAttributes().derefOrNullBytes;
+        max_access_size = max(max_access_size, deref_bytes);
+      }
       if (i->hasAttribute(ParamAttrs::ByVal)) {
         does_mem_access = true;
         uint64_t sz = i->getAttributes().blockSize;

--- a/tools/transform.cpp
+++ b/tools/transform.cpp
@@ -756,6 +756,8 @@ static void calculateAndInitConstants(Transform &t) {
         // Optimization: unless explicitly compared with a null pointer, assume
         // that the pointer can never be null.
         // Hence, nullptr_is_used doesn't need to be updated.
+        // Note that dereferenceable_or_null implies num_ptrinputs > 0,
+        // which may turn has_null_block on.
         does_mem_access = true;
         uint64_t deref_bytes = i->getAttributes().derefOrNullBytes;
         max_access_size = max(max_access_size, deref_bytes);


### PR DESCRIPTION
Resolves a regression in Transforms/SimplifyCFG/UnreachableEliminate.ll

I'll leave the LLVM unit test result here when it's done