### PR TITLE
fix build failure due to unused capture signaled by clang

### DIFF
--- a/llvm_util/llvm2alive.cpp
+++ b/llvm_util/llvm2alive.cpp
@@ -672,7 +672,7 @@ public:
     llvm::SmallVector<const llvm::Value *> Objs;
     llvm::getUnderlyingObjects(Ptr, Objs);
 
-    if (llvm::all_of(Objs, [this](const llvm::Value *V) {
+    if (llvm::all_of(Objs, [](const llvm::Value *V) {
         // Stack coloring algorithm doesn't assign slots for global variables
         // or objects passed as pointer arguments
         return llvm::isa<llvm::Argument,


### PR DESCRIPTION
if clang is wrong here then this isn't the correct fix, but this is stopping me from building latest alive2 using clang