### PR TITLE
only use provenance when comparing equality with null or same origin

### DIFF
--- a/ir/instr.h
+++ b/ir/instr.h
@@ -234,12 +234,17 @@ private:
   std::string cond_name;
   Cond cond;
   bool defined;
+  bool use_provenance = false;
   smt::expr cond_var() const;
 
 public:
   ICmp(Type &type, std::string &&name, Cond cond, Value &a, Value &b);
 
   bool isPtrCmp() const;
+  bool usesProvenance() const { return use_provenance; }
+  void setUseProvenance(bool flag) { use_provenance = flag; }
+  Cond getCond() const { return cond; }
+
   std::vector<Value*> operands() const override;
   bool propagatesPoison() const override;
   void rauw(const Value &what, Value &with) override;
@@ -610,6 +615,7 @@ public:
   void addIdx(uint64_t obj_size, Value &idx);
   Value& getPtr() const { return *ptr; }
   auto& getIdxs() const { return idxs; }
+  bool isInBounds() const { return inbounds; }
 
   uint64_t getMaxAllocSize() const override;
   uint64_t getMaxAccessSize() const override;

--- a/tests/alive-tv/opt-memory/ptrcmp-null.ident.ll
+++ b/tests/alive-tv/opt-memory/ptrcmp-null.ident.ll
@@ -1,0 +1,9 @@
+; TEST-ARGS: -dbg
+define i1 @f(i8* %p) {
+  %p2 = getelementptr inbounds i8, i8* %p, i64 0
+  %c = icmp eq i8* %p2, null
+  ret i1 %c
+}
+
+; CHECK: use_provenance
+; CHECK: has_ptr2int: 0

--- a/tests/alive-tv/opt-memory/ptrcmp-null2.ident.ll
+++ b/tests/alive-tv/opt-memory/ptrcmp-null2.ident.ll
@@ -1,0 +1,9 @@
+; TEST-ARGS: -dbg
+define i1 @f(i8* %p) {
+  %p2 = getelementptr inbounds i8, i8* %p, i64 0
+  %c = icmp eq i8* null, %p2
+  ret i1 %c
+}
+
+; CHECK: use_provenance
+; CHECK: has_ptr2int: 0

--- a/tests/alive-tv/opt-memory/ptrcmp-sameorigin.ident.ll
+++ b/tests/alive-tv/opt-memory/ptrcmp-sameorigin.ident.ll
@@ -1,0 +1,10 @@
+; TEST-ARGS: -dbg
+define i1 @f(i8* %p) {
+  %p2 = getelementptr inbounds i8, i8* %p, i64 0
+  %p3 = getelementptr inbounds i8, i8* %p, i64 1
+  %c = icmp eq i8* %p2, %p3
+  ret i1 %c
+}
+
+; CHECK: use_provenance
+; CHECK: has_ptr2int: 0

--- a/tests/alive-tv/opt-memory/ptrcmp-sameorigin2.ident.ll
+++ b/tests/alive-tv/opt-memory/ptrcmp-sameorigin2.ident.ll
@@ -1,0 +1,10 @@
+; TEST-ARGS: -dbg
+define i1 @f(i8* %p) {
+  %p2 = getelementptr i8, i8* %p, i64 0
+  %p3 = getelementptr i8, i8* %p, i64 1
+  %c = icmp eq i8* %p2, %p3
+  ret i1 %c
+}
+
+; CHECK: use_provenance
+; CHECK: has_ptr2int: 0

--- a/tests/lit/lit/formats/alive2test.py
+++ b/tests/lit/lit/formats/alive2test.py
@@ -138,9 +138,11 @@ class Alive2Test(TestFormat):
     if is_timeout(output):
       return lit.Test.PASS, ''
 
-    chk = self.regex_check.search(input)
-    if chk != None and output.find(chk.group(1).strip()) == -1:
-      return lit.Test.FAIL, output
+    # allow multiple 'CHECK: ..'
+    chks = self.regex_check.findall(input)
+    for chk in chks:
+      if output.find(chk.strip()) == -1:
+        return lit.Test.FAIL, output
 
     chk_not = self.regex_check_not.search(input)
     if chk_not != None and output.find(chk_not.group(1).strip()) != -1:
@@ -152,7 +154,8 @@ class Alive2Test(TestFormat):
       return lit.Test.FAIL, output
 
     expect_err = self.regex_errs.search(input)
-    if expect_err is None and xfail is None and chk is None and chk_not is None:
+    if expect_err is None and xfail is None and len(chks) == 0 and \
+       chk_not is None:
       # If there's no other test, correctness of the transformation should be
       # checked.
       if exitCode == 0 and output.find(ok_string) != -1 and \

--- a/tools/transform.cpp
+++ b/tools/transform.cpp
@@ -828,7 +828,7 @@ static void calculateAndInitConstants(Transform &t) {
         min_access_size = gcd(min_access_size, getCommonAccessSize(t));
 
       } else if (auto *ic = dynamic_cast<const ICmp*>(&i)) {
-        has_ptr2int |= ic->isPtrCmp()  && !ic->usesProvenance();
+        has_ptr2int |= ic->isPtrCmp() && !ic->usesProvenance();
       }
     }
   }


### PR DESCRIPTION
This is a patch that optimizes pointer comparison encoding by comparing provenance only if one of these two conditions is met:

- p == null where p is inbounds
- p == q where p and q share the same origin