### PR TITLE
fix broken build

### DIFF
--- a/tools/alive-exec.cpp
+++ b/tools/alive-exec.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) 2018-present The Alive2 Authors.
 // Distributed under the MIT license that can be found in the LICENSE file.
 
+#include "cache/cache.h"
 #include "llvm_util/llvm2alive.h"
 #include "llvm_util/utils.h"
 #include "smt/smt.h"
@@ -192,6 +193,8 @@ optional<StateValue> exec(llvm::Function &F,
   UNREACHABLE();
 }
 }
+
+unique_ptr<Cache> cache;
 
 int main(int argc, char **argv) {
   llvm::sys::PrintStackTraceOnErrorSignal(argv[0]);


### PR DESCRIPTION
the cache gets referred to from `llvm_util/cmd_args_def.h` so we have to define/declare that stuff