### PR TITLE
save IR file to disk when encountering an unsoundness

### DIFF
--- a/llvm_util/cmd_args_def.h
+++ b/llvm_util/cmd_args_def.h
@@ -39,6 +39,8 @@ if (!report_dir_created && !opt_report_dir.empty()) {
   if (!opt_overwrite_reports) {
     do {
       auto newname = fname.stem();
+      if (newname.compare("-") == 0 || newname.compare("<stdin>") == 0)
+        newname = "";
       newname += "_" + get_random_str(8) + ".txt";
       path.replace_filename(newname);
     } while (fs::exists(path));

--- a/llvm_util/cmd_args_list.h
+++ b/llvm_util/cmd_args_list.h
@@ -128,7 +128,12 @@ llvm::cl::opt<string> opt_report_dir(LLVM_ARGS_PREFIX "report-dir",
   llvm::cl::cat(alive_cmdargs));
 
 bool report_dir_created = false;
-string report_filename;
+fs::path report_filename;
+
+llvm::cl::opt<bool> opt_save_ir(LLVM_ARGS_PREFIX "save-ir",
+  llvm::cl::desc("Save LLVM IR into the report directory upon encountering a "
+                 "verification error"),
+  llvm::cl::init(false), llvm::cl::cat(alive_cmdargs));
 
 llvm::cl::opt<bool> opt_overwrite_reports(LLVM_ARGS_PREFIX "overwrite-reports",
   llvm::cl::desc("Overwrite existing report files"),

--- a/scripts/alivecc.in
+++ b/scripts/alivecc.in
@@ -80,6 +80,10 @@ if (compiling()) {
         push @ARGV, ("-mllvm", "-tv-report-dir=".$dir);
     }
 
+    if (my $logir = getenv("ALIVECC_SAVE_IR")) {
+        push @ARGV, ("-mllvm", "-tv-save-ir");
+    }
+
     # sanity check: make sure we intercepted all environment variables
     # of the form ALIVECC_*
     foreach my $e (keys %ENV) {


### PR DESCRIPTION
want to look this over Nuno? it works for a few examples I tried (in the sense that it dumps a bitcode file that repros the original error using the pass that's printed) but I don't want to polish if it's not what you're looking for here