### PR TITLE
Define fncall mem block as global, always-live, inaccessible one

### DIFF
--- a/ir/memory.cpp
+++ b/ir/memory.cpp
@@ -1285,11 +1285,6 @@ Memory::mkCallState(const string &fnname, const vector<PtrInput> *ptr_inputs,
     expr zero = expr::mkUInt(0, num_nonlocals);
     expr mask = has_null_block ? one : zero;
     for (unsigned bid = has_null_block; bid < num_nonlocals; ++bid) {
-      if (is_fncall_mem(bid)) {
-        mask = mask | (one << expr::mkUInt(bid, num_nonlocals));
-        continue;
-      }
-
       expr may_free = true;
       if (ptr_inputs) {
         may_free = false;
@@ -1299,7 +1294,7 @@ Memory::mkCallState(const string &fnname, const vector<PtrInput> *ptr_inputs,
         }
       }
       expr heap = Pointer(*this, bid, false).isHeapAllocated();
-      mask = mask | expr::mkIf(heap && may_free,
+      mask = mask | expr::mkIf(heap && may_free && !is_fncall_mem(bid),
                                zero,
                                one << expr::mkUInt(bid, num_nonlocals));
     }

--- a/ir/memory.cpp
+++ b/ir/memory.cpp
@@ -73,7 +73,8 @@ void ensure_non_fncallmem(const Pointer &p) {
   if (!p.isLocal().isFalse())
     return;
   uint64_t ubid;
-  ENSURE(!p.getShortBid().isUInt(ubid) || !is_fncall_mem(ubid));
+  assert(!p.getShortBid().isUInt(ubid) || !is_fncall_mem(ubid));
+  (void)ubid;
 }
 
 // bid: nonlocal block id

--- a/ir/memory.cpp
+++ b/ir/memory.cpp
@@ -1021,7 +1021,6 @@ void Memory::mk_nonlocal_val_axioms(bool skip_consts) {
     Byte byte(*this, non_local_block_val[i].val.load(offset));
     Pointer loadedptr = byte.ptr();
     expr bid = loadedptr.getShortBid();
-
     state->addAxiom(
       expr::mkForAll({ offset },
         byte.isPtr().implies(!loadedptr.isLocal(false) &&

--- a/ir/memory.cpp
+++ b/ir/memory.cpp
@@ -1022,20 +1022,11 @@ void Memory::mk_nonlocal_val_axioms(bool skip_consts) {
     Pointer loadedptr = byte.ptr();
     expr bid = loadedptr.getShortBid();
 
-    unsigned bid_upperbound = numNonlocals() - 1;
-    if (has_fncall && state->isSource())
-      // exclude fncall mem block (src)
-      bid_upperbound = numNonlocals() - 2;
-    expr loadedptr_cond = !loadedptr.isLocal(false) &&
-                          !loadedptr.isNocapture(false) &&
-                          bid.ule(bid_upperbound);
-
-    if (has_fncall && !state->isSource())
-      // exclude fncall mem block (tgt): bid_upperbound is larger than fnbid
-      loadedptr_cond &= bid != expr::mkUInt(get_fncallmem_bid(), bid);
-
     state->addAxiom(
-      expr::mkForAll({ offset }, byte.isPtr().implies(move(loadedptr_cond))));
+      expr::mkForAll({ offset },
+        byte.isPtr().implies(!loadedptr.isLocal(false) &&
+                             !loadedptr.isNocapture(false) &&
+                             bid.ule(numNonlocals() - 1))));
   }
 }
 

--- a/ir/memory.h
+++ b/ir/memory.h
@@ -163,7 +163,7 @@ class Memory {
 
   smt::expr isBlockAlive(const smt::expr &bid, bool local) const;
 
-  void mkNonlocalValAxioms(bool skip_consts);
+  void mk_nonlocal_val_axioms(bool skip_consts);
 
   bool mayalias(bool local, unsigned bid, const smt::expr &offset,
                 unsigned bytes, unsigned align, bool write) const;

--- a/ir/memory.h
+++ b/ir/memory.h
@@ -163,7 +163,7 @@ class Memory {
 
   smt::expr isBlockAlive(const smt::expr &bid, bool local) const;
 
-  void mk_nonlocal_val_axioms(bool skip_consts);
+  void mkNonlocalValAxioms(bool skip_consts);
 
   bool mayalias(bool local, unsigned bid, const smt::expr &offset,
                 unsigned bytes, unsigned align, bool write) const;


### PR DESCRIPTION
This is a follow-up of #654 and treats the memory block for recording fncall's side effect as global, always live, and inaccessible one. This reduces the size of may-alias sets.
Also, this updates the disjointness of blocks to never consider the fncall mem block because its address is unobservable.

Note that things can be further improved by reordering the block ids; currently, `bid != expr::mkUInt(get_fncallmem_bid(), bid);` is individually added to the may-alias SMT formula. This can be improved by reassigning fncallmem_bid to be placed after the pointers from loads/fncalls/etc.
