### PR TITLE
Add extract_value as a side effect-less instruction

### DIFF
--- a/ir/instr.cpp
+++ b/ir/instr.cpp
@@ -3871,7 +3871,8 @@ const ConversionOp* isCast(ConversionOp::Op op, const Value &v) {
 bool hasNoSideEffects(const Instr &i) {
   return isNoOp(i) ||
          dynamic_cast<const GEP*>(&i) ||
-         dynamic_cast<const ShuffleVector*>(&i);
+         dynamic_cast<const ShuffleVector*>(&i) ||
+         dynamic_cast<const ExtractValue*>(&i);
 }
 
 Value* isNoOp(const Value &v) {

--- a/ir/instr.cpp
+++ b/ir/instr.cpp
@@ -3870,9 +3870,9 @@ const ConversionOp* isCast(ConversionOp::Op op, const Value &v) {
 
 bool hasNoSideEffects(const Instr &i) {
   return isNoOp(i) ||
+         dynamic_cast<const ExtractValue*>(&i) ||
          dynamic_cast<const GEP*>(&i) ||
-         dynamic_cast<const ShuffleVector*>(&i) ||
-         dynamic_cast<const ExtractValue*>(&i);
+         dynamic_cast<const ShuffleVector*>(&i);
 }
 
 Value* isNoOp(const Value &v) {


### PR DESCRIPTION
Adds `extract_value` as a side effect-less instruction.

As a caution:

I noticed that pre-processing and the dead code elimination step runs before the typechecking/index checking of `extractvalue` when passing the IR straight into the verifier (bypassing the parser).

(See: https://github.com/AliveToolkit/alive2/blob/e7805d6f5eadd0e10b49f8a4470f7754777dbdbb/tv/tv.cpp#L256)

 This means that if we have some code along the lines of:

```
  %1006_0 = sadd_overflow {i32, i1, i24} noundef %187, noundef %188
  %1006_1 = extractvalue {i32, i1, i24} %1006_0, 13
```

and `%1006_1` is unused, then we will optimize it out and no typecheck error will be thrown.

I'm not sure if we want to preserve these typechecking errors, or even throw them earlier so they get caught before preprocessing, but that will need to be taken into consideration before merging this PR.