### PR TITLE
--verbose and --no-timeout options for opt-alive.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,7 +365,7 @@ deprecated Python 2; update the shebang line to `python3`.
 * The `opt` wrapper script `build/opt-alive.sh` accepts a `--verbose` option,
 which outputs the command passed to `opt`.  Note that this may interfere 
 with tests which check output.
-* The script also accepts a `--no-timeout` option, which disable the `opt`
+* The script also accepts a `--no-timeout` option, which disables the `opt`
 process timeout.  This timeout is not supported on Macintosh.  To change the
 SMT timeout, instead adjust the `query_timeout` constant in `smt/smt.cpp`.
 

--- a/README.md
+++ b/README.md
@@ -365,6 +365,9 @@ deprecated Python 2; update the shebang line to `python3`.
 * The `opt` wrapper script `build/opt-alive.sh` accepts a `--verbose` option,
 which outputs the command passed to `opt`.  Note that this may interfere 
 with tests which check output.
+* The script also accepts a `--no-timeout` option, which disable the `opt`
+process timeout.  This timeout is not supported on Macintosh.  To change the
+SMT timeout, instead adjust the `query_timeout` constant in `smt/smt.cpp`.
 
 LLVM Bugs Found by Alive2
 --------

--- a/README.md
+++ b/README.md
@@ -362,6 +362,9 @@ Clang versions and vendors.
 * Building older source on an up-to-date machine may require adjustments.  For
 example, the now-deleted file `scripts/rewritepass.py` depended on the
 deprecated Python 2; update the shebang line to `python3`.
+* The `opt` wrapper script `build/opt-alive.sh` accepts a `--verbose` option,
+which outputs the command passed to `opt`.  Note that this may interfere 
+with tests which check output.
 
 LLVM Bugs Found by Alive2
 --------

--- a/llvm_util/llvm2alive.cpp
+++ b/llvm_util/llvm2alive.cpp
@@ -12,6 +12,7 @@
 #include "llvm/IR/GetElementPtrTypeIterator.h"
 #include "llvm/IR/GlobalVariable.h"
 #include "llvm/IR/InlineAsm.h"
+#include "llvm/IR/InstrTypes.h"
 #include "llvm/IR/InstVisitor.h"
 #include "llvm/IR/Operator.h"
 #include "llvm/Support/ModRef.h"

--- a/scripts/opt-alive.sh.in
+++ b/scripts/opt-alive.sh.in
@@ -21,6 +21,7 @@ SKIP_TV=0
 
 NEW_ARGS=$@
 VERBOSE=0
+NO_TIMEOUT=0
 for arg in $NEW_ARGS; do
   for p in $SKIP_TV_PASSES; do
     if [[ $arg == *"$p"* || $arg == "-tbaa" ]]; then
@@ -40,7 +41,14 @@ for arg in $NEW_ARGS; do
     VERBOSE=1
     echo VERBOSE
     NEW_ARGS="${NEW_ARGS/--verbose/}"
-    break
+    continue
+  fi
+  
+  if [[ $arg == "--no-timeout" ]]; then
+    NO_TIMEOUT=1
+    echo NO_TIMEOUT
+    NEW_ARGS="${NEW_ARGS/--no-timeout/}"
+   continue
   fi
   
 done
@@ -52,7 +60,7 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
 else
   # Linux, Cygwin/Msys, or Win32?
   TV_SHAREDLIB=tv.so
-  if [[ @FOR_ALIVE2_TEST@ == 0 ]]; then
+  if [[ @FOR_ALIVE2_TEST@ == 0 && $NO_TIMEOUT == 0 ]]; then
     TIMEOUT="timeout 4000"
   fi
 fi

--- a/scripts/opt-alive.sh.in
+++ b/scripts/opt-alive.sh.in
@@ -46,7 +46,6 @@ for arg in $OPT_ARGS; do
   
   if [[ $arg == "--no-timeout" ]]; then
     NO_TIMEOUT=1
-    echo NO_TIMEOUT
     OPT_ARGS="${OPT_ARGS/--no-timeout/}"
    continue
   fi

--- a/scripts/opt-alive.sh.in
+++ b/scripts/opt-alive.sh.in
@@ -19,10 +19,10 @@ FORCE_OLD_NPM="codegenprepare interleaved-load-combine unreachableblockelim atom
 NPM_TV=1
 SKIP_TV=0
 
-NEW_ARGS=$@
+OPT_ARGS=$@
 VERBOSE=0
 NO_TIMEOUT=0
