### PR TITLE
Fix D99642

### DIFF
--- a/tests/alive-tv/ptrcmp/D99642.srctgt.ll
+++ b/tests/alive-tv/ptrcmp/D99642.srctgt.ll
@@ -10,7 +10,6 @@ entry:
   ; `%a` is non-null at the end of the block, because we store through it.
   ; However, `%q` is derived from `%a` via a GEP that is not `inbounds`, therefore we cannot judge `%q` is non-null as well
   ; and must retain the `icmp` instruction.
-  ; CHECK: %c = icmp eq i8* %q, null
   ret i1 %c 
 }
 


### PR DESCRIPTION
`; CHECK: %c = icmp eq i8* %q, null` in the original source confused alive2test, sorry. :/