### PR TITLE
cmake: Set targets to INSTALL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -244,6 +244,7 @@ target_link_libraries(alive PRIVATE ${ALIVE_LIBS})
 add_executable(alive-jobserver
                "tools/alive-jobserver.cpp"
               )
+install(TARGETS alive alive-jobserver)
 
 #add_library(alive2 SHARED ${IR_SRCS} ${SMT_SRCS} ${TOOLS_SRCS} ${UTIL_SRCS} ${LLVM_UTIL_SRCS})
 
@@ -253,6 +254,7 @@ if (BUILD_LLVM_UTILS OR BUILD_TV)
   target_link_libraries(alive-tv PRIVATE ${ALIVE_LIBS_LLVM} ${Z3_LIBRARIES} ${HIREDIS_LIBRARIES} ${llvm_libs})
   target_link_libraries(quick-fuzz PRIVATE ${ALIVE_LIBS_LLVM} ${Z3_LIBRARIES} ${HIREDIS_LIBRARIES} ${llvm_libs})
   target_link_libraries(alive-exec PRIVATE ${ALIVE_LIBS_LLVM} ${Z3_LIBRARIES} ${HIREDIS_LIBRARIES} ${llvm_libs})
+  install(TARGETS alive-tv quick-fuzz alive-exec)
 endif()
 
 target_link_libraries(alive PRIVATE ${Z3_LIBRARIES} ${HIREDIS_LIBRARIES})


### PR DESCRIPTION
I'm in the process of trying to get alive2 available in the JuliaLang binary distribution system [1]. That system would like all relevant targets to be INSTALL'ed, so add appropriate CMake directives.

[1] https://github.com/JuliaPackaging/Yggdrasil/pull/4271