-for arg in $NEW_ARGS; do
+for arg in $OPT_ARGS; do
   for p in $SKIP_TV_PASSES; do
     if [[ $arg == *"$p"* || $arg == "-tbaa" ]]; then
       SKIP_TV=1
@@ -40,14 +40,14 @@ for arg in $NEW_ARGS; do
   if [[ $arg == "--verbose" ]]; then
     VERBOSE=1
     echo VERBOSE
-    NEW_ARGS="${NEW_ARGS/--verbose/}"
+    OPT_ARGS="${OPT_ARGS/--verbose/}"
     continue
   fi
   
   if [[ $arg == "--no-timeout" ]]; then
     NO_TIMEOUT=1
     echo NO_TIMEOUT
-    NEW_ARGS="${NEW_ARGS/--no-timeout/}"
+    OPT_ARGS="${OPT_ARGS/--no-timeout/}"
    continue
   fi
   
@@ -84,7 +84,7 @@ if [[ $SKIP_TV == 0 && $NPM_TV == 1 ]]; then
   NPM_PLUGIN="-load-pass-plugin=@CMAKE_BINARY_DIR@/tv/$TV_SHAREDLIB"
 fi
 
-COMMAND="$TIMEOUT @LLVM_BINARY_DIR@/bin/opt -load=@CMAKE_BINARY_DIR@/tv/$TV_SHAREDLIB  $NPM_PLUGIN -tv-exit-on-error $TV $NEW_ARGS $TV $TV_SMT_TO $TV_REPORT_DIR $TV_SMT_STATS"
+COMMAND="$TIMEOUT @LLVM_BINARY_DIR@/bin/opt -load=@CMAKE_BINARY_DIR@/tv/$TV_SHAREDLIB  $NPM_PLUGIN -tv-exit-on-error $TV $OPT_ARGS $TV $TV_SMT_TO $TV_REPORT_DIR $TV_SMT_STATS"
 
 if [[ $VERBOSE == 1 ]]; then
   echo COMMAND: $COMMAND

--- a/scripts/opt-alive.sh.in
+++ b/scripts/opt-alive.sh.in
@@ -19,7 +19,9 @@ FORCE_OLD_NPM="codegenprepare interleaved-load-combine unreachableblockelim atom
 NPM_TV=1
 SKIP_TV=0
 
-for arg in $@; do
+NEW_ARGS=$@
+VERBOSE=0
+for arg in $NEW_ARGS; do
   for p in $SKIP_TV_PASSES; do
     if [[ $arg == *"$p"* || $arg == "-tbaa" ]]; then
       SKIP_TV=1
@@ -33,6 +35,14 @@ for arg in $@; do
       break
     fi
   done
+  
+  if [[ $arg == "--verbose" ]]; then
+    VERBOSE=1
+    echo VERBOSE
+    NEW_ARGS="${NEW_ARGS/--verbose/}"
+    break
+  fi
+  
 done
 
 TIMEOUT=""
@@ -66,4 +76,11 @@ if [[ $SKIP_TV == 0 && $NPM_TV == 1 ]]; then
   NPM_PLUGIN="-load-pass-plugin=@CMAKE_BINARY_DIR@/tv/$TV_SHAREDLIB"
 fi
 
-$TIMEOUT @LLVM_BINARY_DIR@/bin/opt -load=@CMAKE_BINARY_DIR@/tv/$TV_SHAREDLIB  $NPM_PLUGIN -tv-exit-on-error $TV $@ $TV $TV_SMT_TO $TV_REPORT_DIR $TV_SMT_STATS
+COMMAND="$TIMEOUT @LLVM_BINARY_DIR@/bin/opt -load=@CMAKE_BINARY_DIR@/tv/$TV_SHAREDLIB  $NPM_PLUGIN -tv-exit-on-error $TV $NEW_ARGS $TV $TV_SMT_TO $TV_REPORT_DIR $TV_SMT_STATS"
+
+if [[ $VERBOSE == 1 ]]; then
+  echo COMMAND: $COMMAND
+  echo
+fi
+
+$COMMAND


### PR DESCRIPTION
* Add `--verbose` and `--no-timeout` options for `opt-alive.sh`.
* Add them to the ReadMe and warn about timeout limitations.
* Also add the include file which [llvm::PossiblyNonNegInst Class Reference](https://llvm.org/docs/doxygen/classllvm_1_1PossiblyNonNegInst.html) documents, though that wasn’t what broke my build.

I’m not sure how to add tests for this.  Some of the infrastructure seems to rely on Python 2, which (no matter how much I miss it), I should probably not install on my work machine.