### PR TITLE
Bypass assume_welldefined to handle metadata correctly

### DIFF
--- a/llvm_util/llvm2alive.cpp
+++ b/llvm_util/llvm2alive.cpp
@@ -1756,6 +1756,8 @@ public:
 
           if (!alive_i->isVoid()) {
             add_identifier(i, *alive_i);
+          } else {
+            alive_i = static_cast<Instr *>(get_operand(&i));
           }
 
           if (i.hasMetadataOtherThanDebugLoc() &&

--- a/tests/alive-tv/calls/noundef-range.srctgt.ll
+++ b/tests/alive-tv/calls/noundef-range.srctgt.ll
@@ -1,0 +1,13 @@
+define i32 @src(i32 %0) {
+entry:
+  %1 = call noundef i32 @llvm.ctlz.i32(i32 %0, i1 true), !range !0
+  ret i32 %1
+}
+
+define i32 @tgt(i32 %0) {
+entry:
+  %1 = call noundef i32 @llvm.ctlz.i32(i32 %0, i1 true), !range !0
+  ret i32 %1
+}
+
+!0 = !{i32 0, i32 33}


### PR DESCRIPTION
See the following code:
https://github.com/AliveToolkit/alive2/blob/22bc6f2791796708cbcfc99935992145f4ae2800/llvm_util/llvm2alive.cpp#L113-L123

alive2 returns node `assume_welldefined` instead of the original value when `noundef` exists.
https://github.com/AliveToolkit/alive2/blob/22bc6f2791796708cbcfc99935992145f4ae2800/llvm_util/llvm2alive.cpp#L1754-L1763
However, `alive_i` will be set to `assume_welldefined`, which causes type checks to fail when handing metadata of a call.
This patch bypasses `assume_welldefined` to set `alive_i` to the original value.

Fixes https://github.com/AliveToolkit/alive2/issues/1043.
