### PR TITLE
Signed comparison of pointers must compare underlying addrs

### DIFF
--- a/tests/alive-tv/ptrcmp/slt.srctgt.ll
+++ b/tests/alive-tv/ptrcmp/slt.srctgt.ll
@@ -13,5 +13,3 @@ entry:
   %cmp = icmp slt i8* %first1, %last1
   ret i1 %cmp
 }
-
-

--- a/tests/alive-tv/ptrcmp/slt.srctgt.ll
+++ b/tests/alive-tv/ptrcmp/slt.srctgt.ll
@@ -1,0 +1,17 @@
+define i1 @src(i8* %ptr) {
+entry:
+  %first1 = getelementptr inbounds i8, i8* %ptr, i32 0
+  %last1 = getelementptr inbounds i8, i8* %ptr, i32 42
+  %cmp = icmp slt i8* %first1, %last1
+  ret i1 %cmp
+}
+
+define i1 @tgt(i8* %ptr) {
+entry:
+  %first1 = getelementptr inbounds i8, i8* %ptr, i32 0
+  %last1 = getelementptr i8, i8* %ptr, i32 42
+  %cmp = icmp slt i8* %first1, %last1
+  ret i1 %cmp
+}
+
+

--- a/tools/transform.cpp
+++ b/tools/transform.cpp
@@ -1342,6 +1342,8 @@ static void optimize_ptrcmp(Function &f) {
 
     auto cond = icmp->getCond();
     bool is_eq = cond == ICmp::EQ || cond == ICmp::NE;
+    bool is_signed_cmp = cond == ICmp::SLE || cond == ICmp::SLT ||
+                         cond == ICmp::SGE || cond == ICmp::SGT;
 
     auto ops = icmp->operands();
     auto *op0 = ops[0];
@@ -1358,7 +1360,10 @@ static void optimize_ptrcmp(Function &f) {
     if (base0 && base0 == base1) {
       if (is_eq)
         const_cast<ICmp*>(icmp)->setPtrCmpMode(ICmp::PROVENANCE);
-      else if (is_inbounds(*op0) && is_inbounds(*op1))
+      else if (is_inbounds(*op0) && is_inbounds(*op1) && !is_signed_cmp)
+        // Even if op0 and op1 are inbounds, 'icmp slt op0, op1' must
+        // compare underlying addresses because it is possible for the block
+        // to span across [a, b] where a >s 0 && b <s 0.
         const_cast<ICmp*>(icmp)->setPtrCmpMode(ICmp::OFFSETONLY);
     }
   }


### PR DESCRIPTION
This fixes a bug due to an incorrect ptr comparison encoding.

Consider `p = gep inbounds p0, 0`, `q = gep inbounds p0, 1` where p0 points to the beginning of some block.

`icmp slt p, q` cannot be optimized to a comparison of their block offsets `icmp slt 0, 1` because the block p0's address may be 0x7fffffff (which is signed_int_max).
In this case, q=p+1 is 0x80000001, which is signed_int_min.

Therefore, `icmp slt p, q` is false, whereas `icmp slt 0, 1` is true.



The counter example of `slt.srctgt.ll` shows the case:

```
ERROR: Value mismatch                                
                                                           
Example:                                             
* %ptr = pointer(non-local, block_id=1, offset=5)    
                                                                                                                       
Source: 
* %first1 = pointer(non-local, block_id=1, offset=5)
* %last1 = pointer(non-local, block_id=1, offset=47)  
i1 %cmp = #x1 (1)              
                                                           
SOURCE MEMORY STATE      
===================                                                                                                    
NON-LOCAL BLOCKS:
Block 0 >       size: 0 align: 1        alloc type: 0   address: 0
Block 1 >       size: 64        align: 1        alloc type: 0   address: 103
                                                                                                                       
Target:                                                                                                                
* %first1 = pointer(non-local, block_id=1, offset=5)     <----- 103+5=108: less than sign_int_max (127)
* %last1 = pointer(non-local, block_id=1, offset=47)   <----- 103+47=150: overflows sign_int_max
i1 %cmp = #x0 (0)                                                                                                      
Source value: #x1 (1)                                    
Target value: #x0 (0)                                                                                                  
```
