### PR TITLE
Enable multiple 'src'/'tgt' pairs in a single source

### DIFF
--- a/tests/alive-tv/ssub-cmp-zero.v0.srctgt.ll
+++ b/tests/alive-tv/ssub-cmp-zero.v0.srctgt.ll
@@ -1,0 +1,44 @@
+declare i8 @llvm.ssub.sat.i8(i8, i8)
+define i1 @src(i8 %x, i8 %y) {
+  %m = call i8 @llvm.ssub.sat.i8(i8 %x, i8 %y)
+  %r = icmp eq i8 %m, 0
+  ret i1 %r
+}
+
+define i1 @tgt(i8 %x, i8 %y) {
+  %r = icmp eq i8 %x, %y
+  ret i1 %r
+}
+
+define i1 @src1(i8 %x, i8 %y) {
+  %m = call i8 @llvm.ssub.sat.i8(i8 %x, i8 %y)
+  %r = icmp ne i8 %m, 0
+  ret i1 %r
+}
+
+define i1 @tgt1(i8 %x, i8 %y) {
+  %r = icmp ne i8 %x, %y
+  ret i1 %r
+}
+
+define i1 @src2(i8 %x, i8 %y) {
+  %m = call i8 @llvm.ssub.sat.i8(i8 %x, i8 %y)
+  %r = icmp sle i8 %m, 0
+  ret i1 %r
+}
+
+define i1 @tgt2(i8 %x, i8 %y) {
+  %r = icmp sle i8 %x, %y
+  ret i1 %r
+}
+
+define i1 @src3(i8 %x, i8 %y) {
+  %m = call i8 @llvm.ssub.sat.i8(i8 %x, i8 %y)
+  %r = icmp slt i8 %m, 0
+  ret i1 %r
+}
+
+define i1 @tgt3(i8 %x, i8 %y) {
+  %r = icmp slt i8 %x, %y
+  ret i1 %r
+}

--- a/tests/alive-tv/ssub-cmp-zero.v1.srctgt.ll
+++ b/tests/alive-tv/ssub-cmp-zero.v1.srctgt.ll
@@ -1,0 +1,29 @@
+declare i8 @llvm.ssub.sat.i8(i8, i8)
+define i1 @src_sge(i8 %x, i8 %y) {
+  %m = call i8 @llvm.ssub.sat.i8(i8 %x, i8 %y)
+  %r = icmp sge i8 %m, 0
+  ret i1 %r
+}
+
+define i1 @tgt_sge(i8 %x, i8 %y) {
+  %r = icmp sge i8 %x, %y
+  ret i1 %r
+}
+
+define i1 @src_sgt(i8 %x, i8 %y) {
+  %m = call i8 @llvm.ssub.sat.i8(i8 %x, i8 %y)
+  %r = icmp sgt i8 %m, 0
+  ret i1 %r
+}
+
+define i1 @tgt_sgt(i8 %x, i8 %y) {
+  %r = icmp sgt i8 %x, %y
+  ret i1 %r
+}
+
+; unused
+define i1 @src(i8 %x, i8 %y) {
+  %m = call i8 @llvm.ssub.sat.i8(i8 %x, i8 %y)
+  %r = icmp sgt i8 %m, 0
+  ret i1 %r
+}

--- a/tests/alive-tv/sub-is-not.srctgt.ll
+++ b/tests/alive-tv/sub-is-not.srctgt.ll
@@ -1,0 +1,47 @@
+define i8 @src(i8 %x) {
+  %m = sub i8 %x, -1
+  ret i8 %m
+}
+
+define i8 @tgt(i8 %x) {
+  %m = xor i8 %x, -1
+  ret i8 %m
+}
+
+; Transformation doesn't verify!
+
+define i8 @src3(i8 %x) {
+  %m = sub i8 0, %x
+  ret i8 %m
+}
+
+define i8 @tgt3(i8 %x) {
+  %m = xor i8 %x, -1
+  ret i8 %m
+}
+
+; Transformation doesn't verify!
+
+define i8 @src9(i8 %x) {
+  %m = sub i8 -1, %x
+  ret i8 %m
+}
+
+define i8 @tgt9(i8 %x) {
+  %m = xor i8 %x, -1
+  ret i8 %m
+}
+
+; Transformation seems to be correct!
+
+define i8 @src4(i8 %x, i8 %y) {
+  %m = add i8 %y, %x
+  ret i8 %m
+}
+
+define i8 @tgt4(i8 %x) {
+  %m = xor i8 %x, -1
+  ret i8 %m
+}
+
+; ERROR: Signature mismatch between src and tgt


### PR DESCRIPTION
Change:
Instead of only searching for 'src' and 'tgt' in single-file mode, search for an arbitrary number of pairs of 'src{+d}', 'tgt{+d}'.

I.e if have the following functions in a file:

```
define @src {}
define @tgt {}
define @src2 {}
define @tgt2 {}
define @src3 {}
define @tgt3 {}
define @src4 {}
define @tgt5 {}
```

Alive2 will have the following pairs: 'src'/'tgt', 'src2'/'tgt2', and 'src3'/'tgt3'. It will ignore 'src4' and 'tgt5'.

Motivation:
This just a QOL change. A lot of LLVM patches have assosiated alive2 links. In some cases there need to be many links (i.e https://reviews.llvm.org/D149521).

Being able to specify multiple 'src'/'tgt' pairs in a single file would enable verifying multiple cases with a single link making it easier.