### PR TITLE
Add support for nowrap flags to `trunc`

### DIFF
--- a/ir/instr.h
+++ b/ir/instr.h
@@ -259,7 +259,7 @@ public:
 class ConversionOp final : public Instr {
 public:
   enum Op { SExt, ZExt, Trunc, BitCast, Ptr2Int, Int2Ptr };
-  enum Flags { None = 0, NNEG = 1 << 0 };
+  enum Flags { None = 0, NNEG = 1 << 0, NSW = 1 << 1, NUW = 1 << 2 };
 
 private:
   Value *val;
@@ -268,8 +268,7 @@ private:
 
 public:
   ConversionOp(Type &type, std::string &&name, Value &val, Op op,
-               unsigned flags = None)
-    : Instr(type, std::move(name)), val(&val), op(op), flags(flags) {}
+               unsigned flags = None);
 
   Op getOp() const { return op; }
   Value& getValue() const { return *val; }

--- a/llvm_util/llvm2alive.cpp
+++ b/llvm_util/llvm2alive.cpp
@@ -12,8 +12,9 @@
 #include "llvm/IR/GetElementPtrTypeIterator.h"
 #include "llvm/IR/GlobalVariable.h"
 #include "llvm/IR/InlineAsm.h"
-#include "llvm/IR/InstrTypes.h"
 #include "llvm/IR/InstVisitor.h"
+#include "llvm/IR/InstrTypes.h"
+#include "llvm/IR/Instructions.h"
 #include "llvm/IR/Operator.h"
 #include "llvm/Support/ModRef.h"
 #include <sstream>
@@ -308,6 +309,11 @@ public:
         if (const auto *NNI = dyn_cast<llvm::PossiblyNonNegInst>(&i)) {
           if (NNI->hasNonNeg())
             flags |= ConversionOp::NNEG;
+        } else if (const auto *TI = dyn_cast<llvm::TruncInst>(&i)) {
+          if (TI->hasNoUnsignedWrap())
+            flags |= ConversionOp::NUW;
+          if (TI->hasNoSignedWrap())
+            flags |= ConversionOp::NSW;
         }
         RETURN_IDENTIFIER(
           make_unique<ConversionOp>(*ty, value_name(i), *val, op, flags));

--- a/tests/alive-tv/nsw.trunc.srctgt.ll
+++ b/tests/alive-tv/nsw.trunc.srctgt.ll
@@ -1,0 +1,9 @@
+define i8 @src(i8 %x) {
+  %trunc = trunc nsw i8 %x to i1
+  %sext = sext i1 %trunc to i8
+  ret i8 %sext
+}
+
+define i8 @tgt(i8 %x) {
+  ret i8 %x
+}

--- a/tests/alive-tv/nuw.trunc.srctgt.ll
+++ b/tests/alive-tv/nuw.trunc.srctgt.ll
@@ -1,0 +1,9 @@
+define i8 @src(i8 %x) {
+  %trunc = trunc nuw i8 %x to i1
+  %zext = zext i1 %trunc to i8
+  ret i8 %zext
+}
+
+define i8 @tgt(i8 %x) {
+  ret i8 %x
+}


### PR DESCRIPTION
Nowrap poison-generating flags to `trunc` have been recently introduced in LLVM.