### PR TITLE
Tweak ReadMe: Variablize uses of ~/llvm in the build instructions,

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,11 +75,11 @@ cmake -GNinja -DCMAKE_PREFIX_PATH=$LLVM2_HOME/llvm/build -DBUILD_TV=1 -DCMAKE_BU
 
 Translation validation of one or more LLVM passes transforming an IR file on Linux:
 ```
-$LLVM2_HOME/llvm/build/bin/opt -load $HOME/alive2/build/tv/tv.so -load-pass-plugin $HOME/alive2/build/tv/tv.so -tv -instcombine -tv -o /dev/null foo.ll
+$LLVM2_HOME/llvm/build/bin/opt -load $ALIVE2_HOME/alive2/build/tv/tv.so -load-pass-plugin $ALIVE2_HOME/alive2/build/tv/tv.so -tv -instcombine -tv -o /dev/null foo.ll
 ```
 On a Mac:
 ```
-$LLVM2_HOME/llvm/build/bin/opt -load $HOME/alive2/build/tv/tv.dylib -load-pass-plugin $HOME/alive2/build/tv/tv.dylib -tv -instcombine -tv -o /dev/null foo.ll
+$LLVM2_HOME/llvm/build/bin/opt -load $ALIVE2_HOME/alive2/build/tv/tv.dylib -load-pass-plugin $ALIVE2_HOME/alive2/build/tv/tv.dylib -tv -instcombine -tv -o /dev/null foo.ll
 ```
 You can run any pass or combination of passes, but on the command line
 they must be placed in between the two invocations of the Alive2 `-tv`
@@ -88,7 +88,7 @@ pass.
 
 Translation validation of a single LLVM unit test, using lit:
 ```
-$LLVM2_HOME/llvm/build/bin/llvm-lit -vv -Dopt=$HOME/alive2/build/opt-alive.sh $LLVM2_HOME/llvm/llvm/test/Transforms/InstCombine/canonicalize-constant-low-bit-mask-and-icmp-sge-to-icmp-sle.ll
+$LLVM2_HOME/llvm/build/bin/llvm-lit -vv -Dopt=$ALIVE2_HOME/alive2/build/opt-alive.sh $LLVM2_HOME/llvm/llvm/test/Transforms/InstCombine/canonicalize-constant-low-bit-mask-and-icmp-sge-to-icmp-sle.ll
 ```
 
 The output should be:
@@ -103,7 +103,7 @@ To run translation validation on all the LLVM unit tests for IR-level
 transformations:
 
 ```
-$LLVM2_HOME/llvm/build/bin/llvm-lit -vv -Dopt=$HOME/alive2/build/opt-alive.sh $LLVM2_HOME/llvm/llvm/test/Transforms
+$LLVM2_HOME/llvm/build/bin/llvm-lit -vv -Dopt=$ALIVE2_HOME/alive2/build/opt-alive.sh $LLVM2_HOME/llvm/llvm/test/Transforms
 ```
 
 We run this command on the main LLVM branch each day, and keep track of the results
@@ -118,15 +118,15 @@ by LLVM.  Invoke the plugin like this:
 
 ```
 $ clang -O3 <src.c> -S -emit-llvm \
-  -fpass-plugin=$HOME/alive2/build/tv/tv.so \
-  -Xclang -load -Xclang $HOME/alive2/build/tv/tv.so
+  -fpass-plugin=$ALIVE2_HOME/alive2/build/tv/tv.so \
+  -Xclang -load -Xclang $ALIVE2_HOME/alive2/build/tv/tv.so
 ```
 
 Or, more conveniently:
 
 ```
-$ $HOME/alive2/build/alivecc -O3 -c <src.c>
-$ $HOME/alive2/build/alive++ -O3 -c <src.cpp>
+$ $ALIVE2_HOME/alive2/build/alivecc -O3 -c <src.c>
+$ $ALIVE2_HOME/alive2/build/alive++ -O3 -c <src.cpp>
 ```
 
 The Clang plugin can optionally use multiple cores. To enable parallel

--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ Building
 --------
 
 ```
+export ALIVE2_HOME=$PWD
+export LLVM2_HOME=$PWD
 mkdir build
 cd build
 cmake -GNinja -DCMAKE_BUILD_TYPE=Release ..
@@ -68,16 +70,16 @@ cmake -GNinja -DLLVM_ENABLE_RTTI=ON -DLLVM_ENABLE_EH=ON -DBUILD_SHARED_LIBS=ON -
 
 Alive2 should then be configured as follows:
 ```
