### PR TITLE
Separate compareFunctions from alive-tv.cpp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -183,11 +183,11 @@ if (BUILD_LLVM_UTILS OR BUILD_TV)
   add_definitions(${LLVM_DEFINITIONS})
 
   set(LLVM_UTIL_SRCS
+    "llvm_util/function_verify.cpp"
     "llvm_util/known_fns.cpp"
     "llvm_util/llvm_optimizer.cpp"
     "llvm_util/llvm2alive.cpp"
     "llvm_util/utils.cpp"
-    "llvm_util/function_verify.cpp"
   )
 
   add_library(llvm_util STATIC ${LLVM_UTIL_SRCS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -187,6 +187,7 @@ if (BUILD_LLVM_UTILS OR BUILD_TV)
     "llvm_util/llvm_optimizer.cpp"
     "llvm_util/llvm2alive.cpp"
     "llvm_util/utils.cpp"
+    "llvm_util/function_verify.cpp"
   )
 
   add_library(llvm_util STATIC ${LLVM_UTIL_SRCS})

--- a/llvm_util/function_verify.cpp
+++ b/llvm_util/function_verify.cpp
@@ -1,0 +1,194 @@
+// Copyright (c) 2022-present The Alive2 Authors.
+// Distributed under the MIT license that can be found in the LICENSE file.
+
+#include "function_verify.h"
+
+using namespace tools;
+using namespace util;
+using namespace std;
+using namespace llvm_util;
+
+namespace {
+bool opt_quiet = false;
+bool opt_always_verify = false;
+bool opt_print_dot = false;
+bool opt_bidirectional = false;
+
+ostream* out = &cout;
+
+struct Results {
+  tools::Transform t;
+  std::string error;
+  util::Errors errs;
+  enum {
+    ERROR,
+    TYPE_CHECKER_FAILED,
+    SYNTACTIC_EQ,
+    CORRECT,
+    UNSOUND,
+    FAILED_TO_PROVE
+  } status;
+
+  static Results Error(std::string &&err) {
+    Results r;
+    r.status = ERROR;
+    r.error = std::move(err);
+    return r;
+  }
+};
+
+Results verify(llvm::Function &F1, llvm::Function &F2,
+               llvm::TargetLibraryInfoWrapperPass &TLI, bool print_transform,
+               bool always_verify) {
+  auto fn1 = llvm2alive(F1, TLI.getTLI(F1), true);
+  if (!fn1)
+    return Results::Error("Could not translate '" + F1.getName().str() +
+                          "' to Alive IR\n");
+
+  auto fn2 = llvm2alive(F2, TLI.getTLI(F2), false, fn1->getGlobalVarNames());
+  if (!fn2)
+    return Results::Error("Could not translate '" + F2.getName().str() +
+                          "' to Alive IR\n");
+
+  Results r;
+  r.t.src = std::move(*fn1);
+  r.t.tgt = std::move(*fn2);
+
+  if (!always_verify) {
+    std::stringstream ss1, ss2;
+    r.t.src.print(ss1);
+    r.t.tgt.print(ss2);
+    if (std::move(ss1).str() == std::move(ss2).str()) {
+      if (print_transform)
+        r.t.print(*out, {});
+      r.status = Results::SYNTACTIC_EQ;
+      return r;
+    }
+  }
+
+  verifier::smt_init->reset();
+  r.t.preprocess();
+  tools::TransformVerify verifier(r.t, false);
+
+  if (print_transform)
+    r.t.print(*out, {});
+
+  {
+    auto types = verifier.getTypings();
+    if (!types) {
+      r.status = Results::TYPE_CHECKER_FAILED;
+      return r;
+    }
+    assert(types.hasSingleTyping());
+  }
+
+  r.errs = verifier.verify();
+  if (r.errs) {
+    r.status = r.errs.isUnsound() ? Results::UNSOUND : Results::FAILED_TO_PROVE;
+  } else {
+    r.status = Results::CORRECT;
+  }
+  return r;
+}
+}
+
+namespace verifier {
+
+std::optional<smt::smt_initializer> smt_init;
+std::unique_ptr<Cache> cache;
+
+unsigned num_correct = 0;
+unsigned num_unsound = 0;
+unsigned num_failed = 0;
+unsigned num_errors = 0;
+
+
+void initialize_verifier(bool set_opt_quiet, bool set_opt_always_verify,
+                        bool set_opt_print_dot, bool set_opt_bidirectional,
+                        std::ostream* set_out) {
+  opt_quiet = set_opt_quiet;
+  opt_always_verify = set_opt_always_verify;
+  opt_print_dot = set_opt_print_dot;
+  opt_bidirectional = set_opt_bidirectional;
+  out = set_out;
+}
+
+
+bool compareFunctions(llvm::Function &F1, llvm::Function &F2,
+                      llvm::TargetLibraryInfoWrapperPass &TLI) {
+  auto r = verify(F1, F2, TLI, !opt_quiet, opt_always_verify);
+  if (r.status == Results::ERROR) {
+    *out << "ERROR: " << r.error;
+    ++num_errors;
+    return true;
+  }
+
+  if (opt_print_dot) {
+    r.t.src.writeDot("src");
+    r.t.tgt.writeDot("tgt");
+  }
+
+  switch (r.status) {
+  case Results::ERROR:
+    UNREACHABLE();
+    break;
+
+  case Results::SYNTACTIC_EQ:
+    *out << "Transformation seems to be correct! (syntactically equal)\n\n";
+    ++num_correct;
+    break;
+
+  case Results::CORRECT:
+    *out << "Transformation seems to be correct!\n\n";
+    ++num_correct;
+    break;
+
+  case Results::TYPE_CHECKER_FAILED:
+    *out << "Transformation doesn't verify!\n"
+            "ERROR: program doesn't type check!\n\n";
+    ++num_errors;
+    return true;
+
+  case Results::UNSOUND:
+    *out << "Transformation doesn't verify!\n\n";
+    if (!opt_quiet)
+      *out << r.errs << endl;
+    ++num_unsound;
+    return false;
+
+  case Results::FAILED_TO_PROVE:
+    *out << r.errs << endl;
+    ++num_failed;
+    return true;
+  }
+
+  if (opt_bidirectional) {
+    r = verify(F2, F1, TLI, false, opt_always_verify);
+    switch (r.status) {
+    case Results::ERROR:
+    case Results::TYPE_CHECKER_FAILED:
+      UNREACHABLE();
+      break;
+
+    case Results::SYNTACTIC_EQ:
+    case Results::CORRECT:
+      *out << "These functions seem to be equivalent!\n\n";
+      return true;
+
+    case Results::FAILED_TO_PROVE:
+      *out << "Failed to verify the reverse transformation\n\n";
+      if (!opt_quiet)
+        *out << r.errs << endl;
+      return true;
+
+    case Results::UNSOUND:
+      *out << "Reverse transformation doesn't verify!\n\n";
+      if (!opt_quiet)
+        *out << r.errs << endl;
+      return false;
+    }
+  }
+  return true;
+}
+}
+

--- a/llvm_util/function_verify.cpp
+++ b/llvm_util/function_verify.cpp
@@ -2,6 +2,10 @@
 // Distributed under the MIT license that can be found in the LICENSE file.
 
 #include "function_verify.h"
+#include "llvm_util/llvm2alive.h"
+#include "tools/transform.h"
+#include <iostream>
+#include <sstream>
 
 using namespace tools;
 using namespace util;
@@ -14,7 +18,7 @@ bool opt_always_verify = false;
 bool opt_print_dot = false;
 bool opt_bidirectional = false;
 
-ostream* out = &cout;
+ostream *out = &cout;
 
 struct Results {
   tools::Transform t;
@@ -92,7 +96,7 @@ Results verify(llvm::Function &F1, llvm::Function &F2,
 }
 }
 
-namespace verifier {
+namespace llvm_util::verifier {
 
 std::optional<smt::smt_initializer> smt_init;
 std::unique_ptr<Cache> cache;
@@ -103,9 +107,9 @@ unsigned num_failed = 0;
 unsigned num_errors = 0;
 
 
-void initialize_verifier(bool set_opt_quiet, bool set_opt_always_verify,
-                        bool set_opt_print_dot, bool set_opt_bidirectional,
-                        std::ostream* set_out) {
+void initialize(bool set_opt_quiet, bool set_opt_always_verify,
+                bool set_opt_print_dot, bool set_opt_bidirectional,
+                std::ostream* set_out) {
   opt_quiet = set_opt_quiet;
   opt_always_verify = set_opt_always_verify;
   opt_print_dot = set_opt_print_dot;
@@ -191,4 +195,3 @@ bool compareFunctions(llvm::Function &F1, llvm::Function &F2,
   return true;
 }
 }
-

--- a/llvm_util/function_verify.h
+++ b/llvm_util/function_verify.h
@@ -1,0 +1,35 @@
+#pragma once
+
+// Copyright (c) 2022-present The Alive2 Authors.
+// Distributed under the MIT license that can be found in the LICENSE file.
+
+#include "cache/cache.h"
+#include "llvm_util/llvm2alive.h"
+#include "smt/smt.h"
+#include "tools/transform.h"
+
+#include "llvm/Analysis/TargetLibraryInfo.h"
+
+#include <iostream>
+#include <sstream>
+
+namespace verifier {
+
+extern std::optional<smt::smt_initializer> smt_init;
+extern std::unique_ptr<Cache> cache;
+
+extern unsigned num_correct;
+extern unsigned num_unsound;
+extern unsigned num_failed;
+extern unsigned num_errors;
+
+
+bool compareFunctions(llvm::Function &F1, llvm::Function &F2,
+                      llvm::TargetLibraryInfoWrapperPass &TLI);
+
+
+void initialize_verifier(bool set_opt_quiet, bool set_opt_always_verify,
+                         bool set_opt_print_dot, bool set_opt_bidirectional,
+                         std::ostream *set_out);
+
+}

--- a/llvm_util/function_verify.h
+++ b/llvm_util/function_verify.h
@@ -4,16 +4,12 @@
 // Distributed under the MIT license that can be found in the LICENSE file.
 
 #include "cache/cache.h"
-#include "llvm_util/llvm2alive.h"
-#include "smt/smt.h"
-#include "tools/transform.h"
-
 #include "llvm/Analysis/TargetLibraryInfo.h"
+#include "smt/smt.h"
+#include <optional>
+#include <ostream>
 
-#include <iostream>
-#include <sstream>
-
-namespace verifier {
+namespace llvm_util::verifier {
 
 extern std::optional<smt::smt_initializer> smt_init;
 extern std::unique_ptr<Cache> cache;
@@ -28,8 +24,8 @@ bool compareFunctions(llvm::Function &F1, llvm::Function &F2,
                       llvm::TargetLibraryInfoWrapperPass &TLI);
 
 
-void initialize_verifier(bool set_opt_quiet, bool set_opt_always_verify,
-                         bool set_opt_print_dot, bool set_opt_bidirectional,
-                         std::ostream *set_out);
+void initialize(bool set_opt_quiet, bool set_opt_always_verify,
+                bool set_opt_print_dot, bool set_opt_bidirectional,
+                std::ostream *set_out);
 
 }

--- a/tools/alive-tv.cpp
+++ b/tools/alive-tv.cpp
@@ -82,7 +82,7 @@ std::unique_ptr<llvm::Module> openInputFile(llvm::LLVMContext &Context,
   return M;
 }
 
-llvm::Function *findFunction(llvm::Module &M, const std::string &FName) {
+llvm::Function *findFunction(llvm::Module &M, const string &FName) {
   for (auto &F : M) {
     if (F.isDeclaration())
       continue;
@@ -93,6 +93,7 @@ llvm::Function *findFunction(llvm::Module &M, const std::string &FName) {
   return 0;
 }
 }
+
 
 int main(int argc, char **argv) {
   llvm::sys::PrintStackTraceOnErrorSignal(argv[0]);
@@ -147,8 +148,8 @@ convenient way to demonstrate an existing optimizer bug.
   llvm_util::initializer llvm_util_init(*out, DL);
   smt_init.emplace();
 
-  initialize_verifier(opt_quiet, opt_always_verify, opt_print_dot,
-                      opt_bidirectional, out);
+  initialize(opt_quiet, opt_always_verify, opt_print_dot, opt_bidirectional,
+             out);
 
   unique_ptr<llvm::Module> M2;
   if (opt_file2.empty()) {


### PR DESCRIPTION
`compareFunctions` is a very useful function for comparing LLVM functions for refinement, but it is currently inside `alive-tv.cpp`. This makes it impossible to include the code in other projects due to the main function, so I have separated out its functionality into `function_verify.cpp` and `function_verify.h`. I also added an additional function `initialize` which sets `opt_quiet`, `opt_always_verify`, `out`, etc, in order to keep from polluting the namespace.