### PR TITLE
Remove X86 setting from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,12 +63,13 @@ Building and Running Translation Validation
 
 Alive2's `opt` and `clang` translation validation requires a build of LLVM with
 RTTI and exceptions turned on.
-LLVM can be built targeting X86 in the following way.  (You may prefer to add `-DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++` to the CMake step if your default compiler is `gcc`.)
+LLVM can be built in the following way.
+(You may prefer to add `-DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DLLVM_ENABLE_LLD=ON` to the CMake step if your default compiler is `gcc`.)
 ```
 cd $LLVM2_HOME
 mkdir build
 cd build
-cmake -GNinja -DLLVM_ENABLE_RTTI=ON -DLLVM_ENABLE_EH=ON -DBUILD_SHARED_LIBS=ON -DCMAKE_BUILD_TYPE=Release -DLLVM_TARGETS_TO_BUILD=X86 -DLLVM_ENABLE_ASSERTIONS=ON -DLLVM_ENABLE_PROJECTS="llvm;clang" ../llvm
+cmake -GNinja -DLLVM_ENABLE_RTTI=ON -DLLVM_ENABLE_EH=ON -DBUILD_SHARED_LIBS=ON -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_ASSERTIONS=ON -DLLVM_ENABLE_PROJECTS="llvm;clang" ../llvm
 ninja
 ```
 


### PR DESCRIPTION
I just built LLVM and `alive-tv` locally on a M2 chip (`aarch64`) after removing `-DLLVM_TARGETS_TO_BUILD=X86` and confirmed that `alive-tv` works. So I guess the flag can be removed? If I'm not mistaken, LLVM will automatically infer these targets on X86 systems anyway.