### PR TITLE
refactor code duplication in fn/paramattr encoding

### DIFF
--- a/ir/attrs.cpp
+++ b/ir/attrs.cpp
@@ -91,8 +91,8 @@ uint64_t ParamAttrs::getDerefBytes() const {
 static void
 encodePtrAttrs(const State &s, const expr &ptrvalue,
                AndExpr &UB, expr &non_poison,
-               uint64_t derefBytes,
-               uint64_t derefOrNullBytes, uint64_t align, bool nonnull) {
+               uint64_t derefBytes, uint64_t derefOrNullBytes, uint64_t align,
+               bool nonnull) {
   Pointer p(s.getMemory(), ptrvalue);
 
   if (nonnull)

--- a/ir/attrs.h
+++ b/ir/attrs.h
@@ -7,6 +7,10 @@
 
 namespace IR {
 
+class State;
+struct StateValue;
+class Type;
+
 class ParamAttrs final {
   unsigned bits;
 
@@ -18,8 +22,8 @@ public:
 
   ParamAttrs(unsigned bits = None) : bits(bits) {}
 
-  uint64_t derefBytes; // Dereferenceable
-  uint64_t derefOrNullBytes; // DereferenceableOrNull
+  uint64_t derefBytes = 0; // Dereferenceable
+  uint64_t derefOrNullBytes = 0; // DereferenceableOrNull
   unsigned blockSize;  // exact block size for e.g. byval args
   unsigned align = 1;
 
@@ -56,8 +60,8 @@ public:
   bool has(Attribute a) const { return (bits & a) != 0; }
   void set(Attribute a) { bits |= (unsigned)a; }
 
-  uint64_t derefBytes; // Dereferenceable
-  uint64_t derefOrNullBytes; // DereferenceableOrNull
+  uint64_t derefBytes = 0; // Dereferenceable
+  uint64_t derefOrNullBytes = 0; // DereferenceableOrNull
   unsigned align = 1;
 
   // Returns true if returning poison or an aggregate having a poison is UB
@@ -68,5 +72,13 @@ public:
 
   friend std::ostream& operator<<(std::ostream &os, const FnAttrs &attr);
 };
+
+
+// Encode attributes for a non-aggregate value using UB and poison.
+// Attributes requiring more than UB or poison are not encoded.
+void encodeParamAttrs(const ParamAttrs &attrs, State &s, StateValue &value,
+                      const Type &ty);
+void encodeFnAttrs(const FnAttrs &attrs, State &s, StateValue &value,
+                   const Type &ty);
 
 }

--- a/ir/attrs.h
+++ b/ir/attrs.h
@@ -23,7 +23,7 @@ public:
 
   ParamAttrs(unsigned bits = None) : bits(bits) {}
 
-  uint64_t derefBytes = 0; // Dereferenceable
+  uint64_t derefBytes = 0;       // Dereferenceable
   uint64_t derefOrNullBytes = 0; // DereferenceableOrNull
   unsigned blockSize;  // exact block size for e.g. byval args
   unsigned align = 1;
@@ -65,7 +65,7 @@ public:
   bool has(Attribute a) const { return (bits & a) != 0; }
   void set(Attribute a) { bits |= (unsigned)a; }
 
-  uint64_t derefBytes = 0; // Dereferenceable
+  uint64_t derefBytes = 0;       // Dereferenceable
   uint64_t derefOrNullBytes = 0; // DereferenceableOrNull
   unsigned align = 1;
 

--- a/ir/attrs.h
+++ b/ir/attrs.h
@@ -3,6 +3,7 @@
 // Copyright (c) 2018-present The Alive2 Authors.
 // Distributed under the MIT license that can be found in the LICENSE file.
 
+#include "smt/exprs.h"
 #include <ostream>
 
 namespace IR {
@@ -41,6 +42,10 @@ public:
   uint64_t getDerefBytes() const;
 
   friend std::ostream& operator<<(std::ostream &os, const ParamAttrs &attr);
+
+  // Encodes the semantics of attributes using UB and poison.
+  std::pair<smt::AndExpr, smt::expr>
+      encode(const State &s, const StateValue &val, const Type &ty) const;
 };
 
 
@@ -71,14 +76,10 @@ public:
   bool undefImpliesUB() const;
 
   friend std::ostream& operator<<(std::ostream &os, const FnAttrs &attr);
+
+  // Encodes the semantics of attributes using UB and poison.
+  std::pair<smt::AndExpr, smt::expr>
+      encode(const State &s, const StateValue &val, const Type &ty) const;
 };
-
-
-// Encode attributes for a non-aggregate value using UB and poison.
-// Attributes requiring more than UB or poison are not encoded.
-void encodeParamAttrs(const ParamAttrs &attrs, State &s, StateValue &value,
-                      const Type &ty);
-void encodeFnAttrs(const FnAttrs &attrs, State &s, StateValue &value,
-                   const Type &ty);
 
 }

