### PR TITLE
clang plugin: the messages before getline should be clipped out

### DIFF
--- a/util/parallel.cpp
+++ b/util/parallel.cpp
@@ -225,7 +225,7 @@ bool parallel::emitOutput() {
          */
         stringstream new_ss;
         new_ss << line << '\n';
-        new_ss << parent_ss.str().substr(parent_ss.tellg());
+        new_ss << move(parent_ss).str().substr(parent_ss.tellg());
         parent_ss.swap(new_ss);
         return false;
       }

--- a/util/parallel.cpp
+++ b/util/parallel.cpp
@@ -206,8 +206,6 @@ bool parallel::emitOutput() {
   ensureParent();
   std::string line;
   std::regex rgx("^include\\(([0-9]+)\\)$");
-
-  auto befpos = parent_ss.tellg();
   while (getline(parent_ss, line)) {
     std::smatch sm;
     if (std::regex_match(line, sm, rgx)) {
@@ -217,14 +215,24 @@ bool parallel::emitOutput() {
         out_file << children[index].output.str();
         stringstream().swap(children[index].output); // free the RAM
       } else {
-        parent_ss.seekg(befpos);
+        /*
+         * here, for two reasons, we swap parent_ss with a fresh one
+         * containing a copy of the unwritten data. first, we've
+         * already grabbed one line too many from parent_ss, and we
+         * don't have a good way to put it back. second, we want to
+         * free the RAM associated with data we've already read out of
+         * the stringstream.
+         */
+        stringstream new_ss;
+        new_ss << line << '\n';
+        new_ss << parent_ss.str().substr(parent_ss.tellg());
+        parent_ss.swap(new_ss);
         return false;
       }
     } else {
       assert(line.rfind("include(", 0) == std::string::npos);
       out_file << line << '\n';
     }
-    befpos = parent_ss.tellg();
   }
   /*
    * reset the EOF flag since this process is going to keep writing

--- a/util/parallel.cpp
+++ b/util/parallel.cpp
@@ -225,7 +225,7 @@ bool parallel::emitOutput() {
          */
         stringstream new_ss;
         new_ss << line << '\n';
-        new_ss << parent_ss.str();
+        new_ss << parent_ss.str().substr(parent_ss.tellg());
         parent_ss.swap(new_ss);
         return false;
       }


### PR DESCRIPTION
This fixes #720 by fixing `parallel::emitOutput()` to clip out the lines before the line read by `getline`.

An example: https://gist.github.com/aqjune/2ea18cefa4fc1fd98ba1e47ddeab5f97

I never knew that `sstream::str` has the full string even if it is being consumed :(