### PR TITLE
linux-specific code for printing the command line args from the opt

### DIFF
--- a/tv/tv.cpp
+++ b/tv/tv.cpp
@@ -108,6 +108,23 @@ static void showStats() {
     IR::Memory::printAliasStats(*out);
 }
 
+static void emitCommandLine(ostream *out) {
+#ifdef __linux__
+  ifstream cmd_args;
+  cmd_args.open("/proc/self/cmdline");
+  if (!cmd_args.is_open()) {
+    cerr << "Alive2: Couldn't open /proc/self/cmdline" << endl;
+    exit(1);
+  }
+  *out << "Command line: ";
+  std::string arg;
+  while (std::getline(cmd_args, arg, '\0'))
+    *out << "'" << arg << "' ";
+#else
+  *out << "Command line: not available on this platform";
+#endif
+  *out << "\n\n";
+}
 
 struct TVLegacyPass final : public llvm::ModulePass {
   static char ID;
@@ -267,6 +284,8 @@ struct TVLegacyPass final : public llvm::ModulePass {
       has_failure |= errs.isUnsound();
       if (opt_error_fatal && has_failure)
         finalize();
+      if (errs.isUnsound())
+        emitCommandLine(out);
     } else {
       *out << "Transformation seems to be correct!\n\n";
     }


### PR DESCRIPTION
pass when an unsound transformation is detected

this'll conflict with my other patch from today but resolving is trivial, I'm happy to fix which ever one lands second