-cmake -GNinja -DCMAKE_PREFIX_PATH=~/llvm/build -DBUILD_TV=1 -DCMAKE_BUILD_TYPE=Release ..
+cmake -GNinja -DCMAKE_PREFIX_PATH=$LLVM2_HOME/llvm/build -DBUILD_TV=1 -DCMAKE_BUILD_TYPE=Release ..
 ```
 
 Translation validation of one or more LLVM passes transforming an IR file on Linux:
 ```
-~/llvm/build/bin/opt -load $HOME/alive2/build/tv/tv.so -load-pass-plugin $HOME/alive2/build/tv/tv.so -tv -instcombine -tv -o /dev/null foo.ll
+$LLVM2_HOME/llvm/build/bin/opt -load $HOME/alive2/build/tv/tv.so -load-pass-plugin $HOME/alive2/build/tv/tv.so -tv -instcombine -tv -o /dev/null foo.ll
 ```
 On a Mac:
 ```
-~/llvm/build/bin/opt -load $HOME/alive2/build/tv/tv.dylib -load-pass-plugin $HOME/alive2/build/tv/tv.dylib -tv -instcombine -tv -o /dev/null foo.ll
+$LLVM2_HOME/llvm/build/bin/opt -load $HOME/alive2/build/tv/tv.dylib -load-pass-plugin $HOME/alive2/build/tv/tv.dylib -tv -instcombine -tv -o /dev/null foo.ll
 ```
 You can run any pass or combination of passes, but on the command line
 they must be placed in between the two invocations of the Alive2 `-tv`
@@ -86,7 +88,7 @@ pass.
 
 Translation validation of a single LLVM unit test, using lit:
 ```
-~/llvm/build/bin/llvm-lit -vv -Dopt=$HOME/alive2/build/opt-alive.sh ~/llvm/llvm/test/Transforms/InstCombine/canonicalize-constant-low-bit-mask-and-icmp-sge-to-icmp-sle.ll
+$LLVM2_HOME/llvm/build/bin/llvm-lit -vv -Dopt=$HOME/alive2/build/opt-alive.sh $LLVM2_HOME/llvm/llvm/test/Transforms/InstCombine/canonicalize-constant-low-bit-mask-and-icmp-sge-to-icmp-sle.ll
 ```
 
 The output should be:
@@ -101,7 +103,7 @@ To run translation validation on all the LLVM unit tests for IR-level
 transformations:
 
 ```
-~/llvm/build/bin/llvm-lit -vv -Dopt=$HOME/alive2/build/opt-alive.sh ~/llvm/llvm/test/Transforms
+$LLVM2_HOME/llvm/build/bin/llvm-lit -vv -Dopt=$HOME/alive2/build/opt-alive.sh $LLVM2_HOME/llvm/llvm/test/Transforms
 ```
 
 We run this command on the main LLVM branch each day, and keep track of the results

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Building
 ```
 export ALIVE2_HOME=$PWD
 export LLVM2_HOME=$PWD
+export LLVM2_BUILD=$LLVM2_HOME/llvm/build
 git clone git@github.com:AliveToolkit/alive2.git
 cd alive2
 mkdir build
@@ -72,16 +73,16 @@ cmake -GNinja -DLLVM_ENABLE_RTTI=ON -DLLVM_ENABLE_EH=ON -DBUILD_SHARED_LIBS=ON -
 
 Alive2 should then be configured as follows:
 ```
-cmake -GNinja -DCMAKE_PREFIX_PATH=$LLVM2_HOME/llvm/build -DBUILD_TV=1 -DCMAKE_BUILD_TYPE=Release ..
+cmake -GNinja -DCMAKE_PREFIX_PATH=$LLVM2_BUILD -DBUILD_TV=1 -DCMAKE_BUILD_TYPE=Release ..
 ```
 
 Translation validation of one or more LLVM passes transforming an IR file on Linux:
 ```
-$LLVM2_HOME/llvm/build/bin/opt -load $ALIVE2_HOME/alive2/build/tv/tv.so -load-pass-plugin $ALIVE2_HOME/alive2/build/tv/tv.so -tv -instcombine -tv -o /dev/null foo.ll
+$LLVM2_BUILD/bin/opt -load $ALIVE2_HOME/alive2/build/tv/tv.so -load-pass-plugin $ALIVE2_HOME/alive2/build/tv/tv.so -tv -instcombine -tv -o /dev/null foo.ll
 ```
 On a Mac:
 ```
-$LLVM2_HOME/llvm/build/bin/opt -load $ALIVE2_HOME/alive2/build/tv/tv.dylib -load-pass-plugin $ALIVE2_HOME/alive2/build/tv/tv.dylib -tv -instcombine -tv -o /dev/null foo.ll
+$LLVM2_BUILD/bin/opt -load $ALIVE2_HOME/alive2/build/tv/tv.dylib -load-pass-plugin $ALIVE2_HOME/alive2/build/tv/tv.dylib -tv -instcombine -tv -o /dev/null foo.ll
 ```
 You can run any pass or combination of passes, but on the command line
 they must be placed in between the two invocations of the Alive2 `-tv`
