### PR TITLE
M1 Mac doesn't put python in /usr/bin

### DIFF
--- a/scripts/rewritepass.py
+++ b/scripts/rewritepass.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 import os
 import re
 import sys


### PR DESCRIPTION
this is needed to make tests run on my M1 Mac

I also had to create `python` as a symlink to `python3` -- we might just hardcode python3 instead of python to save people the trouble?