### PR TITLE
[RFC] undef ptr cannot be local if there's no local

### DIFF
--- a/ir/memory.h
+++ b/ir/memory.h
@@ -158,7 +158,6 @@ class Memory {
   static bool observesAddresses();
   static int isInitialMemBlock(const smt::expr &e, bool match_any_init = false);
 
-  unsigned numLocals() const;
   unsigned numNonlocals() const;
 
   smt::expr isBlockAlive(const smt::expr &bid, bool local) const;
@@ -226,6 +225,8 @@ public:
 
   static void resetGlobals();
   void syncWithSrc(const Memory &src);
+
+  unsigned numLocals() const;
 
   void markByVal(unsigned bid);
   smt::expr mkInput(const char *name, const ParamAttrs &attrs);

--- a/ir/value.cpp
+++ b/ir/value.cpp
@@ -48,6 +48,10 @@ StateValue UndefValue::toSMT(State &s) const {
   auto val = getType().getDummyValue(true);
   expr var = expr::mkFreshVar("undef", val.value);
   s.addUndefVar(expr(var));
+  if (getType().isPtrType() && s.getMemory().numLocals() == 0) {
+    expr one = expr::mkUInt(1, var);
+    var = var & ((one << expr::mkUInt(var.bits() - 1, var)) - one);
+  }
   return { move(var), move(val.non_poison) };
 }
 

--- a/tests/alive-tv/undef/local.srctgt.ll
+++ b/tests/alive-tv/undef/local.srctgt.ll
@@ -1,0 +1,19 @@
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+define void @src() {
+entry:
+  %retval = alloca i32, align 4
+  call i32 @b(i32* undef)
+  ret void
+}
+
+define void @tgt() {
+entry:
+  call i32 @b(i32* undef)
+  ret void
+}
+
+declare i32* @a()
+
+declare i32 @b(i32*)


### PR DESCRIPTION
This is a proposal to fix #689 and many regressions found while compiling Redis.

If a function does not have any local vars, undef cannot have nonlocal bit set to one.

This patch does not fully implement vector or struct of undefs yet.
If this direction makes sense, I'll continue and finish this.