### PR TITLE
Infer poison-generating flags

### DIFF
--- a/llvm_util/cmd_args_list.h
+++ b/llvm_util/cmd_args_list.h
@@ -185,4 +185,9 @@ llvm::cl::opt<bool> opt_disallow_ub_exploitation(
   llvm::cl::desc("Disallow UB exploitation by optimizations (default=allow)"),
   llvm::cl::init(false), llvm::cl::cat(alive_cmdargs));
 
+llvm::cl::opt<bool> opt_refine_tgt(
+  LLVM_ARGS_PREFIX "refine-tgt",
+  llvm::cl::desc("Allow poison generating flags inference for target"),
+  llvm::cl::init(false), llvm::cl::cat(alive_cmdargs));
+
 }

--- a/llvm_util/compare.cpp
+++ b/llvm_util/compare.cpp
@@ -6,6 +6,9 @@
 #include "llvm_util/llvm_optimizer.h"
 #include "smt/smt.h"
 #include "tools/transform.h"
+#include "llvm/IR/PatternMatch.h"
+#include "llvm/Support/raw_os_ostream.h"
+#include "llvm/Transforms/Utils/Cloning.h"
 
 #include <sstream>
 #include <utility>
@@ -41,7 +44,7 @@ struct Results {
 Results verify(llvm::Function &F1, llvm::Function &F2,
                llvm::TargetLibraryInfoWrapperPass &TLI,
                smt::smt_initializer &smt_init, ostream &out,
-               bool print_transform, bool always_verify) {
+               bool print_transform, bool always_verify, bool refine_tgt) {
   auto fn1 = llvm2alive(F1, TLI.getTLI(F1), true);
   if (!fn1)
     return Results::Error("Could not translate '" + F1.getName().str() +
@@ -89,6 +92,105 @@ Results verify(llvm::Function &F1, llvm::Function &F2,
     r.status = r.errs.isUnsound() ? Results::UNSOUND : Results::FAILED_TO_PROVE;
   } else {
     r.status = Results::CORRECT;
+
+    if (refine_tgt) {
+      bool changed = false;
+      auto src = std::move(r.t.src);
+      llvm::ValueToValueMapTy vmap;
+      auto F3 = llvm::CloneFunction(&F2, vmap);
+
+      auto verify = [&] {
+        auto fn3 = llvm2alive(*F3, TLI.getTLI(*F3), false,
+                              r.t.src.getGlobalVarNames());
+        assert(fn3);
+
+        Transform t;
+        t.src = std::move(src);
+        t.tgt = std::move(*fn3);
+        smt_init.reset();
+        t.preprocess();
+        TransformVerify verifier(t, false);
+        auto errs = verifier.verify();
+        src = std::move(t.src);
+        return !errs;
+      };
+
+      for (auto &BB : *F3)
+        for (auto &I : BB) {
+          using namespace llvm::PatternMatch;
+
+          if (llvm::isa<llvm::ZExtInst>(I)) {
+            if (!I.hasNonNeg()) {
+              I.setNonNeg(true);
+              if (verify())
+                changed = true;
+              else
+                I.setNonNeg(false);
+            }
+          } else if (llvm::isa<llvm::OverflowingBinaryOperator>(I)) {
+            if (!I.hasNoSignedWrap()) {
+              I.setHasNoSignedWrap(true);
+              if (verify())
+                changed = true;
+              else
+                I.setHasNoSignedWrap(false);
+            }
+            if (!I.hasNoUnsignedWrap()) {
+              I.setHasNoUnsignedWrap(true);
+              if (verify())
+                changed = true;
+              else
+                I.setHasNoUnsignedWrap(false);
+            }
+          } else if (llvm::isa<llvm::PossiblyExactOperator>(I)) {
+            if (!I.isExact()) {
+              I.setIsExact(true);
+              if (verify())
+                changed = true;
+              else
+                I.setIsExact(false);
+            }
+          } else if (auto gep = llvm::dyn_cast<llvm::GetElementPtrInst>(&I)) {
+            if (!gep->isInBounds()) {
+              gep->setIsInBounds(true);
+              if (verify())
+                changed = true;
+              else
+                gep->setIsInBounds(false);
+            }
+          } else if (auto *call = llvm::dyn_cast<llvm::CallInst>(&I)) {
+            if (const auto *callee = call->getCalledFunction()) {
+              switch (callee->getIntrinsicID()) {
+              case llvm::Intrinsic::abs:
+              case llvm::Intrinsic::ctlz:
+              case llvm::Intrinsic::cttz: {
+                if (match(call->getArgOperand(1), m_Zero())) {
+                  call->setArgOperand(
+                      1, llvm::ConstantInt::getTrue(call->getContext()));
+                  if (verify())
+                    changed = true;
+                  else
+                    call->setArgOperand(
+                        1, llvm::ConstantInt::getFalse(call->getContext()));
+                }
+                break;
+              }
+              default:
+                break;
+              }
+            }
+          }
+        }
+
+      if (changed) {
+        out << "\nRefined target (potential optimization):\n\n";
+        llvm::raw_os_ostream os(out);
+        F3->print(os);
+      }
+
+      F3->eraseFromParent();
+      r.t.src = std::move(src);
+    }
   }
   return r;
 }
@@ -96,7 +198,8 @@ Results verify(llvm::Function &F1, llvm::Function &F2,
 } // namespace
 
 bool Verifier::compareFunctions(llvm::Function &F1, llvm::Function &F2) {
-  auto r = verify(F1, F2, TLI, smt_init, out, !quiet, always_verify);
+  auto r =
+      verify(F1, F2, TLI, smt_init, out, !quiet, always_verify, refine_tgt);
   if (r.status == Results::ERROR) {
     out << "ERROR: " << r.error;
     ++num_errors;
@@ -143,7 +246,7 @@ bool Verifier::compareFunctions(llvm::Function &F1, llvm::Function &F2) {
   }
 
   if (bidirectional) {
-    r = verify(F2, F1, TLI, smt_init, out, false, always_verify);
+    r = verify(F2, F1, TLI, smt_init, out, false, always_verify, refine_tgt);
     switch (r.status) {
     case Results::ERROR:
     case Results::TYPE_CHECKER_FAILED:

--- a/llvm_util/compare.h
+++ b/llvm_util/compare.h
@@ -22,6 +22,7 @@ struct Verifier {
   bool always_verify = false;
   bool print_dot = false;
   bool bidirectional = false;
+  bool refine_tgt = false;
 
   Verifier(llvm::TargetLibraryInfoWrapperPass &TLI,
            smt::smt_initializer &smt_init, std::ostream &out)

--- a/tools/alive-tv.cpp
+++ b/tools/alive-tv.cpp
@@ -137,6 +137,7 @@ and "tgt5" will unused.
   verifier.always_verify = opt_always_verify;
   verifier.print_dot = opt_print_dot;
   verifier.bidirectional = opt_bidirectional;
+  verifier.refine_tgt = opt_refine_tgt;
 
   unique_ptr<llvm::Module> M2;
   if (opt_file2.empty()) {

--- a/tools/quick-fuzz.cpp
+++ b/tools/quick-fuzz.cpp
@@ -927,6 +927,7 @@ reduced using llvm-reduce.
   verifier.always_verify = opt_always_verify;
   verifier.print_dot = opt_print_dot;
   verifier.bidirectional = opt_bidirectional;
+  verifier.refine_tgt = opt_refine_tgt;
 
   function<unique_ptr<Fuzzer>(Module &, long)> makeFuzzer;
   if (opt_fuzzer == "value") {

--- a/util/config.cpp
+++ b/util/config.cpp
@@ -23,6 +23,7 @@ unsigned src_unroll_cnt = 0;
 unsigned tgt_unroll_cnt = 0;
 unsigned max_offset_bits = 64;
 unsigned max_sizet_bits = 64;
+bool refine_tgt = false;
 
 ostream &dbg() {
   return *debug_os;

--- a/util/config.h
+++ b/util/config.h
@@ -44,6 +44,8 @@ extern unsigned max_offset_bits;
 // size and size of pointers (not to be confused with program pointer size).
 extern unsigned max_sizet_bits;
 
+extern bool refine_tgt;
+
 std::ostream &dbg();
 void set_debug(std::ostream &os);
 


### PR DESCRIPTION
This patch infers poison-generating flags after the original transform is proven correct.
It introduces a new option, `-refine-tgt`. When enabled, alive2 tries to add poison-generating flags and verify the transform.

Example:
```
; alive-tv test.srctgt.ll -refine-tgt 
----------------------------------------
define i8 @src(i8 %a, i8 %b) {
entry:
  %sub = sub nsw i8 0, %a
  %add = add nsw i8 %sub, %b
  ret i8 %add
}
=>
define i8 @tgt(i8 %a, i8 %b) {
entry:
  %sub = sub i8 %b, %a
  ret i8 %sub
}

Refined target (potential optimization):

define i8 @tgt.1(i8 %a, i8 %b) {
entry:
  %sub = sub nsw i8 %b, %a
  ret i8 %sub
}
Transformation seems to be correct!
```

Inspired by https://github.com/llvm/llvm-project/issues/72119, I did this work to exploit some missed optimizations.
