### PR TITLE
getMaxAllocSize should consider alignment

### DIFF
--- a/tests/alive-tv/memory/compare-alloca.ll
+++ b/tests/alive-tv/memory/compare-alloca.ll
@@ -1,0 +1,12 @@
+target datalayout = "p:32:32"
+
+define i1 @src(i64* %arg) {
+  %alloc = alloca i64
+  %cmp = icmp eq i64* %arg, %alloc
+  ret i1 %cmp
+}
+
+define i1 @tgt(i64* %arg) {
+  ret i1 false
+}
+


### PR DESCRIPTION
This fixes the regression of `Transforms/InstCombine/compare-alloca.ll`.

```
define i1 @src(i64* %arg) {
  %alloc = alloca i64
  %cmp = icmp eq i64* %arg, %alloc
  ret i1 %cmp
}

define i1 @tgt(i64* %arg) {
  ret i1 false
}
```

This failed because `bits_size_t` was too small.
It caused `%alloc` to be located in only one place in the memory, so properly guessing `%arg` could make the comparison always true.
`bits_size_t` was set to 5, so `%alloc` should be somewhere at `10000 ~ 11111`.
However, `%alloc`'s size is 8 and it has alignment 8, so only `10000` was the possible choice. `11000` doesn't work because adding 8 overflows.

To fix this, I updated `getMaxAllocSize` to consider alignment as well because it is the true size that occupies memory.