### PR TITLE
ReadMe: metadata, SDK, appending other opt options

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,7 +318,8 @@ this is guaranteed to contain an unsoundness report.  Many log files, however,
 contain only “Source: \<stdin\>” rather than a file path; the names of these
 files begin with “in_”.
 * Do a verbose run of Lit for just that file, with the `opt`  option
-`--print-after-all` appended, e.g.:
+`--print-after-all` appended.  (You may also append other `opt`  options, such
+as other optimizations.)  E.g.:
 ```
 $LLVM2_BUILD/bin/llvm-lit -vva "-Dopt=$ALIVE2_HOME/alive2/build/opt-alive.sh --print-after-all" $LLVM2_HOME/llvm/test/Transforms/InstCombine/insert-const-shuf.ll
 ```

--- a/README.md
+++ b/README.md
@@ -358,7 +358,7 @@ CMake files’ use of `USEDLIBS` and `LLVMLIBS` and perhaps `dd_llvm_target`.
 * Building for Translation Validation is tightly coupled to LLVM top of tree
 source.  Building a fork with older source may require reverting to the
 corresponding Alive2 commit.  This in turn may require experimentation with
-Clang versions and vendors.
+Clang and SDK versions and vendors.
 * Building older source on an up-to-date machine may require adjustments.  For
 example, the now-deleted file `scripts/rewritepass.py` depended on the
 deprecated Python 2; update the shebang line to `python3`.

--- a/README.md
+++ b/README.md
@@ -330,7 +330,7 @@ RUN command separately may give better results.
 versions of the misoptimized function.  The Alive2 IR function body may
 indicate the problem to a human, but for the Alive2 Compiler Explorer instance
 you will need LLVM IR.  Search for the function name in the terminal output.
-* Copy the first function definition and necessary declarations to
+* Copy the first function definition and necessary declarations and metadata to
 [https://alive2.llvm.org/ce/](https://alive2.llvm.org/ce/).  Without a second
 version of the function to compare, it just runs some standard optimizations;
 if it reports an error, your fork’s optimizations are not to blame.


### PR DESCRIPTION
Note in the ReadMe:

- Experimentation with SDK versions as well as compiler versions and vendors, when working around build breakages.
- Occasional need to copy metadata, which may be much later in the file, or sometimes absent.  (In which case, subject to correction, I delete it.)
- Possibility of appending other `opt` options, such as other optimizations.  (This looks promising for finding unsoundness in our fork’s use of O3, our normal optimization, though of course it can invalidate Lit pass/fail reports.)
