### PR TITLE
remove duplicate code on cmd_args_def.h

### DIFF
--- a/llvm_util/cmd_args_def.h
+++ b/llvm_util/cmd_args_def.h
@@ -6,7 +6,6 @@ config::src_unroll_cnt = opt_src_unrolling_factor;
 config::tgt_unroll_cnt = opt_tgt_unrolling_factor;
 #else
 config::src_unroll_cnt = opt_unrolling_factor;
-config::src_unroll_cnt = opt_unrolling_factor;
 #endif
 config::disable_undef_input = opt_disable_undef;
 config::disable_poison_input = opt_disable_poison;

--- a/llvm_util/cmd_args_def.h
+++ b/llvm_util/cmd_args_def.h
@@ -6,6 +6,7 @@ config::src_unroll_cnt = opt_src_unrolling_factor;
 config::tgt_unroll_cnt = opt_tgt_unrolling_factor;
 #else
 config::src_unroll_cnt = opt_unrolling_factor;
+config::tgt_unroll_cnt = opt_unrolling_factor;
 #endif
 config::disable_undef_input = opt_disable_undef;
 config::disable_poison_input = opt_disable_poison;


### PR DESCRIPTION
There is redundancy in the code that sets the value of the `config::src_unroll_cnt` variable.