### PR TITLE
save IR to disk in the report directory from the plugin, if asked to

### DIFF
--- a/llvm_util/cmd_args_list.h
+++ b/llvm_util/cmd_args_list.h
@@ -130,6 +130,11 @@ llvm::cl::opt<string> opt_report_dir(LLVM_ARGS_PREFIX "report-dir",
 bool report_dir_created = false;
 string report_filename;
 
+llvm::cl::opt<bool> opt_save_ir(LLVM_ARGS_PREFIX "save-ir",
+  llvm::cl::desc("Save LLVM IR into the report directory upon encountering a "
+                 "verification error"),
+  llvm::cl::init(false), llvm::cl::cat(alive_cmdargs));
+
 llvm::cl::opt<bool> opt_overwrite_reports(LLVM_ARGS_PREFIX "overwrite-reports",
   llvm::cl::desc("Overwrite existing report files"),
   llvm::cl::init(false), llvm::cl::cat(alive_cmdargs));

--- a/scripts/alivecc.in
+++ b/scripts/alivecc.in
@@ -80,6 +80,10 @@ if (compiling()) {
         push @ARGV, ("-mllvm", "-tv-report-dir=".$dir);
     }
 
+    if (my $logir = getenv("ALIVECC_SAVE_IR")) {
+        push @ARGV, ("-mllvm", "-tv-save-ir");
+    }
+
     # sanity check: make sure we intercepted all environment variables
     # of the form ALIVECC_*
     foreach my $e (keys %ENV) {


### PR DESCRIPTION
the strategy is to save bitcode from the child process, meaning that the same module could end up being saved multiple times. we finesse this by writing to a temp file and then atomically renaming it.

I don't have a windows machine available to test this but I'll watch the buildbots...

the next part of this patchset will record command line options -- at that point we should have enough information to automatically run llvm-reduce on errors found by the plugin