### PR TITLE
disjoint_local_blocks should use local pointers to compare addrs

### DIFF
--- a/ir/memory.cpp
+++ b/ir/memory.cpp
@@ -1346,7 +1346,7 @@ static expr disjoint_local_blocks(const Memory &m, const expr &addr,
   // Disjointness of block's address range with other local blocks
   auto zero = expr::mkUInt(0, bits_for_offset);
   for (auto &[sbid, addr0] : blk_addr) {
-    Pointer p2(m, Pointer::mkLongBid(sbid, false), zero);
+    Pointer p2(m, Pointer::mkLongBid(sbid, true), zero);
     disj &= p2.isBlockAlive()
               .implies(disjoint(addr, sz, p2.getAddress(), p2.blockSize()));
   }

--- a/ir/pointer.cpp
+++ b/ir/pointer.cpp
@@ -95,8 +95,11 @@ Pointer::Pointer(const Memory &m, const expr &bid, const expr &offset,
   : Pointer(m, bid, offset, attr_to_bitvec(attr)) {}
 
 expr Pointer::mkLongBid(const expr &short_bid, bool local) {
-  if (!has_local_bit())
+  assert((local  && (num_locals_src || num_locals_tgt)) ||
+         (!local && num_nonlocals));
+  if (!has_local_bit()) {
     return short_bid;
+  }
   return expr::mkUInt(local, 1).concat(short_bid);
 }
 

--- a/tests/alive-tv/memory/issue689_lifetime.srctgt.ll
+++ b/tests/alive-tv/memory/issue689_lifetime.srctgt.ll
@@ -1,0 +1,24 @@
+define void @src() {
+entry:
+  %retval = alloca i32, align 4
+  %b = alloca i32, align 4
+  %0 = bitcast i32* %b to i8*
+  call void @llvm.lifetime.start.p0i8(i64 4, i8* %0)
+  %1 = ptrtoint i32* %b to i32
+  %call = call i32 @a(i32 %1)
+  ret void
+}
+
+define void @tgt() {
+entry:
+  %b = alloca i32, align 4
+  %0 = bitcast i32* %b to i8*
+  call void @llvm.lifetime.start.p0i8(i64 4, i8* %0)
+  %1 = ptrtoint i32* %b to i32
+  %call = call i32 @a(i32 %1)
+  ret void
+}
+
+declare i32 @a(i32)
+declare void @llvm.lifetime.start.p0i8(i64, i8*)
+


### PR DESCRIPTION
This patch fixes https://github.com/AliveToolkit/alive2/issues/689#issuecomment-817185265. It happened because `Pointer::mkLongBid`'s second argument (local flag) was incorrectly set to false.

I added an assertion there to sanity-check whether `local` isn't bogus.