### PR TITLE
support tracking the SignExt and ZeroExt attributes that can appear o…

### DIFF
--- a/ir/attrs.cpp
+++ b/ir/attrs.cpp
@@ -36,6 +36,10 @@ ostream& operator<<(ostream &os, const ParamAttrs &attr) {
     os << "noalias ";
   if (attr.has(ParamAttrs::DereferenceableOrNull))
     os << "dereferenceable_or_null(" << attr.derefOrNullBytes << ") ";
+  if (attr.has(ParamAttrs::ZeroExt))
+    os << "zeroext ";
+  if (attr.has(ParamAttrs::SignExt))
+    os << "signext ";
   if (attr.has(ParamAttrs::AllocPtr))
     os << "allocptr ";
   if (attr.has(ParamAttrs::AllocAlign))
@@ -87,6 +91,10 @@ ostream& operator<<(ostream &os, const FnAttrs &attr) {
     os << " dereferenceable_or_null(" << attr.derefOrNullBytes << ')';
   if (attr.has(FnAttrs::NullPointerIsValid))
     os << " null_pointer_is_valid";
+  if (attr.has(FnAttrs::ZeroExt))
+    os << " zeroext";
+  if (attr.has(FnAttrs::SignExt))
+    os << " signext";
   if (!attr.allocfamily.empty())
     os << " alloc-family(" << attr.allocfamily << ')';
   if (attr.allockind != 0) {

--- a/ir/attrs.h
+++ b/ir/attrs.h
@@ -63,7 +63,8 @@ public:
                    NoRead = 1<<3, NoWrite = 1<<4, Dereferenceable = 1<<5,
                    NoUndef = 1<<6, Align = 1<<7, Returned = 1<<8,
                    NoAlias = 1<<9, DereferenceableOrNull = 1<<10,
-                   AllocPtr = 1<<11, AllocAlign = 1<<12 };
+                   AllocPtr = 1<<11, AllocAlign = 1<<12,
+                   ZeroExt = 1<<13, SignExt = 1<<14};
 
   ParamAttrs(unsigned bits = None) : bits(bits) {}
 
@@ -123,7 +124,8 @@ public:
                    NoThrow = 1 << 7, NoAlias = 1 << 8, WillReturn = 1 << 9,
                    DereferenceableOrNull = 1 << 10,
                    NullPointerIsValid = 1 << 11,
-                   AllocSize = 1 << 12 };
+                   AllocSize = 1 << 12, ZeroExt = 1<<13,
+                   SignExt = 1<<14 };
 
   FnAttrs(unsigned bits = None) : bits(bits) {}
 

--- a/llvm_util/llvm2alive.cpp
+++ b/llvm_util/llvm2alive.cpp
@@ -1290,11 +1290,19 @@ public:
         continue;
 
       switch (llvmattr.getKindAsEnum()) {
+
+        // TODO: SignExt, ZeroExt, and InReg are not important for IR
+        // verification, but we should check that they don't change
+
       case llvm::Attribute::InReg:
+        break;
+
       case llvm::Attribute::SExt:
+        attrs.set(ParamAttrs::SignExt);
+        break;
+
       case llvm::Attribute::ZExt:
-        // TODO: not important for IR verification, but we should check that
-        // they don't change
+        attrs.set(ParamAttrs::ZeroExt);
         break;
 
       case llvm::Attribute::ByVal: {
@@ -1380,6 +1388,8 @@ public:
         continue;
 
       switch (llvmattr.getKindAsEnum()) {
+      case llvm::Attribute::SExt: attrs.set(FnAttrs::SignExt); break;
+      case llvm::Attribute::ZExt: attrs.set(FnAttrs::ZeroExt); break;
       case llvm::Attribute::NoAlias: attrs.set(FnAttrs::NoAlias); break;
       case llvm::Attribute::NonNull: attrs.set(FnAttrs::NonNull); break;
       case llvm::Attribute::NoUndef: attrs.set(FnAttrs::NoUndef); break;


### PR DESCRIPTION
…n functions and function arguments. these have no IR-level semantics, but this patch is used by Utah's work on verifying the behavior of the AArch64 backend