@@ -90,7 +91,7 @@ pass.
 
 Translation validation of a single LLVM unit test, using lit:
 ```
-$LLVM2_HOME/llvm/build/bin/llvm-lit -vv -Dopt=$ALIVE2_HOME/alive2/build/opt-alive.sh $LLVM2_HOME/llvm/llvm/test/Transforms/InstCombine/canonicalize-constant-low-bit-mask-and-icmp-sge-to-icmp-sle.ll
+$LLVM2_BUILD/bin/llvm-lit -vv -Dopt=$ALIVE2_HOME/alive2/build/opt-alive.sh $LLVM2_HOME/llvm/llvm/test/Transforms/InstCombine/canonicalize-constant-low-bit-mask-and-icmp-sge-to-icmp-sle.ll
 ```
 
 The output should be:
@@ -105,7 +106,7 @@ To run translation validation on all the LLVM unit tests for IR-level
 transformations:
 
 ```
-$LLVM2_HOME/llvm/build/bin/llvm-lit -vv -Dopt=$ALIVE2_HOME/alive2/build/opt-alive.sh $LLVM2_HOME/llvm/llvm/test/Transforms
+$LLVM2_BUILD/bin/llvm-lit -vv -Dopt=$ALIVE2_HOME/alive2/build/opt-alive.sh $LLVM2_HOME/llvm/llvm/test/Transforms
 ```
 
 We run this command on the main LLVM branch each day, and keep track of the results

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ cd $LLVM2_HOME
 mkdir build
 cd build
 cmake -GNinja -DLLVM_ENABLE_RTTI=ON -DLLVM_ENABLE_EH=ON -DBUILD_SHARED_LIBS=ON -DCMAKE_BUILD_TYPE=Release -DLLVM_TARGETS_TO_BUILD=X86 -DLLVM_ENABLE_ASSERTIONS=ON -DLLVM_ENABLE_PROJECTS="llvm;clang" ../llvm
+ninja
 ```
 
 Alive2 should then be configured as follows:

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Building and Running Translation Validation
 
 Alive2's `opt` and `clang` translation validation requires a build of LLVM with
 RTTI and exceptions turned on.
-LLVM can be built in the following way:
+LLVM can be built targeting X86 in the following way:
 ```
 cd llvm
 mkdir build

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Building and Running Translation Validation
 
 Alive2's `opt` and `clang` translation validation requires a build of LLVM with
 RTTI and exceptions turned on.
-LLVM can be built targeting X86 in the following way:
+LLVM can be built targeting X86 in the following way.  (You may prefer to add `-DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++` to the CMake step if your default compiler is `gcc`.)
 ```
 cd $LLVM2_HOME
 mkdir build

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ cmake -GNinja -DLLVM_ENABLE_RTTI=ON -DLLVM_ENABLE_EH=ON -DBUILD_SHARED_LIBS=ON -
 
 Alive2 should then be configured as follows:
 ```
+cd $ALIVE2_HOME/alive2/build
 cmake -GNinja -DCMAKE_PREFIX_PATH=$LLVM2_BUILD -DBUILD_TV=1 -DCMAKE_BUILD_TYPE=Release ..
 ```
 

--- a/README.md
+++ b/README.md
@@ -33,10 +33,10 @@ Prerequisites
 To build Alive2 you need recent versions of:
 * cmake
 * gcc/clang
-* re2c
-* Z3
+* [re2c](https://re2c.org/)
+* [Z3](https://github.com/Z3Prover/z3)
 * LLVM (optional)
-* hiredis (optional, needed for caching)
+* [hiredis](https://github.com/redis/hiredis) (optional, needed for caching)
 
 
 Building

--- a/README.md
+++ b/README.md
@@ -31,11 +31,11 @@ spurious counterexamples if run with such passes.
 Prerequisites
 -------------
 To build Alive2 you need recent versions of:
-* cmake
-* gcc/clang
+* [cmake](https://cmake.org)
+* [gcc](https://gcc.gnu.org)/[clang](https://clang.llvm.org)
 * [re2c](https://re2c.org/)
 * [Z3](https://github.com/Z3Prover/z3)
-* LLVM (optional)
+* [LLVM](https://llvm.org) (optional)
 * [hiredis](https://github.com/redis/hiredis) (optional, needed for caching)
 
 

--- a/README.md
+++ b/README.md
@@ -83,6 +83,12 @@ Translation validation of one or more LLVM passes transforming an IR file on Lin
 ```
 $LLVM2_BUILD/bin/opt -load $ALIVE2_HOME/alive2/build/tv/tv.so -load-pass-plugin $ALIVE2_HOME/alive2/build/tv/tv.so -tv -instcombine -tv -o /dev/null foo.ll
 ```
+For the new pass manager:
+```
+$LLVM2_BUILD/bin/opt -load $ALIVE2_HOME/alive2/build/tv/tv.so -load-pass-plugin $ALIVE2_HOME/alive2/build/tv/tv.so -passes=tv -passes=instcombine -passes=tv -o /dev/null $LLVM2_HOME/llvm/test/Analysis/AssumptionCache/basic.ll
+```
+
+
 On a Mac:
 ```
 $LLVM2_BUILD/bin/opt -load $ALIVE2_HOME/alive2/build/tv/tv.dylib -load-pass-plugin $ALIVE2_HOME/alive2/build/tv/tv.dylib -tv -instcombine -tv -o /dev/null foo.ll

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Building
 
 ```
 export ALIVE2_HOME=$PWD
-export LLVM2_HOME=$PWD
+export LLVM2_HOME=$PWD/llvm-project
 export LLVM2_BUILD=$LLVM2_HOME/llvm/build
 git clone git@github.com:AliveToolkit/alive2.git
 cd alive2
@@ -65,7 +65,7 @@ Alive2's `opt` and `clang` translation validation requires a build of LLVM with
 RTTI and exceptions turned on.
 LLVM can be built targeting X86 in the following way:
 ```
