### PR TITLE
fix build with latest version of llvm

### DIFF
--- a/llvm_util/known_fns.cpp
+++ b/llvm_util/known_fns.cpp
@@ -447,12 +447,12 @@ known_call(llvm::CallInst &i, const llvm::TargetLibraryInfo &TLI,
     RETURN_VAL(
       make_unique<Malloc>(*ty, value_name(i), *args[0], isNonNull, align(i)));
   }
-  if (llvm::isReallocLikeFn(&i, &TLI)) {
+  if (llvm::getReallocatedOperand(&i, &TLI)) {
     bool isNonNull = i.hasRetAttr(llvm::Attribute::NonNull);
     RETURN_VAL(make_unique<Malloc>(*ty, value_name(i), *args[0], *args[1],
                                    isNonNull, align(i)));
   }
-  if (llvm::isFreeCall(&i, &TLI)) {
+  if (llvm::getFreedOperand(&i, &TLI)) {
     if (i.hasFnAttr(llvm::Attribute::NoFree)) {
       auto zero = make_intconst(0, 1);
       RETURN_VAL(make_unique<Assume>(*zero, Assume::AndNonPoison));


### PR DESCRIPTION
Attempt to fix the following build issue that occurs with latest version of llvm

```
regehr@ohm:~/alive2-nader/build$ ninja
[45/71] Building CXX object CMakeFiles/llvm_util.dir/llvm_util/known_fns.cpp.o
FAILED: CMakeFiles/llvm_util.dir/llvm_util/known_fns.cpp.o 
/home/regehr/llvm-project-14.0.6.src/build/bin/clang++  -I/home/regehr/alive2-nader -I/home/regehr/alive2-nader/build -I/home/regehr/llvm-project/llvm/include -I/home/regehr/llvm-project/for-alive/include -I/home/regehr/llvm-project/for-alive/lib -Wall -Werror -fPIC -fstrict-enums  -O3 -O3    -D_GNU_SOURCE -D_DEBUG -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -std=c++20 -MD -MT CMakeFiles/llvm_util.dir/llvm_util/known_fns.cpp.o -MF CMakeFiles/llvm_util.dir/llvm_util/known_fns.cpp.o.d -o CMakeFiles/llvm_util.dir/llvm_util/known_fns.cpp.o -c /home/regehr/alive2-nader/llvm_util/known_fns.cpp
/home/regehr/alive2-nader/llvm_util/known_fns.cpp:450:29: error: cannot initialize a parameter of type 'const llvm::Function *' with an rvalue of type 'llvm::CallInst *'
  if (llvm::isReallocLikeFn(&i, &TLI)) {
                            ^~
/home/regehr/llvm-project/llvm/include/llvm/Analysis/MemoryBuiltins.h:70:38: note: passing argument to parameter 'F' here
bool isReallocLikeFn(const Function *F, const TargetLibraryInfo *TLI);
                                     ^
/home/regehr/alive2-nader/llvm_util/known_fns.cpp:455:13: error: no member named 'isFreeCall' in namespace 'llvm'
  if (llvm::isFreeCall(&i, &TLI)) {
      ~~~~~~^
2 errors generated.
[57/71] Building CXX object CMakeFiles/ir.dir/ir/instr.cpp.o
```