--- a/ir/type.h
+++ b/ir/type.h
@@ -275,8 +275,8 @@ public:
   unsigned numPaddingsConst() const;
 
   StateValue aggregateVals(const std::vector<StateValue> &vals) const;
-  IR::StateValue extract(const IR::StateValue &val, unsigned index,
-                         bool fromInt = false) const;
+  StateValue extract(const StateValue &val, unsigned index,
+                     bool fromInt = false) const;
   Type& getChild(unsigned index) const { return *children[index]; }
   bool isPadding(unsigned i) const { return is_padding[i]; }
   unsigned countPaddings(unsigned to_idx) const;

--- a/ir/value.cpp
+++ b/ir/value.cpp
@@ -218,15 +218,14 @@ StateValue Input::mkInput(State &s, const Type &ty, unsigned child) const {
     s.addUndefVar(move(var));
   }
 
-  // Some attributes generate poison rather than raise UB
-  StateValue sval(move(val), true);
-  encodeParamAttrs(attrs, s, sval, ty);
+  auto [UB, non_poison] = attrs.encode(s, {expr(val), expr(true)}, ty);
+  s.addUB(move(UB));
 
   bool never_poison = config::disable_poison_input || attrs.poisonImpliesUB();
   string np_name = "np_" + getSMTName(child);
 
-  return { move(sval.value),
-           move(sval.non_poison) &&
+  return { move(val),
+           move(non_poison) &&
               (never_poison ? true : expr::mkBoolVar(np_name.c_str())) };
 }
 

--- a/ir/value.cpp
+++ b/ir/value.cpp
@@ -225,8 +225,8 @@ StateValue Input::mkInput(State &s, const Type &ty, unsigned child) const {
   string np_name = "np_" + getSMTName(child);
 
   return { move(val),
-           move(non_poison) &&
-              (never_poison ? true : expr::mkBoolVar(np_name.c_str())) };
+           move(non_poison) && (never_poison ? true :
+                                  expr::mkBoolVar(np_name.c_str())) };
 }
 
 bool Input::isUndefMask(const expr &e, const expr &var) {
@@ -241,12 +241,7 @@ StateValue Input::toSMT(State &s) const {
 }
 
 expr Input::getUndefVar(const Type &ty, unsigned child) const {
-  // TODO: Clarify whether byval/dereferenceable accept partially undefined
-  // pointers
-  if (config::disable_undef_input ||
-      hasAttribute(ParamAttrs::ByVal) ||
-      hasAttribute(ParamAttrs::Dereferenceable) ||
-      attrs.undefImpliesUB())
+  if (config::disable_undef_input || attrs.undefImpliesUB())
     return {};
 
   string tyname = "isundef_" + getSMTName(child);


### PR DESCRIPTION
This patch goes one step further and refactors code duplication in FnAttrs <-> ParamAttrs.
