### PR TITLE
unsupport align op bundle with an extra argument

### DIFF
--- a/llvm_util/llvm2alive.cpp
+++ b/llvm_util/llvm2alive.cpp
@@ -751,6 +751,10 @@ public:
         } else if (name == "align") {
           llvm::Value *ptr = bundle.Inputs[0].get();
           llvm::Value *align = bundle.Inputs[1].get();
+          if (bundle.Inputs.size() != 2)
+            // TODO: "align" assume operand bundle may take a third argument.
+            return error(i);
+
           auto *aptr = get_operand(ptr), *aalign = get_operand(align);
           if (!aptr || !aalign)
             return error(i);

--- a/tests/alive-tv/assume/align-op3.srctgt.ll
+++ b/tests/alive-tv/assume/align-op3.srctgt.ll
@@ -1,0 +1,18 @@
+; SKIP-IDENTITY
+declare void @llvm.assume(i1)
+
+declare void @f(i8* align(4)) ; has no noundef
+
+define void @src(i8* %ptr) {
+  call void @f(i8* %ptr)
+  ret void
+}
+
+define void @tgt(i8* %ptr) {
+  call void @f(i8* %ptr)
+  call void @llvm.assume(i1 1) [ "align"(i8* %ptr, i64 4, i64 0) ]
+  ret void
+}
+
+; align with 3 ops isn't supported yet.
+; XFAIL: Unsupported instruction


### PR DESCRIPTION
This patch resolves the two failures (Transforms/AlignmentFromAssumptions/simple.ll, simple32.ll) by unsupporting align with 3 arguments.
According to `llvm/lib/Transforms/Scalar/AlignmentFromAssumptions.cpp`, the extra argument seems to represent an information describing that there exists i and j s.t. `(int)ptr = ai + bj` given an operand bundle `"align"[i8* ptr, i64 a, i64 b]`, but I'm not sure.
Maybe I can ask this to people.