### PR TITLE
remove dbg_addr, which has been removed from LLVM

### DIFF
--- a/llvm_util/llvm2alive.cpp
+++ b/llvm_util/llvm2alive.cpp
@@ -1134,7 +1134,6 @@ public:
     }
 
     // do nothing intrinsics
-    case llvm::Intrinsic::dbg_addr:
     case llvm::Intrinsic::dbg_declare:
     case llvm::Intrinsic::dbg_label:
     case llvm::Intrinsic::dbg_value:


### PR DESCRIPTION
discussion here:
https://discourse.llvm.org/t/what-is-the-status-of-dbg-addr/62898