### PR TITLE
Fix build failure with Xcode 14.3 release candidate.

### DIFF
--- a/util/spaceship.h
+++ b/util/spaceship.h
@@ -3,13 +3,17 @@
 // Copyright (c) 2018-present The Alive2 Authors.
 // Distributed under the MIT license that can be found in the LICENSE file.
 
-#if defined(__clang__) && __clang_major__ < 15 && defined(__APPLE__)
+#if defined(__clang__) && defined(__APPLE__)
 
 #include <compare>
+
+#if (__clang_major__ < 14 || (__clang_major__ == 14 && __clang_patchlevel__ == 0))
 
 namespace std {
 inline bool is_neq(std::weak_ordering o) { return o != 0; }
 }
+
+#endif
 
 namespace {
 
@@ -41,6 +45,7 @@ std::weak_ordering operator<=>(const std::map<K,V> &lhs,
   return compare_iterators(lhs.begin(), lhs.end(), rhs.begin(), rhs.end());
 }
 
+#if (__clang_major__ < 14 || (__clang_major__ == 14 && __clang_patchlevel__ == 0))
 template <typename X, typename Y>
 std::weak_ordering operator<=>(const std::pair<X,Y> &lhs,
                                const std::pair<X,Y> &rhs) {
@@ -49,6 +54,7 @@ std::weak_ordering operator<=>(const std::pair<X,Y> &lhs,
     return cmp;
   return lhs.second <=> rhs.second;
 }
+#endif
 
 template <typename T>
 std::weak_ordering compare_iterators(T &&I, const T &E, T &&II, const T &EE) {


### PR DESCRIPTION
The Xcode 14.3 release candidate is available
(https://developer.apple.com/documentation/xcode-release-notes/xcode-14_3-release-notes)

It requires the following changes to build Alive2.