### PR TITLE
Silence a compiler warning

### DIFF
--- a/ir/attrs.h
+++ b/ir/attrs.h
@@ -136,8 +136,8 @@ public:
   uint64_t derefOrNullBytes = 0; // DereferenceableOrNull
   uint64_t align = 0;
 
-  unsigned allocsize_0;
-  unsigned allocsize_1 = -1u;
+  unsigned allocsize_0 = 0;      // AllocSize
+  unsigned allocsize_1 = -1u;    // AllocSize
 
   MemoryAccess mem;
 


### PR DESCRIPTION
GCC 11 complains about allocsize_0 being uninitialized. I don't see any place where the uninitialized value is actually used, but let's silence the compiler warning anyway.