### PR TITLE
ReadMe: Diagnosing Unsoundness Reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,14 +313,14 @@ Diagnosing Unsoundness Reports
 --------
 
 * Select a failing test file. It may be convenient to choose one whose path is given at the beginning of a log file containing the text "(unsound)" as above; this is guaranteed to contain an unsoundness report.  Many log files, however, contain only “Source: <stdin>” rather than a file path.
-* Do a verbose run of Lit for just that file, with the `opt`  option `--print-after-all` appended e.g.
+* Do a verbose run of Lit for just that file, with the `opt`  option `--print-after-all` appended, e.g. (as of Alive2 commit 43c51831 and LLVM b2417f51dbbd):
 ```
 $LLVM2_BUILD/bin/llvm-lit -vva "-Dopt=$ALIVE2_HOME/alive2/build/opt-alive.sh --print-after-all" $LLVM2_HOME/llvm/test/Transforms/InstCombine/insert-const-shuf.ll
 ```
 * Collect Lit’s LLVM IR terminal output, for comparison with Alive2’s Alive2 IR output in the log file indicated by “Report written to…”.
-* The Alive2 unsoundness report in the corresponding log file will have two versions of the misoptimized function.  The Alive2 IR function body may indicate the problem to a human.   For the Alive2 Compiler Explorer instance you will need LLVM IR.  Search for the function name in the terminal output.
+* The Alive2 unsoundness report in the corresponding log file will have two versions of the misoptimized function.  The Alive2 IR function body may indicate the problem to a human, but for the Alive2 Compiler Explorer instance you will need LLVM IR.  Search for the function name in the terminal output.
 * Copy the first function definition and necessary declarations to [https://alive2.llvm.org/ce/](https://alive2.llvm.org/ce/).  Without a second version of the function to compare, it just runs some standard optimizations; if it reports an error, your fork’s optimizations are not to blame.
-* Otherwise copy the second, unsound, function definition and necessary declarations, and change the second function name.
+* If there is a second, unsound, function definition in the LLVM IR terminal output, copy it and necessary declarations to Compiler Explorer, and change the second function name.
 * If it now reports a miscompilation, presumably your fork has a bug, demonstrated by the provided examples.
 
 

--- a/README.md
+++ b/README.md
@@ -312,7 +312,7 @@ should be the only user of this server.
 Diagnosing Unsoundness Reports
 --------
 
-* Select a failing test file. It may be convenient to choose one whose path is given at the beginning of a log file containing the text "(unsound)" as above; this is guaranteed to contain an unsoundness report.  Many log files, however, contain only “Source: <stdin>” rather than a file path.
+* Select a failing test file. It may be convenient to choose one whose path is given at the beginning of a log file containing the text "(unsound)" as above; this is guaranteed to contain an unsoundness report.  Many log files, however, contain only “Source: <stdin>” rather than a file path; the names of these files begin with “in_”.
 * Do a verbose run of Lit for just that file, with the `opt`  option `--print-after-all` appended, e.g. (as of Alive2 commit 43c51831 and LLVM b2417f51dbbd):
 ```
 $LLVM2_BUILD/bin/llvm-lit -vva "-Dopt=$ALIVE2_HOME/alive2/build/opt-alive.sh --print-after-all" $LLVM2_HOME/llvm/test/Transforms/InstCombine/insert-const-shuf.ll

--- a/README.md
+++ b/README.md
@@ -312,7 +312,7 @@ should be the only user of this server.
 Diagnosing Unsoundness Reports
 --------
 
-* Select a failing test file. It may be convenient to choose one whose path is given at the beginning of a log file containing the text "(unsound)" as above; this is guaranteed to contain an unsoundness report.  Many log files, however, contain only “Source: <stdin>” rather than a file path; the names of these files begin with “in_”.
+* Select a failing test file. It may be convenient to choose one whose path is given at the beginning of a log file containing the text "(unsound)" as above; this is guaranteed to contain an unsoundness report.  Many log files, however, contain only “Source: \<stdin\>” rather than a file path; the names of these files begin with “in_”.
 * Do a verbose run of Lit for just that file, with the `opt`  option `--print-after-all` appended, e.g. (as of Alive2 commit 43c51831 and LLVM b2417f51dbbd):
 ```
 $LLVM2_BUILD/bin/llvm-lit -vva "-Dopt=$ALIVE2_HOME/alive2/build/opt-alive.sh --print-after-all" $LLVM2_HOME/llvm/test/Transforms/InstCombine/insert-const-shuf.ll

--- a/README.md
+++ b/README.md
@@ -317,9 +317,9 @@ installations of LLVM, e.g., under `/opt/`, if these are not set properly.
 * Some combinations of Clang and MacOS versions may give link warnings 
 “-undefined dynamic_lookup may not work with chained fixups,” and
 runtime errors with “symbol not found in flat namespace.”  Setting
-[CMAKE_OSX_DEPLOYMENT_TARGET](https://cmake.org/cmake/help/latest/variable/
-CMAKE_OSX_DEPLOYMENT_TARGET.html) as a cache entry to 11.0
-or less at the beginning of CMakeLists.txt may work around this.
+[CMAKE_OSX_DEPLOYMENT_TARGET](https://cmake.org/cmake/help/latest/variable/CMAKE_OSX_DEPLOYMENT_TARGET.html)
+as a cache entry to 11.0 or less at the beginning of CMakeLists.txt may work
+around this.
 * Building for Translation Validation requires enabling `BUILD_SHARED_LIBS`. 
 For LLVM forks not normally built with the option, this may interfere with
 CMake files’ use of `USEDLIBS` and `LLVMLIBS` and perhaps `dd_llvm_target`. 

--- a/README.md
+++ b/README.md
@@ -318,8 +318,7 @@ this is guaranteed to contain an unsoundness report.  Many log files, however,
 contain only “Source: \<stdin\>” rather than a file path; the names of these
 files begin with “in_”.
 * Do a verbose run of Lit for just that file, with the `opt`  option
-`--print-after-all` appended, e.g. (as of Alive2 commit 43c51831 and LLVM
-b2417f51dbbd):
+`--print-after-all` appended, e.g.:
 ```
 $LLVM2_BUILD/bin/llvm-lit -vva "-Dopt=$ALIVE2_HOME/alive2/build/opt-alive.sh --print-after-all" $LLVM2_HOME/llvm/test/Transforms/InstCombine/insert-const-shuf.ll
 ```

--- a/README.md
+++ b/README.md
@@ -309,6 +309,21 @@ If you want to use this functionality, you will need to manually start
 and stop, as appropriate, a Redis server instance on localhost. Alive2
 should be the only user of this server.
 
+Diagnosing Unsoundness Reports
+--------
+
+* Select a failing test file. It may be convenient to choose one whose path is given at the beginning of a log file containing the text "(unsound)" as above; this is guaranteed to contain an unsoundness report.  Many log files, however, contain only “Source: <stdin>” rather than a file path.
+* Do a verbose run of Lit for just that file, with the `opt`  option `--print-after-all` appended e.g.
+```
+$LLVM2_BUILD/bin/llvm-lit -vva "-Dopt=$ALIVE2_HOME/alive2/build/opt-alive.sh --print-after-all" $LLVM2_HOME/llvm/test/Transforms/InstCombine/insert-const-shuf.ll
+```
+* Collect Lit’s LLVM IR terminal output, for comparison with Alive2’s Alive2 IR output in the log file indicated by “Report written to…”.
+* The Alive2 unsoundness report in the corresponding log file will have two versions of the misoptimized function.  The Alive2 IR function body may indicate the problem to a human.   For the Alive2 Compiler Explorer instance you will need LLVM IR.  Search for the function name in the terminal output.
+* Copy the first function definition and necessary declarations to [https://alive2.llvm.org/ce/](https://alive2.llvm.org/ce/).  Without a second version of the function to compare, it just runs some standard optimizations; if it reports an error, your fork’s optimizations are not to blame.
+* Otherwise copy the second, unsound, function definition and necessary declarations, and change the second function name.
+* If it now reports a miscompilation, presumably your fork has a bug, demonstrated by the provided examples.
+
+
 Troubleshooting
 --------
 * Check the “LLVMConfig.cmake” and “CMAKE_PREFIX_PATH” output from CMake in

--- a/README.md
+++ b/README.md
@@ -312,16 +312,32 @@ should be the only user of this server.
 Diagnosing Unsoundness Reports
 --------
 
-* Select a failing test file. It may be convenient to choose one whose path is given at the beginning of a log file containing the text "(unsound)" as above; this is guaranteed to contain an unsoundness report.  Many log files, however, contain only “Source: \<stdin\>” rather than a file path; the names of these files begin with “in_”.
-* Do a verbose run of Lit for just that file, with the `opt`  option `--print-after-all` appended, e.g. (as of Alive2 commit 43c51831 and LLVM b2417f51dbbd):
+* Select a failing test file. It may be convenient to choose one whose path is
+given at the beginning of a log file containing the text "(unsound)" as above;
+this is guaranteed to contain an unsoundness report.  Many log files, however,
+contain only “Source: \<stdin\>” rather than a file path; the names of these
+files begin with “in_”.
+* Do a verbose run of Lit for just that file, with the `opt`  option
+`--print-after-all` appended, e.g. (as of Alive2 commit 43c51831 and LLVM
+b2417f51dbbd):
 ```
 $LLVM2_BUILD/bin/llvm-lit -vva "-Dopt=$ALIVE2_HOME/alive2/build/opt-alive.sh --print-after-all" $LLVM2_HOME/llvm/test/Transforms/InstCombine/insert-const-shuf.ll
 ```
-* Collect Lit’s LLVM IR terminal output, for comparison with Alive2’s Alive2 IR output in the log file indicated by “Report written to…”.
-* The Alive2 unsoundness report in the corresponding log file will have two versions of the misoptimized function.  The Alive2 IR function body may indicate the problem to a human, but for the Alive2 Compiler Explorer instance you will need LLVM IR.  Search for the function name in the terminal output.
-* Copy the first function definition and necessary declarations to [https://alive2.llvm.org/ce/](https://alive2.llvm.org/ce/).  Without a second version of the function to compare, it just runs some standard optimizations; if it reports an error, your fork’s optimizations are not to blame.
-* If there is a second, unsound, function definition in the LLVM IR terminal output, copy it and necessary declarations to Compiler Explorer, and change the second function name.
-* If it now reports a miscompilation, presumably your fork has a bug, demonstrated by the provided examples.
+* Collect Lit’s LLVM IR terminal output, for comparison with Alive2’s Alive2 IR
+output in the log file indicated by “Report written to…”.
+* The Alive2 unsoundness report in the corresponding log file will have two
+versions of the misoptimized function.  The Alive2 IR function body may
+indicate the problem to a human, but for the Alive2 Compiler Explorer instance
+you will need LLVM IR.  Search for the function name in the terminal output.
+* Copy the first function definition and necessary declarations to
+[https://alive2.llvm.org/ce/](https://alive2.llvm.org/ce/).  Without a second
+version of the function to compare, it just runs some standard optimizations;
+if it reports an error, your fork’s optimizations are not to blame.
+* If there is a second, unsound, function definition in the LLVM IR terminal
+output, copy it and necessary declarations to Compiler Explorer, and change the
+second function name.
+* If it now reports a miscompilation, presumably your fork has a bug,
+demonstrated by the provided examples.
 
 
 Troubleshooting

--- a/README.md
+++ b/README.md
@@ -324,7 +324,9 @@ b2417f51dbbd):
 $LLVM2_BUILD/bin/llvm-lit -vva "-Dopt=$ALIVE2_HOME/alive2/build/opt-alive.sh --print-after-all" $LLVM2_HOME/llvm/test/Transforms/InstCombine/insert-const-shuf.ll
 ```
 * Collect Lit’s LLVM IR terminal output, for comparison with Alive2’s Alive2 IR
-output in the log file indicated by “Report written to…”.
+output in the log file indicated by “Report written to…”.  Sometimes the Lit
+output may not contain useful LLVM IR, in which case executing the output
+RUN command separately may give better results.
 * The Alive2 unsoundness report in the corresponding log file will have two
 versions of the misoptimized function.  The Alive2 IR function body may
 indicate the problem to a human, but for the Alive2 Compiler Explorer instance


### PR DESCRIPTION
* Instructions for using the Alive2 IR in its log files to find LLVM IR for use in diagnosing unsoundness reports, especially with the Alive2 Compiler Explorer instance.
* Also unwrap a link broken by wrapping.