### PR TITLE
Fix build with fresh clang

### DIFF
--- a/tools/transform.cpp
+++ b/tools/transform.cpp
@@ -777,7 +777,6 @@ static void calculateAndInitConstants(Transform &t) {
   unsigned min_vect_elem_sz = 0;
   bool does_mem_access = false;
   bool has_ptr_load = false;
-  bool has_vector_bitcast = false;
 
   for (auto fn : { &t.src, &t.tgt }) {
     unsigned &cur_num_locals = fn == &t.src ? num_locals_src : num_locals_tgt;
@@ -870,7 +869,6 @@ static void calculateAndInitConstants(Transform &t) {
 
       } else if (auto *bc = isCast(ConversionOp::BitCast, i)) {
         auto &t = bc->getType();
-        has_vector_bitcast |= t.isVectorType();
         min_access_size = gcd(min_access_size, getCommonAccessSize(t));
 
       } else if (auto *ic = dynamic_cast<const ICmp*>(&i)) {


### PR DESCRIPTION
```
[ 50% 28/55][ 30% 0:00:02 + 0:00:05] Building CXX object CMakeFiles/tools.dir/tools/transform.cpp.o
FAILED: CMakeFiles/tools.dir/tools/transform.cpp.o
/usr/local/bin/clang++  -I../ -I. -I/repositories/llvm-project/llvm/include -I/builddirs/llvm-project/build-Clang12/include -Wall -Werror -march=native -fPIC  -O3 -O3    -D_GNU_SOURCE -D_DEBUG -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -std=c++20 -MD -MT CMakeFiles/tools.dir/tools/transform.cpp.o -MF CMakeFiles/tools.dir/tools/transform.cpp.o.d -o CMakeFiles/tools.dir/tools/transform.cpp.o -c ../tools/transform.cpp
../tools/transform.cpp:780:8: error: variable 'has_vector_bitcast' set but not used [-Werror,-Wunused-but-set-variable]
  bool has_vector_bitcast = false;
       ^
1 error generated.
[ 76% 42/55][ 94% 0:00:06 + 0:00:00] Building CXX object CMakeFiles/alive-tv.dir/tools/alive-tv.cpp.o
ninja: build stopped: subcommand failed.

```