### PR TITLE
fix another deprecation.

### DIFF
--- a/llvm_util/llvm2alive.cpp
+++ b/llvm_util/llvm2alive.cpp
@@ -127,7 +127,7 @@ class llvm2alive_ : public llvm::InstVisitor<llvm2alive_, unique_ptr<Instr>> {
   template <typename T>
   uint64_t pref_alignment(T &i, llvm::Type *ty) const {
     auto a = i.getAlign().value();
-    return a != 0 ? a : DL().getPrefTypeAlignment(ty);
+    return a != 0 ? a : DL().getPrefTypeAlign(ty).value();
   }
 
   Value* convert_constexpr(llvm::ConstantExpr *cexpr) {


### PR DESCRIPTION
I didn't see an immediate way to use getValueOrOne() here