-cd $LLVM2_HOME/llvm
+cd $LLVM2_HOME
 mkdir build
 cd build
 cmake -GNinja -DLLVM_ENABLE_RTTI=ON -DLLVM_ENABLE_EH=ON -DBUILD_SHARED_LIBS=ON -DCMAKE_BUILD_TYPE=Release -DLLVM_TARGETS_TO_BUILD=X86 -DLLVM_ENABLE_ASSERTIONS=ON -DLLVM_ENABLE_PROJECTS="llvm;clang" ../llvm

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Building
 ```
 export ALIVE2_HOME=$PWD
 export LLVM2_HOME=$PWD/llvm-project
-export LLVM2_BUILD=$LLVM2_HOME/llvm/build
+export LLVM2_BUILD=$LLVM2_HOME/build
 git clone git@github.com:AliveToolkit/alive2.git
 cd alive2
 mkdir build

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ To build Alive2 you need recent versions of:
 * [gcc](https://gcc.gnu.org)/[clang](https://clang.llvm.org)
 * [re2c](https://re2c.org/)
 * [Z3](https://github.com/Z3Prover/z3)
-* [LLVM](https://llvm.org) (optional)
+* [LLVM](https://github.com/llvm/llvm-project) (optional)
 * [hiredis](https://github.com/redis/hiredis) (optional, needed for caching)
 
 

--- a/README.md
+++ b/README.md
@@ -72,10 +72,11 @@ cmake -GNinja -DLLVM_ENABLE_RTTI=ON -DLLVM_ENABLE_EH=ON -DBUILD_SHARED_LIBS=ON -
 ninja
 ```
 
-Alive2 should then be configured as follows:
+Alive2 should then be configured and built as follows:
 ```
 cd $ALIVE2_HOME/alive2/build
 cmake -GNinja -DCMAKE_PREFIX_PATH=$LLVM2_BUILD -DBUILD_TV=1 -DCMAKE_BUILD_TYPE=Release ..
+ninja
 ```
 
 Translation validation of one or more LLVM passes transforming an IR file on Linux:

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ Building
 ```
 export ALIVE2_HOME=$PWD
 export LLVM2_HOME=$PWD
+git clone git@github.com:AliveToolkit/alive2.git
+cd alive2
 mkdir build
 cd build
 cmake -GNinja -DCMAKE_BUILD_TYPE=Release ..
@@ -62,7 +64,7 @@ Alive2's `opt` and `clang` translation validation requires a build of LLVM with
 RTTI and exceptions turned on.
 LLVM can be built targeting X86 in the following way:
 ```
-cd llvm
+cd $LLVM2_HOME/llvm
 mkdir build
 cd build
 cmake -GNinja -DLLVM_ENABLE_RTTI=ON -DLLVM_ENABLE_EH=ON -DBUILD_SHARED_LIBS=ON -DCMAKE_BUILD_TYPE=Release -DLLVM_TARGETS_TO_BUILD=X86 -DLLVM_ENABLE_ASSERTIONS=ON -DLLVM_ENABLE_PROJECTS="llvm;clang" ../llvm


### PR DESCRIPTION
- and other hard-coded directories.
- Add official links for prerequisites.
- Add the obvious Ninja build steps.
- Note X86-centricity.

I’ve tested these on Mac and Linux up to the TV Build instructions, at which point I get CMake and/or linkage problems, but that’s presumably a separate issue.