### PR TITLE
argh-- burned by order of libraries in the link line, without this

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,7 +155,7 @@ if (HIREDIS_LIBRARIES)
     cache/cache.cpp
   )
   add_library(cache STATIC ${CACHE_SRCS})
-  set(ALIVE_LIBS ${ALIVE_LIBS} cache)
+  set(ALIVE_LIBS cache ${ALIVE_LIBS})
 else()
   set(HIREDIS_LIBRARIES $<0:''>)
   add_compile_definitions(NO_REDIS_SUPPORT)


### PR DESCRIPTION
patch on my Linux box, libcache.a can't find crc_update()