### PR TITLE
Take loop exit blocks into account in constructing edges for top sort when dealing with a loop header

### DIFF
--- a/ir/function.cpp
+++ b/ir/function.cpp
@@ -59,6 +59,10 @@ void BasicBlock::delInstr(const Instr *i) {
   }
 }
 
+void BasicBlock::addExitBlock(BasicBlock* bb) {
+    exit_blocks.emplace(bb);
+}
+
 vector<Phi*> BasicBlock::phis() const {
   vector<Phi*> phis;
   for (auto &i : m_instrs) {

--- a/ir/function.h
+++ b/ir/function.h
@@ -15,8 +15,8 @@
 #include <string_view>
 #include <tuple>
 #include <unordered_map>
-#include <vector>
 #include <unordered_set>
+#include <vector>
 
 namespace smt { class Model; }
 

--- a/ir/function.h
+++ b/ir/function.h
@@ -16,6 +16,7 @@
 #include <tuple>
 #include <unordered_map>
 #include <vector>
+#include <unordered_set>
 
 namespace smt { class Model; }
 
@@ -28,7 +29,7 @@ class BasicBlock final {
   std::vector<std::unique_ptr<Instr>> m_instrs;
 
   // If the basic block is a header, this holds all exit blocks of its loop
-  std::set<BasicBlock*> exit_blocks; 
+    std::unordered_set<BasicBlock*> exit_blocks; 
 
 public:
   BasicBlock(std::string_view name) : name(name) {}
@@ -45,7 +46,7 @@ public:
   void addExitBlock(BasicBlock* bb) {
     exit_blocks.emplace(bb);
   }
-  const std::set<BasicBlock*>& getExitBlocks() const {
+  const std::unordered_set<BasicBlock*>& getExitBlocks() const {
     return exit_blocks;
   }
 

--- a/ir/function.h
+++ b/ir/function.h
@@ -43,9 +43,7 @@ public:
   void addInstrAt(std::unique_ptr<Instr> &&i, const Instr *other, bool before);
   void delInstr(const Instr *i);
 
-  void addExitBlock(BasicBlock* bb) {
-    exit_blocks.emplace(bb);
-  }
+  void addExitBlock(BasicBlock* bb);
   const std::unordered_set<BasicBlock*>& getExitBlocks() const {
     return exit_blocks;
   }

--- a/ir/function.h
+++ b/ir/function.h
@@ -27,6 +27,9 @@ class BasicBlock final {
   std::string name;
   std::vector<std::unique_ptr<Instr>> m_instrs;
 
+  // If the basic block is a header, this holds all exit blocks of its loop
+  std::set<BasicBlock*> exit_blocks; 
+
 public:
   BasicBlock(std::string_view name) : name(name) {}
 
@@ -38,6 +41,13 @@ public:
   void addInstr(std::unique_ptr<Instr> &&i, bool push_front = false);
   void addInstrAt(std::unique_ptr<Instr> &&i, const Instr *other, bool before);
   void delInstr(const Instr *i);
+
+  void addExitBlock(BasicBlock* bb) {
+    exit_blocks.emplace(bb);
+  }
+  const std::set<BasicBlock*>& getExitBlocks() const {
+    return exit_blocks;
+  }
 
   util::const_strip_unique_ptr<decltype(m_instrs)> instrs() const {
     return m_instrs;

--- a/tests/alive-tv/loops/partial_sub_loop_test_branch_loop.srctgt.ll
+++ b/tests/alive-tv/loops/partial_sub_loop_test_branch_loop.srctgt.ll
@@ -1,0 +1,62 @@
+; TEST-ARGS: -src-unroll=2 -tgt-unroll=2
+; llvm/llvm/test/Transforms/LoopSimplifyCFG/constant-fold-branch.ll
+
+define i32 @src(i32 %end) {
+entry:
+  br label %outer_header
+
+outer_header:
+  %j = phi i32 [0, %entry], [%j.inc, %outer_backedge]
+  br label %preheader
+
+preheader:
+  br label %header
+
+header:
+  %i = phi i32 [0, %preheader], [%i.inc, %backedge]
+  br label %backedge
+
+backedge:
+  %i.inc = add i32 %i, 1
+  %cmp = icmp slt i32 %i.inc, %end
+  br i1 %cmp, label %header, label %outer_backedge
+
+outer_backedge:
+  %j.inc = add i32 %j, 1
+  %cmp.j = icmp slt i32 %j.inc, %end
+  br i1 %cmp.j, label %outer_header, label %exit
+
+exit:
+  ret i32 %i.inc
+}
+
+define i32 @tgt(i32 %end) {
+entry:
+  br label %outer_header
+
+outer_header:                                     ; preds = %outer_backedge, %entry
+  %j = phi i32 [ 0, %entry ], [ %j.inc, %outer_backedge ]
+  br label %preheader
+
+preheader:                                        ; preds = %outer_header
+  br label %header
+
+header:                                           ; preds = %backedge, %preheader
+  %i = phi i32 [ 0, %preheader ], [ %i.inc, %backedge ]
+  br label %backedge
+
+backedge:                                         ; preds = %header
+  %i.inc = add i32 %i, 1
+  %cmp = icmp slt i32 %i.inc, %end
+  br i1 %cmp, label %header, label %outer_backedge
+
+outer_backedge:                                   ; preds = %backedge
+  %i.inc.lcssa = phi i32 [ %i.inc, %backedge ]
+  %j.inc = add i32 %j, 1
+  %cmp.j = icmp slt i32 %j.inc, %end
+  br i1 %cmp.j, label %outer_header, label %exit
+
+exit:                                             ; preds = %outer_backedge
+  %i.inc.lcssa.lcssa = phi i32 [ %i.inc.lcssa, %outer_backedge ]
+  ret i32 %i.inc.lcssa.lcssa
+}


### PR DESCRIPTION
This patch fixes a [failing example](https://github.com/AliveToolkit/alive2/issues/748#issuecomment-1372248300) mentioned in issue [#748](https://github.com/AliveToolkit/alive2/issues/748). The original issue had likely gotten "fixed" by accident before this patch, so I only refer to that specific example, but it affects any code with nested loops (though sometimes the problem may not manifest itself).

Here is the reduced example:

```llvm
define i32 @partial_sub_loop_test_branch_loop(i32 %end) {
entry:
  br label %outer_header

outer_header:
  %j = phi i32 [0, %entry], [%j.inc, %outer_backedge]
  br label %preheader

preheader:
  br label %header

header:
  %i = phi i32 [0, %preheader], [%i.inc, %backedge]
  br label %backedge

backedge:
  %i.inc = add i32 %i, 1
  %cmp = icmp slt i32 %i.inc, %end
  br i1 %cmp, label %header, label %outer_backedge

outer_backedge:
  %j.inc = add i32 %j, 1
  %cmp.j = icmp slt i32 %j.inc, %end
  br i1 %cmp.j, label %outer_header, label %exit

exit:
  ret i32 %i.inc
}
```
And this is the CFG:

![bug-cfg](https://github.com/AliveToolkit/alive2/assets/28180969/b63e5f7f-4857-4b0c-a4a6-34d8d3546e07)

Running `alive-tv bug.ll -src-unroll=2 -tgt-unroll=2 --passes=lcssa` currently produces a false positive (i.e. it says the transformation is incorrect even though it should be correct). This is fixed by this patch.

The problem is that when you have a nested loop and the outer loop is being unrolled and you need to topologically sort the body, the inner loops are compressed into a single node (i.e. they are represented only by the header), but the outgoing edges from the loop are not preserved, so there is a chance the basic blocks will not be in correct topological order (depending on tiebreaks). This then causes problems when values are replaced in cloning BBs, because a BB can come "sooner" and have the wrong predecessors (as it has a different `vmap`).
So in this example, when running top-sort on the body of the outer loop, which contains `preheader`, `header` (representing the inner loop), and `outer_backedge`, Alive2 doesn't know that there's a transitive dependency between `header` and `outer_backedge` (due to the loop being compressed), so it puts `outer_backedge` before `header`.

I fixed this by adding an `std::set` of exit basic blocks to the `BasicBlock` class. If a `BasicBlock` is a header of some loop, this property keeps track of the exit blocks of the loop. This of course only makes sense if the given basic block is a header of a loop, the set is empty otherwise. Thus, these exit blocks can be taken into account when creating edges for top sort.
I've tried to work within the constraints of the design and intervene in the existing code as little as possible, so I'm sure the implementation details are bound to change, but it is a working solution from what I've tested and hopefully gets the idea across.