### PR TITLE
Ignore unsupported metadata in target functions.

### DIFF
--- a/llvm_util/llvm2alive.cpp
+++ b/llvm_util/llvm2alive.cpp
@@ -99,6 +99,9 @@ class llvm2alive_ : public llvm::InstVisitor<llvm2alive_, unique_ptr<Instr>> {
   BasicBlock *BB;
   llvm::Function &f;
   const llvm::TargetLibraryInfo &TLI;
+  /// True if converting a source function, false when converting a target
+  /// function.
+  bool IsSrc;
   vector<llvm::Instruction*> i_constexprs;
   const vector<string_view> &gvnamesInSrc;
   vector<pair<Phi*, llvm::PHINode*>> todo_phis;
@@ -167,9 +170,10 @@ class llvm2alive_ : public llvm::InstVisitor<llvm2alive_, unique_ptr<Instr>> {
   }
 
 public:
-  llvm2alive_(llvm::Function &f, const llvm::TargetLibraryInfo &TLI,
+  llvm2alive_(llvm::Function &f, const llvm::TargetLibraryInfo &TLI, bool IsSrc,
               const vector<string_view> &gvnamesInSrc)
-      : f(f), TLI(TLI), gvnamesInSrc(gvnamesInSrc), out(&get_outs()) {}
+      : f(f), TLI(TLI), IsSrc(IsSrc), gvnamesInSrc(gvnamesInSrc),
+        out(&get_outs()) {}
 
   ~llvm2alive_() {
     for (auto &inst : i_constexprs) {
@@ -1221,6 +1225,10 @@ public:
         break;
 
       default:
+        // For the target, dropping metadata is fine as metadata will never turn
+        // a incorrect function into a correct one.
+        if (!IsSrc)
+          break;
         *out << "ERROR: Unsupported metadata: " << ID << '\n';
         return false;
       }
@@ -1683,8 +1691,8 @@ initializer::initializer(ostream &os, const llvm::DataLayout &DL) {
 
 optional<IR::Function> llvm2alive(llvm::Function &F,
                                   const llvm::TargetLibraryInfo &TLI,
+                                  bool IsSrc,
                                   const vector<string_view> &gvnamesInSrc) {
-  return llvm2alive_(F, TLI, gvnamesInSrc).run();
+  return llvm2alive_(F, TLI, IsSrc, gvnamesInSrc).run();
 }
-
 }

--- a/llvm_util/llvm2alive.h
+++ b/llvm_util/llvm2alive.h
@@ -21,7 +21,7 @@ struct initializer {
   initializer(std::ostream &os, const llvm::DataLayout &DL);
 };
 
-std::optional<IR::Function> llvm2alive(llvm::Function &F,
-    const llvm::TargetLibraryInfo &TLI,
-    const std::vector<std::string_view> &gvnamesInSrc = {});
+std::optional<IR::Function>
+llvm2alive(llvm::Function &F, const llvm::TargetLibraryInfo &TLI, bool IsSrc,
+           const std::vector<std::string_view> &gvnamesInSrc = {});
 }

--- a/tests/alive-tv/unsupported.metadata.in.src.srctgt.ll
+++ b/tests/alive-tv/unsupported.metadata.in.src.srctgt.ll
@@ -1,0 +1,21 @@
+define i1 @src(i8* %a, i8* %b) {
+  %l = load i8, i8* %a, !alias.scope !0, !noalias !3
+  store i8 %l, i8* %b, !alias.scope !0, !noalias !3
+  ret i1 false
+}
+
+define i1 @tgt(i8* %a, i8* %b) {
+  %l = load i8, i8* %a, !alias.scope !0, !noalias !3
+  store i8 %l, i8* %b, !alias.scope !0, !noalias !3
+  ret i1 true
+}
+
+; ERROR: Unsupported metadata: 7
+
+; SKIP-IDENTITY
+
+!0 = !{!1}
+!1 = distinct !{!1, !2}
+!2 = distinct !{!2, !"LVerDomain"}
+!3 = !{!4}
+!4 = distinct !{!4, !2}

--- a/tests/alive-tv/unsupported.metadata.in.tgt.srctgt.ll
+++ b/tests/alive-tv/unsupported.metadata.in.tgt.srctgt.ll
@@ -10,7 +10,7 @@ define i1 @tgt(i8* %a, i8* %b) {
   ret i1 true
 }
 
-; ERROR: Unsupported metadata: 7
+; ERROR: Value mismatch
 
 ; SKIP-IDENTITY
 

--- a/tests/alive-tv/unsupported.metadata.in.tgt.srctgt.ll
+++ b/tests/alive-tv/unsupported.metadata.in.tgt.srctgt.ll
@@ -1,0 +1,21 @@
+define i1 @src(i8* %a, i8* %b) {
+  %l = load i8, i8* %a
+  store i8 %l, i8* %b
+  ret i1 false
+}
+
+define i1 @tgt(i8* %a, i8* %b) {
+  %l = load i8, i8* %a, !alias.scope !0, !noalias !3
+  store i8 %l, i8* %b, !alias.scope !0, !noalias !3
+  ret i1 true
+}
+
+; ERROR: Unsupported metadata: 7
+
+; SKIP-IDENTITY
+
+!0 = !{!1}
+!1 = distinct !{!1, !2}
+!2 = distinct !{!2, !"LVerDomain"}
+!3 = !{!4}
+!4 = distinct !{!4, !2}

--- a/tools/alive-exec.cpp
+++ b/tools/alive-exec.cpp
@@ -68,7 +68,7 @@ optional<smt::smt_initializer> smt_init;
 
 void execFunction(llvm::Function &F, llvm::TargetLibraryInfoWrapperPass &TLI,
                   unsigned &successCount, unsigned &errorCount) {
-  auto Func = llvm2alive(F, TLI.getTLI(F));
+  auto Func = llvm2alive(F, TLI.getTLI(F), true);
   if (!Func) {
     cerr << "ERROR: Could not translate '" << F.getName().str()
          << "' to Alive IR\n";
@@ -81,7 +81,7 @@ void execFunction(llvm::Function &F, llvm::TargetLibraryInfoWrapperPass &TLI,
 
   Transform t;
   t.src = std::move(*Func);
-  t.tgt = *llvm2alive(F, TLI.getTLI(F));
+  t.tgt = *llvm2alive(F, TLI.getTLI(F), false);
   t.preprocess();
   TransformVerify verifier(t, false);
   if (!opt_quiet)

--- a/tools/alive-tv.cpp
+++ b/tools/alive-tv.cpp
@@ -113,12 +113,12 @@ Results verify(llvm::Function &F1, llvm::Function &F2,
                llvm::TargetLibraryInfoWrapperPass &TLI,
                bool print_transform = false,
                bool always_verify = false) {
-  auto fn1 = llvm2alive(F1, TLI.getTLI(F1));
+  auto fn1 = llvm2alive(F1, TLI.getTLI(F1), true);
   if (!fn1)
     return Results::Error("Could not translate '" + F1.getName().str() +
                           "' to Alive IR\n");
 
-  auto fn2 = llvm2alive(F2, TLI.getTLI(F2), fn1->getGlobalVarNames());
+  auto fn2 = llvm2alive(F2, TLI.getTLI(F2), false, fn1->getGlobalVarNames());
   if (!fn2)
     return Results::Error("Could not translate '" + F2.getName().str() +
                           "' to Alive IR\n");

--- a/tv/tv.cpp
+++ b/tv/tv.cpp
@@ -225,7 +225,7 @@ struct TVLegacyPass final : public llvm::ModulePass {
     t.tgt = std::move(*fn);
 
     verify(t, I->second.n++, I->second.fn_tostr);
-    I->second.fn = *llvm2alive(F, *TLI, false);
+    I->second.fn = *llvm2alive(F, *TLI, true);
     I->second.fn_tostr = toString(I->second.fn);
     return false;
   }

--- a/tv/tv.cpp
+++ b/tv/tv.cpp
@@ -203,8 +203,9 @@ struct TVLegacyPass final : public llvm::ModulePass {
       return false;
     }
 
-    auto fn = llvm2alive(F, *TLI, first ? vector<string_view>()
-                                        : I->second.fn.getGlobalVarNames());
+    auto fn = llvm2alive(F, *TLI, first,
+                         first ? vector<string_view>()
+                               : I->second.fn.getGlobalVarNames());
     if (!fn) {
       fns.erase(I);
       return false;
@@ -223,17 +224,9 @@ struct TVLegacyPass final : public llvm::ModulePass {
     t.src = std::move(I->second.fn);
     t.tgt = std::move(*fn);
 
-    bool regenerate_tgt = verify(t, I->second.n++, I->second.fn_tostr);
-
-    if (regenerate_tgt) {
-      I->second.fn = *llvm2alive(F, *TLI);
-      I->second.fn_tostr = toString(I->second.fn);
-    } else {
-      I->second.fn = std::move(t.tgt);
-      // updating I->second.fn_tostr isn't necessary because the two functions
-      // are equal or some error occurred.
-    }
-
+    verify(t, I->second.n++, I->second.fn_tostr);
+    I->second.fn = *llvm2alive(F, *TLI, false);
+    I->second.fn_tostr = toString(I->second.fn);
     return false;
   }
 


### PR DESCRIPTION
Unsupported metadata in @tgt only should not block verification, as LLVM
IR metadata can be dropped without impacting semantics of the IR
function itself.

In particular, if @tgt can be verified as incorrect without unsupported
metadata, then extra metadata cannot turn the function into a 'correct'
one.

One instance where unsupported metadata can block verification at moment
are transformations that introduce new metadata, like for example
loop-vectorize, which may add !noalias metadata.