### PR TITLE
fptosi/fptoui must convert (-1.0, -0.0) to 0, not poison

### DIFF
--- a/ir/instr.cpp
+++ b/ir/instr.cpp
@@ -1260,11 +1260,8 @@ StateValue ConversionOp::toSMT(State &s) const {
       expr bv  = val.fp2sint(to_type.bits());
       expr fp2 = bv.sint2fp(val);
       // -0.xx is converted to 0 and then to 0.0, though -0.xx is ok to convert
-      expr minus_one = expr::mkFloat(-1.0, val);
-      expr minus_zero = expr::mkFloat(-0.0, val);
-      return { move(bv),
-          (val.fogt(minus_one) && val.fole(minus_zero)) ||
-          fp2 == val.roundtz() };
+      expr valrtz = val.roundtz();
+      return { move(bv), valrtz.isFPZero() || fp2 == valrtz };
     };
     break;
   case FPToUInt:
@@ -1272,11 +1269,8 @@ StateValue ConversionOp::toSMT(State &s) const {
       expr bv  = val.fp2uint(to_type.bits());
       expr fp2 = bv.uint2fp(val);
       // -0.xx must be converted to 0, not poison.
-      expr minus_one = expr::mkFloat(-1.0, val);
-      expr minus_zero = expr::mkFloat(-0.0, val);
-      return { move(bv),
-          (val.fogt(minus_one) && val.fole(minus_zero)) ||
-          fp2 == val.roundtz() };
+      expr valrtz = val.roundtz();
+      return { move(bv), valrtz.isFPZero() || fp2 == valrtz };
     };
     break;
   case FPExt:

--- a/ir/instr.cpp
+++ b/ir/instr.cpp
@@ -1277,7 +1277,6 @@ StateValue ConversionOp::toSMT(State &s) const {
       return { move(bv),
           (val.fogt(minus_one) && val.fole(minus_zero)) ||
           fp2 == val.roundtz() };
-      return { move(bv), fp2 == val.roundtz() };
     };
     break;
   case FPExt:

--- a/tests/alive-tv/fp/D113543-fptosi.srctgt.ll
+++ b/tests/alive-tv/fp/D113543-fptosi.srctgt.ll
@@ -1,0 +1,8 @@
+define i16 @src() {
+  ret i16 0
+}
+
+define i16 @tgt() {
+  %a = fptosi half -0.25 to i16
+  ret i16 %a
+}

--- a/tests/alive-tv/fp/D113543-fptoui.srctgt.ll
+++ b/tests/alive-tv/fp/D113543-fptoui.srctgt.ll
@@ -1,0 +1,8 @@
+define i16 @src() {
+  ret i16 0
+}
+
+define i16 @tgt() {
+  %a = fptoui half -0.25 to i16
+  ret i16 %a
+}


### PR DESCRIPTION
This fixes bugs reported in https://reviews.llvm.org/D113543.

fptosi/fptoui's poison checking expressions were as follows:
```
      expr bv  = val.fp2sint(to_type.bits());
      expr fp2 = bv.sint2fp(val);
      // -0.0 is converted to 0 and then to 0.0, though -0.0 is ok to convert
      return { move(bv), val.isFPZero() || fp2 == val.roundtz() };
```
If the input (`val`) was -0.5, `bv` is 0, `fp2` is +0.0.
Therefore, `fp2 == val.roundtz()` is false because `val.roundtz()` is -0.0.

To fix this, the poison condition's first part (`val.isFPZero()`) is replaced with a range check.