### PR TITLE
split TVLegacyPass::runFunction into preparation & verify

### DIFF
--- a/tv/tv.cpp
+++ b/tv/tv.cpp
@@ -170,7 +170,8 @@ struct TVLegacyPass final : public llvm::ModulePass {
       I->second.fn_tostr = toString(I->second.fn);
     } else {
       I->second.fn = move(t.tgt);
-      I->second.fn_tostr = move(tgt_tostr);
+      // updating I->second.fn_tostr isn't necessary because two functions are
+      // equal or some error occurred.
     }
 
     I->second.n++;


### PR DESCRIPTION
To simplify implementing the batch option, this patch factors out verify part from `TVLegacyPass::runFunction`.
The new `verify` static function takes `Transform` object as well as `FnInfo` and has all the important part.
`TVLegacyPass::runFunction` mainly calls `llvm2alive` to fill the objects.

With this patch, batched opt becomes simpler because what it needs to do is to pre-build src/tgt pair and simply call this `verify` whenever an unsupported optimization is met.