### PR TITLE
Fix build

### DIFF
--- a/util/parallel.cpp
+++ b/util/parallel.cpp
@@ -4,6 +4,7 @@
 #include "util/parallel.h"
 #include "util/compiler.h"
 #include <cassert>
+#include <cstring>
 #include <fcntl.h>
 #include <fstream>
 #include <regex>
@@ -181,7 +182,7 @@ void parallel::finishChild(bool is_timeout) {
   ensureChild();
   if (is_timeout) {
     const char *msg = "ERROR: Timeout asynchronous\n\n";
-    safe_write(fd_to_parent, msg, strlen(msg));
+    safe_write(fd_to_parent, msg, std::strlen(msg));
   } else {
     childProcess &me = children.back();
     auto data = move(me.output).str();


### PR DESCRIPTION
```
$ ninja
[ 46% 26/56][ 26% 0:00:01 + 0:00:05] Building CXX object CMakeFiles/util.dir/util/parallel.cpp.o
FAILED: CMakeFiles/util.dir/util/parallel.cpp.o
/usr/local/bin/clang++  -I/repositories/alive2 -I/repositories/alive2/build-Clang-release -I/repositories/llvm-project/llvm/include -I/builddirs/llvm-project/build-Clang13/include -Wall -Werror -fPIC  -O3 -O3    -D_GNU_SOURCE -D_DEBUG -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -std=c++20 -MD -MT CMakeFiles/util.dir/util/parallel.cpp.o -MF CMakeFiles/util.dir/util/parallel.cpp.o.d -o CMakeFiles/util.dir/util/parallel.cpp.o -c /repositories/alive2/util/parallel.cpp
/repositories/alive2/util/parallel.cpp:184:35: error: use of undeclared identifier 'strlen'
    safe_write(fd_to_parent, msg, strlen(msg));
                                  ^
1 error generated.
[ 76% 43/56][ 94% 0:00:06 + 0:00:00] Building CXX object CMakeFiles/ir.dir/ir/instr.cpp.o
ninja: build stopped: subcommand failed.

```