### PR TITLE
Add include of cstdint to resolve definition of uint64_t

### DIFF
--- a/smt/smt.h
+++ b/smt/smt.h
@@ -3,6 +3,7 @@
 // Copyright (c) 2018-present The Alive2 Authors.
 // Distributed under the MIT license that can be found in the LICENSE file.
 
+#include <cstdint>
 #include <string>
 
 namespace smt {

--- a/tools/alive_lexer.h
+++ b/tools/alive_lexer.h
@@ -3,6 +3,7 @@
 // Copyright (c) 2018-present The Alive2 Authors.
 // Distributed under the MIT license that can be found in the LICENSE file.
 
+#include <cstdint>
 #include <string>
 #include <string_view>
 


### PR DESCRIPTION
This resolves a compilation error experienced on Fedora 38 due to lack of type definition for uint64_t.