### PR TITLE
save IR file to disk when encountering an unsoundness

### DIFF
--- a/llvm_util/cmd_args_def.h
+++ b/llvm_util/cmd_args_def.h
@@ -39,6 +39,8 @@ if (!report_dir_created && !opt_report_dir.empty()) {
   if (!opt_overwrite_reports) {
     do {
       auto newname = fname.stem();
+      if (newname.compare("-") == 0 || newname.compare("<stdin>") == 0)
+        newname = "";
       newname += "_" + get_random_str(8) + ".txt";
       path.replace_filename(newname);
     } while (fs::exists(path));

--- a/llvm_util/cmd_args_list.h
+++ b/llvm_util/cmd_args_list.h
@@ -128,7 +128,12 @@ llvm::cl::opt<string> opt_report_dir(LLVM_ARGS_PREFIX "report-dir",
   llvm::cl::cat(alive_cmdargs));
 
 bool report_dir_created = false;
-string report_filename;
+fs::path report_filename;
+
+llvm::cl::opt<bool> opt_save_ir(LLVM_ARGS_PREFIX "save-ir",
+  llvm::cl::desc("Save LLVM IR into the report directory upon encountering a "
+                 "verification error"),
+  llvm::cl::init(false), llvm::cl::cat(alive_cmdargs));
 
 llvm::cl::opt<bool> opt_overwrite_reports(LLVM_ARGS_PREFIX "overwrite-reports",
   llvm::cl::desc("Overwrite existing report files"),

--- a/scripts/alivecc.in
+++ b/scripts/alivecc.in
@@ -80,6 +80,10 @@ if (compiling()) {
         push @ARGV, ("-mllvm", "-tv-report-dir=".$dir);
     }
 
+    if (my $logir = getenv("ALIVECC_SAVE_IR")) {
+        push @ARGV, ("-mllvm", "-tv-save-ir");
+    }
+
     # sanity check: make sure we intercepted all environment variables
     # of the form ALIVECC_*
     foreach my $e (keys %ENV) {

--- a/scripts/repro.in
+++ b/scripts/repro.in
@@ -1,0 +1,45 @@
+#!/usr/bin/perl -w
+
+use strict;
+
+# run this script in a log directory where Alive2 has been asked to
+# save IR files that result in unsoundness
+
+sub repro($$) {
+    (my $logfn, my $cmd) = @_;
+    my $bcfn = $logfn;
+    die unless $bcfn =~ s/\.txt$/.bc/;
+    die unless $cmd =~ s/\'\-tv\-report\-dir\=(.*?)\' //;
+    my $command = "$cmd < $bcfn 2>&1 |";
+    print "$command\n";
+    open my $OUTPUT, "$command" or die;
+    while (my $line = <$OUTPUT>) {
+        if ($line =~ /\(unsound\)/) {
+            print $line;
+        }
+    }
+    print "\n";
+}
+
+sub process($) {
+    (my $fn) = @_;
+    open my $INF, "<$fn" or die;
+    my $unsound = 0;
+    my $cmd = "";
+    while (my $line = <$INF>) {
+        $unsound = 1 if ($line =~ /\(unsound\)/);
+        if ($unsound && $line =~ /^Command line: (.*)$/) {
+            $cmd = $1;
+        }
+    }
+    close $INF;
+    if ($unsound) {
+        repro($fn, $cmd);
+    }
+}
+
+my @logfiles = glob "*.txt";
+
+foreach my $fn (@logfiles) {
+    process($fn);
+}

--- a/tv/CMakeLists.txt
+++ b/tv/CMakeLists.txt
@@ -6,6 +6,11 @@ else()
 endif()
 
 configure_file(
+  ${CMAKE_SOURCE_DIR}/scripts/repro.in
+  ${CMAKE_BINARY_DIR}/repro
+  @ONLY
+)
+configure_file(
   ${CMAKE_SOURCE_DIR}/scripts/alivecc.in
   ${CMAKE_BINARY_DIR}/alivecc
   @ONLY


### PR DESCRIPTION
ok this time I've included a silly perl script that reproduces all ~57 unsoundnesses that happen when running over the LLVM unit tests.

Nuno I would argue that this approach (saving the original IR, and not trying to grab it just before the unsound transform) is the correct one. or if I'm wrong, at least this is simpler and we should go with it for now.

you'll notice an apparently spurious reset of MClone in `finalize()`, this is necessary the prevent a crash in the module destructor, I don't know what's going on but I don't think it's our bug (Yuyou noticed some bugs in MClone where it does not completely separate the new module from the old one -- this could lead to a crash if the original module is destructed before the cloned one)