### PR TITLE
support lifetime undef or heap alloc

### DIFF
--- a/tests/alive-tv/lifetime/lifetime-malloc.srctgt.ll
+++ b/tests/alive-tv/lifetime/lifetime-malloc.srctgt.ll
@@ -1,0 +1,16 @@
+declare void @llvm.lifetime.start.p0i8(i64, i8*)
+declare void @llvm.lifetime.end.p0i8(i64, i8*)
+declare i8* @malloc(i64)
+
+define i8 @src() {
+  %p = call i8* @malloc(i64 1)
+  store i8 1, i8* %p
+  call void @llvm.lifetime.start.p0i8(i64 1, i8* %p)
+  %v = load i8, i8* %p
+  call void @llvm.lifetime.end.p0i8(i64 1, i8* %p)
+  ret i8 %v
+}
+
+define i8 @tgt() {
+  ret i8 poison
+}

--- a/tests/alive-tv/lifetime/lifetime-malloc2.srctgt.ll
+++ b/tests/alive-tv/lifetime/lifetime-malloc2.srctgt.ll
@@ -1,0 +1,16 @@
+declare void @llvm.lifetime.start.p0i8(i64, i8*)
+declare void @llvm.lifetime.end.p0i8(i64, i8*)
+declare i8* @malloc(i64)
+
+define i8 @src() {
+  %p = call i8* @malloc(i64 1)
+  call void @llvm.lifetime.start.p0i8(i64 1, i8* %p)
+  store i8 1, i8* %p
+  call void @llvm.lifetime.end.p0i8(i64 1, i8* %p)
+  %v = load i8, i8* %p
+  ret i8 %v
+}
+
+define i8 @tgt() {
+  ret i8 poison
+}

--- a/tests/alive-tv/lifetime/lifetime-undef.srctgt.ll
+++ b/tests/alive-tv/lifetime/lifetime-undef.srctgt.ll
@@ -1,0 +1,13 @@
+declare void @llvm.lifetime.start.p0i8(i64, i8*)
+declare void @llvm.lifetime.end.p0i8(i64, i8*)
+
+define void @src() {
+  ret void
+}
+
+define void @tgt() {
+  ; lifetime undef is nop
+  call void @llvm.lifetime.start.p0i8(i64 1, i8* undef)
+  call void @llvm.lifetime.end.p0i8(i64 1, i8* undef)
+  ret void
+}


### PR DESCRIPTION
This patch resolves unsupported lifetime errors from:
```
InstCombine/deadcode.ll
InstCombine/malloc-free-delete.ll
MemCpyOpt/memset-memcpy-oversized.ll
DeadStoreElimination/MSSA/multiblock-multipath.ll
NewGVN/verify-memoryphi.ll
```

LoopVectorize/lifetime.ll still has unsupported lifetimes, but they look weird: https://godbolt.org/z/vf39f3
The input function already isn't looking good; lifetime.start/end is spread over entry and exit block.
The output function either has double lifetime.start or the pointer operand has `extract(...)` form.
I think this is a suboptimal form, and to help stackcoloring it should be fixed from LLVM side.