### PR TITLE
Fix soundness bug due to overflow in expr::ugt() optimisation.

### DIFF
--- a/smt/expr.cpp
+++ b/smt/expr.cpp
@@ -1568,9 +1568,10 @@ expr expr::ugt(const expr &rhs) const {
     return false;
 
   uint64_t n;
-  if (rhs.isUInt(n) && n < numeric_limits<uint64_t>::max())
-    return uge(mkUInt(n + 1, sort()));
-
+  if (rhs.isUInt(n)) {
+    auto ty = sort();
+    return uge(mkUInt(n, ty) + mkUInt(1, ty));
+  }
   return !ule(rhs);
 }
 

--- a/smt/expr.cpp
+++ b/smt/expr.cpp
@@ -1568,7 +1568,7 @@ expr expr::ugt(const expr &rhs) const {
     return false;
 
   uint64_t n;
-  if (rhs.isUInt(n))
+  if (rhs.isUInt(n) && n < numeric_limits<uint64_t>::max())
     return uge(mkUInt(n + 1, sort()));
 
   return !ule(rhs);


### PR DESCRIPTION
Incorrect results were returned when encountering an `icmp ugt` instruction with the maximum uint64 value as its second operand.

For example, these incorrectly verify as equivalent functions ([https://alive2.llvm.org/ce/z/VmnnF_](https://alive2.llvm.org/ce/z/VmnnF_)):
```llvm
define i1 @src(i128 %L)  {
  ; ugt with max uint64 value, decimal 18446744073709551615 = 2^64-1
  %ugt = icmp ugt i128 %L, u0xffffffffffffffff 
  ret i1 %ugt
}

define i1 @tgt(i128 %L) {
  ret i1 1
}
```
Another example compares ugt with not ule, this should verify but does not: https://alive2.llvm.org/ce/z/6JPbFD

This is caused by overflowing the `n+1` operation in the optimisation case, leading to >= 0 which is always true. Ensuring n is less than the maximum before adding fixes these behaviours.