### PR TITLE
opt-alive.sh --verbose to stderr, hints on building with Xcode

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,10 @@ LLVM can be built in the following way.
 * `BUILD_SHARED_LIBS` may not be necessary, and for LLVM forks not normally
 built with the option, may interfere with CMake files’ use of `USEDLIBS` and
 `LLVMLIBS`, and perhaps `dd_llvm_target`.
+* To build with Xcode rather than Ninja, replace `-GNinja` with `-GXcode` in
+the `cmake` step below, and append `-DLLVM_MAIN_SRC_DIR=$LLVM2_HOME/llvm`. 
+Xcode may place `tv.dylib` in a different location; a symbolic link from the
+actual location to that in the resultant error message may help.
 
 ```
 cd $LLVM2_HOME

--- a/README.md
+++ b/README.md
@@ -71,7 +71,8 @@ built with the option, may interfere with CMake files’ use of `USEDLIBS` and
 `LLVMLIBS`, and perhaps `dd_llvm_target`.
 * To build with Xcode rather than Ninja, replace `-GNinja` with `-GXcode` in
 the `cmake` step below, and append `-DLLVM_MAIN_SRC_DIR=$LLVM2_HOME/llvm`. 
-  * It may be necessary to disable warnings for “Implicit Conversion to 32 Bit Type” in the project build settings.
+  * It may be necessary to disable warnings for “Implicit Conversion to 32 Bit
+  Type” in the project build settings.
   * Xcode may place `tv.dylib` in a different location; a symbolic link from the
 actual location to that in the resultant error message may help.
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,8 @@ built with the option, may interfere with CMake files’ use of `USEDLIBS` and
 `LLVMLIBS`, and perhaps `dd_llvm_target`.
 * To build with Xcode rather than Ninja, replace `-GNinja` with `-GXcode` in
 the `cmake` step below, and append `-DLLVM_MAIN_SRC_DIR=$LLVM2_HOME/llvm`. 
-Xcode may place `tv.dylib` in a different location; a symbolic link from the
+  * It may be necessary to disable warnings for “Implicit Conversion to 32 Bit Type” in the project build settings.
+  * Xcode may place `tv.dylib` in a different location; a symbolic link from the
 actual location to that in the resultant error message may help.
 
 ```

--- a/llvm_util/cmd_args_def.h
+++ b/llvm_util/cmd_args_def.h
@@ -50,7 +50,6 @@ if (!report_dir_created && !opt_report_dir.empty()) {
         newname = "in";
       newname += "_" + get_random_str(8) + ".txt";
       path.replace_filename(newname);
-      std::cerr << "\n\nWriting report to: " << newname <<  endl << endl;
     } while (fs::exists(path));
   }
 

--- a/llvm_util/cmd_args_def.h
+++ b/llvm_util/cmd_args_def.h
@@ -50,6 +50,7 @@ if (!report_dir_created && !opt_report_dir.empty()) {
         newname = "in";
       newname += "_" + get_random_str(8) + ".txt";
       path.replace_filename(newname);
+      std::cerr << "\n\nWriting report to: " << newname <<  endl << endl;
     } while (fs::exists(path));
   }
 

--- a/scripts/opt-alive.sh.in
+++ b/scripts/opt-alive.sh.in
@@ -86,8 +86,8 @@ fi
 COMMAND="$TIMEOUT @LLVM_BINARY_DIR@/bin/opt -load=@CMAKE_BINARY_DIR@/tv/$TV_SHAREDLIB  $NPM_PLUGIN -tv-exit-on-error $TV $OPT_ARGS $TV $TV_SMT_TO $TV_REPORT_DIR $TV_SMT_STATS"
 
 if [[ $VERBOSE == 1 ]]; then
-  echo COMMAND: $COMMAND
-  echo
+  echo COMMAND: $COMMAND >&2
+  echo >&2
 fi
 
 $COMMAND


### PR DESCRIPTION
- Fix my 101be628 to redirect verbose `opt-alive.sh` output to stderr, since Lit can swallow it.
- Output report name to stderr in cmd_args_def.h (with a slightly different caption, and white space to make it prominent), since the output at tv.cpp:425 seems to have stopped working.  (Changing it to stderr didn’t work, and an Xcode breakpoint at that line was not hit when running under Lit, so it doesn’t seem to be an output redirection issue.)  It used to work at roughly bc51b72c.
- Add build hints for Xcode. 
  - Recommend disabling “Implicit conversion loses integer precision: 'uint64_t' (aka 'unsigned long long') to 'unsigned int'” warnings, since there are a dozen of them and they break the build with the default warnings as errors, which I’ll file [separately](https://github.com/AliveToolkit/alive2/issues/1012).
  - I didn’t think this belonged in the Alive2 ReadMe, but I’ll note here that for using Xcode breakpoints in `tv.dylib`, even when it’s called indirectly via Lit, the suggestions at https://stackoverflow.com/a/35641035/28312 may be helpful.

The output I’m adding is in executable code in a header file, so there may be uses I haven’t tested.