### PR TITLE
Add missing include of <bit>

### DIFF
--- a/tools/transform.cpp
+++ b/tools/transform.cpp
@@ -13,6 +13,7 @@
 #include "util/stopwatch.h"
 #include "util/symexec.h"
 #include <algorithm>
+#include <bit>
 #include <climits>
 #include <iostream>
 #include <map>


### PR DESCRIPTION
std::bit_width is is defined in <bit> and used in the file.

The missing include can cause build failures with certain libc++
versions, as it is not included by accident through some other includes.