### PR TITLE
Fix alivecc to pass -tv-quiet, add a test for the option

### DIFF
--- a/scripts/alivecc.in
+++ b/scripts/alivecc.in
@@ -32,8 +32,8 @@ if ($0 =~ /alivecc$/) {
 
 if (compiling()) {
 
-    if (getenv("ALIVECC_SUCCINCT")) {
-        push @ARGV, ("-mllvm", "-tv-succinct");
+    if (getenv("ALIVECC_QUIET")) {
+        push @ARGV, ("-mllvm", "-tv-quiet");
     }
 
     if (getenv("ALIVECC_PARALLEL_UNRESTRICTED")) {

--- a/scripts/benchmark-llvm-test-suite.in
+++ b/scripts/benchmark-llvm-test-suite.in
@@ -25,7 +25,7 @@ export ALIVECC_SUBPROCESS_TIMEOUT=600
 export ALIVECC_SMT_TO=30000
 export ALIVECC_DISABLE_UNDEF_INPUT=1
 export ALIVECC_REPORT_DIR=$WORK/report
-export ALIVECC_SUCCINCT=1
+export ALIVECC_QUIET=1
 export ALIVECC_MAX_MEM=1000000 # we'll just let ulimit take care of this
 
 cd $WORK

--- a/tests/clang-tv/quiet.c
+++ b/tests/clang-tv/quiet.c
@@ -1,0 +1,7 @@
+// TEST-ARGS: -O3 -mllvm -tv-quiet
+
+int f(int x) {
+  return x + 1 - x;
+}
+
+// CHECK-NOT: @f


### PR DESCRIPTION
This patch fixes alivecc to use -tv-quiet instead & add a test that checks whether the option works.