### PR TITLE
clang plugin: let stats cmd flag work by printing it when child exits

### DIFF
--- a/ir/memory.cpp
+++ b/ir/memory.cpp
@@ -607,16 +607,20 @@ void Memory::AliasSet::printStats(ostream &os) {
   os << fixed;
 
   os << "\n\nAlias sets statistics\n=====================\n"
-        "Only local:     " << (only_local / total)
-     << "%\nOnly non-local: " << (only_nonlocal / total)
-     << "%\n\nBuckets:\n";
+        "Only local:     " << only_local
+     << " (" << (only_local / total)
+     << "%)\nOnly non-local: " << only_nonlocal
+     << " (" << (only_nonlocal / total)
+     << "%)\n\nBuckets:\n";
 
   for (unsigned i = 0; i < alias_buckets_vals.size(); ++i) {
     os << "\u2264 " << alias_buckets_vals[i] << ": "
-       << (alias_buckets_hits[i] / total) << "%\n";
+       << alias_buckets_hits[i]
+       << " (" << (alias_buckets_hits[i] / total) << "%)\n";
   }
   os << "> " << alias_buckets_vals.back() << ": "
-     << (alias_buckets_hits.back() / total) << "%\n";
+     << alias_buckets_hits.back()
+     << " (" << (alias_buckets_hits.back() / total) << "%)\n";
 }
 
 void Memory::AliasSet::print(ostream &os) const {

--- a/tests/clang-tv/parallel-alias-stats.c
+++ b/tests/clang-tv/parallel-alias-stats.c
@@ -1,0 +1,7 @@
+// TEST-ARGS: -O3 -mllvm -tv-alias-stats -mllvm -tv-parallel=unrestricted -mllvm --max-subprocesses=2
+
+int f(int *x, int *y) {
+  return *x + *y;
+}
+
+// CHECK: Alias sets statistics


### PR DESCRIPTION
Currently clang plugin's `-mllvm -tv-alias-stats` isn't working because the statistics accumulated in the child process isn't being summed up to the parent process.

This is a small patch that makes children to print the statistics.
