### PR TITLE
just a few quality-of-life improvements

### DIFF
--- a/llvm_util/cmd_args_list.h
+++ b/llvm_util/cmd_args_list.h
@@ -143,6 +143,10 @@ llvm::cl::opt<bool> opt_cache(LLVM_ARGS_PREFIX "cache",
   llvm::cl::init(false),
   llvm::cl::desc("Use external cache (default=false)"));
 
+llvm::cl::opt<bool> opt_assume_cache_hit(LLVM_ARGS_PREFIX "assume-cache-hit",
+  llvm::cl::init(false),
+  llvm::cl::desc("Assume cache hits every time (for debugging only, default=false)"));
+
 llvm::cl::opt<unsigned> opt_cache_port(LLVM_ARGS_PREFIX "cache-port",
   llvm::cl::init(6379),
   llvm::cl::desc("Port to connect to Redis server (default=6379"));

--- a/llvm_util/llvm2alive.cpp
+++ b/llvm_util/llvm2alive.cpp
@@ -14,6 +14,7 @@
 #include "llvm/IR/InlineAsm.h"
 #include "llvm/IR/InstVisitor.h"
 #include "llvm/IR/Operator.h"
+#include <sstream>
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>
@@ -1665,8 +1666,13 @@ public:
 
       auto storedval = get_operand(gv->getInitializer());
       if (!storedval) {
-        *out << "ERROR: Unsupported constant: " << *gv->getInitializer()
-             << '\n';
+	std::stringstream s;
+	s << *gv->getInitializer();
+        *out << "ERROR: Unsupported constant: ";
+	if (s.str().size() > 250)
+	  *out << "[too large]\n";
+	else
+	  *out << s.str() << '\n';
         return {};
       }
 

--- a/tv/tv.cpp
+++ b/tv/tv.cpp
@@ -117,7 +117,8 @@ void writeBitcode(const fs::path &report_filename) {
     bc_filename = get_random_str(8) + ".bc";
   } else {
     bc_filename = report_filename;
-    bc_filename.replace_extension(".bc");
+    bc_filename.replace_extension("");
+    bc_filename += "_" + get_random_str(4) + ".bc";
   }
 
   ofstream bc_file(bc_filename);
@@ -251,7 +252,8 @@ struct TVLegacyPass final : public llvm::ModulePass {
 
     // Since we have an open connection to the Redis server, we have
     // to do this before forking. Anyway, this is fast.
-    if (cache && cache->lookup(src_tostr + "===\n" + tgt_tostr)) {
+    if (opt_assume_cache_hit ||
+	(cache && cache->lookup(src_tostr + "===\n" + tgt_tostr))) {
       *out << "Skipping repeated query\n\n";
       return;
     }


### PR DESCRIPTION
- one file from PHP uses like 240 GB of disk space for its log file even in quiet mode because we're printing its initializers which are massive, this suppresses that. this is a one-off fix but it's easy to generalize it if we need it in other locations, but not doing that yet since we've gotten pretty far without this
- I'm always adding a "return" into the main TV function for debugging purposes that avoid doing the actual TV part, here we add a command line flag for this so I don't have to modify the code
-  append a bit of extra random stuff to dumped bitcode files to they don't tend to overwrite each other