### PR TITLE
ReadMe, `alive-tv --help`:  correct timeout, BUILD_SHARED_LIBS optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,9 @@ to add `nsw`.
 If you are not interested in counterexamples using `undef`, you can use the
 command-line argument `-disable-undef-input`.
 
+You can also use the first mode on a single file containing a function called
+“src” and also a function called “tgt”.
+
 In the second mode, specify a single unoptimized IR file. alive-tv
 will optimize it using an optimization pipeline similar to -O2, but
 without any interprocedural passes, and then attempt to validate the

--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ Summary:
 ```
 
 Please keep in mind that you do not have to compile Alive2 in order to
-try out alive-tv; it is available online: [https://alive2.llvm.org/ce/](https://alive2.llvm.org/ce/)
+try out alive-tv; it is available online: https://alive2.llvm.org/ce/
 
 
 Running the Standalone LLVM Execution Tool (alive-exec)

--- a/README.md
+++ b/README.md
@@ -368,7 +368,7 @@ which outputs the command passed to `opt`.  Note that this may interfere
 with tests which check output.
 * The script also accepts a `--no-timeout` option, which disables the `opt`
 process timeout.  This timeout is not supported on Macintosh.  To change the
-SMT timeout, instead adjust the `query_timeout` constant in `smt/smt.cpp`.
+SMT timeout, instead pass an `-smt-to:` option to the `alive` executable.
 
 LLVM Bugs Found by Alive2
 --------

--- a/README.md
+++ b/README.md
@@ -204,8 +204,9 @@ Running the Standalone Translation Validation Tool (alive-tv)
 
 This tool has two modes.
 
-In the first mode, specify a source (original) and target (optimized)
-IR file. For example, let's prove that removing `nsw` is correct
+In the first mode, specify either a source (original) and target (optimized)
+IR file, or a single file containing a function called
+“src” and also a function called “tgt”. For example, let's prove that removing `nsw` is correct
 for addition:
 
 ```
@@ -229,9 +230,6 @@ Flipping the inputs yields a counterexample, since it's not correct, in general,
 to add `nsw`.
 If you are not interested in counterexamples using `undef`, you can use the
 command-line argument `-disable-undef-input`.
-
-You can also use the first mode on a single file containing a function called
-“src” and also a function called “tgt”.
 
 In the second mode, specify a single unoptimized IR file. alive-tv
 will optimize it using an optimization pipeline similar to -O2, but

--- a/README.md
+++ b/README.md
@@ -63,7 +63,13 @@ Building and Running Translation Validation
 
 Alive2's `opt` and `clang` translation validation requires a build of LLVM with
 RTTI and exceptions turned on.
-LLVM can be built targeting X86 in the following way.  (You may prefer to add `-DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++` to the CMake step if your default compiler is `gcc`.)
+LLVM can be built targeting X86 in the following way.  
+* You may prefer to add `-DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++` to the CMake step if your default compiler is `gcc`.
+* Explicitly setting the target may not be necessary.
+* `BUILD_SHARED_LIBS` may not be necessary, and for LLVM forks not normally
+built with the option, may interfere with CMake files’ use of `USEDLIBS` and
+`LLVMLIBS`, and perhaps `dd_llvm_target`.
+
 ```
 cd $LLVM2_HOME
 mkdir build
@@ -353,9 +359,6 @@ runtime errors with “symbol not found in flat namespace.”  Setting
 [CMAKE_OSX_DEPLOYMENT_TARGET](https://cmake.org/cmake/help/latest/variable/CMAKE_OSX_DEPLOYMENT_TARGET.html)
 as a cache entry to 11.0 or less at the beginning of CMakeLists.txt may work
 around this.
-* Building for Translation Validation requires enabling `BUILD_SHARED_LIBS`. 
-For LLVM forks not normally built with the option, this may interfere with
-CMake files’ use of `USEDLIBS` and `LLVMLIBS` and perhaps `dd_llvm_target`. 
 * Building for Translation Validation is tightly coupled to LLVM top of tree
 source.  Building a fork with older source may require reverting to the
 corresponding Alive2 commit.  This in turn may require experimentation with

--- a/README.md
+++ b/README.md
@@ -204,10 +204,10 @@ Running the Standalone Translation Validation Tool (alive-tv)
 
 This tool has two modes.
 
-In the first mode, specify either a source (original) and target (optimized)
-IR file, or a single file containing a function called
-“src” and also a function called “tgt”. For example, let's prove that removing `nsw` is correct
-for addition:
+In the first mode, specify either a source (original) and target (optimized) IR
+file, or a single file containing a function called “src” and also a function
+called “tgt”. For example, let’s prove that removing `nsw` is correct for
+addition:
 
 ```
 $ALIVE2_HOME/alive2/build/alive-tv src.ll tgt.ll

--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ IR file. For example, let's prove that removing `nsw` is correct
 for addition:
 
 ```
-$ alive-tv src.ll tgt.ll
+$ALIVE2_HOME/alive2/build/alive-tv src.ll tgt.ll
 
 ----------------------------------------
 define i32 @f(i32 %a, i32 %b) {
@@ -239,7 +239,8 @@ For example, as of February 6 2020, the `release/10.x` branch contains
 an optimizer bug that can be triggered as follows:
 
 ```
-$ cat foo.ll
+cat foo.ll
+
 define i3 @foo(i3) {
   %x1 = sub i3 0, %0
   %x2 = icmp ne i3 %0, 0
@@ -248,7 +249,8 @@ define i3 @foo(i3) {
   %x5 = lshr i3 %x4, %x3
   ret i3 %x5
 }
-$ alive-tv foo.ll
+
+$ALIVE2_HOME/alive2/build/alive-tv foo.ll
 
 ----------------------------------------
 define i3 @foo(i3 %0) {
@@ -289,7 +291,7 @@ Summary:
 ```
 
 Please keep in mind that you do not have to compile Alive2 in order to
-try out alive-tv; it is available online: https://alive2.llvm.org/ce/
+try out alive-tv; it is available online: [https://alive2.llvm.org/ce/](https://alive2.llvm.org/ce/)
 
 
 Running the Standalone LLVM Execution Tool (alive-exec)

--- a/llvm_util/cmd_args_list.h
+++ b/llvm_util/cmd_args_list.h
@@ -59,7 +59,7 @@ llvm::cl::opt<bool> opt_se_verbose(LLVM_ARGS_PREFIX "se-verbose",
   llvm::cl::init(false), llvm::cl::cat(alive_cmdargs));
 
 llvm::cl::opt<unsigned> opt_smt_to(LLVM_ARGS_PREFIX "smt-to",
-  llvm::cl::desc("Timeout for SMT queries (default=10000)"),
+  llvm::cl::desc("Timeout for SMT queries in ms (default=10000)"),
   llvm::cl::init(10000), llvm::cl::value_desc("ms"),
   llvm::cl::cat(alive_cmdargs));
 


### PR DESCRIPTION
- Note the `-smt-to:` option to the `alive` executable; corrects my c46e7ef.
- Add “in ms” to `alive-tv --help` for `-smt-to`.
- Note in build instructions that `BUILD_SHARED_LIBS` may not be necessary; it wasn’t for our build system, and caused severe problems when enabled.
  -  Move its CMake problems to the instructions from Troubleshooting.
 - Convert `alive-tv` example instructions into text which can be triple-clicked and dragged.  (I’ve started using it a lot; it found an important bug which had been fixed while I was fiddling with the build system.)
 - Convert Compiler Explorer instance URL into a Markdown clickable link.  (Though I expect it will be made clickable anyway for most viewers by GitHub.)

