### PR TITLE
as Nuno suggested, add @llvm.assert which in Alive is just an alias

### DIFF
--- a/llvm_util/llvm2alive.cpp
+++ b/llvm_util/llvm2alive.cpp
@@ -328,7 +328,7 @@ public:
 					       { llvm::Type::getInt1Ty(ctx) },
 					       false);
       if (fn->getFunctionType() == assertTy)
-	return make_unique<Assume>(*args[0], Assume::WellDefined);
+	return make_unique<Assume>(*args[0], Assume::AndNonPoison);
     }
 
     parse_fn_attrs(i, attrs, true);

--- a/tests/alive-tv/assume/assert.srctgt.ll
+++ b/tests/alive-tv/assume/assert.srctgt.ll
@@ -1,0 +1,16 @@
+declare void @llvm.assert(i1)
+
+; LLVM isn't free to remove @llvm.assert, but it's still a refinement
+; from Alive's point of view
+
+define void @src(i16, i16) {
+  %c = icmp eq i16 %0, %1
+  call void @llvm.assert(i1 %c)
+  ret void
+}
+
+define void @tgt(i16, i16) {
+  ret void
+}
+
+


### PR DESCRIPTION
for @llvm.assume, but LLVM doesn't have any semantics for it, so treats it as opaque, so we don't have to worry about LLVM removing it