### PR TITLE
Add named queries

### DIFF
--- a/smt/solver.cpp
+++ b/smt/solver.cpp
@@ -504,7 +504,7 @@ Result Solver::check(const char *query_name) const {
   if (print_queries) {
     dbg() << "\nSMT query";
     if (query_name != nullptr) {
-      dbg() << " (" << query_name << ")";
+      dbg() << " (" << query_name << ')';
     }
     dbg() << ":\n" << Z3_solver_to_string(ctx(), s) << endl;
   }

--- a/smt/solver.cpp
+++ b/smt/solver.cpp
@@ -467,7 +467,7 @@ expr Solver::assertions() const {
   return ret;
 }
 
-Result Solver::check() const {
+Result Solver::check(const char *query_name) const {
   if (!valid) {
     ++num_invalid;
     return Result::INVALID;
@@ -486,7 +486,7 @@ Result Solver::check() const {
     if (!fml.isTrue()) {
       auto str = Z3_benchmark_to_smtlib_string(ctx(), banner, nullptr, nullptr,
                                                nullptr, 0, nullptr, fml());
-      ofstream file(get_random_filename(config::smt_benchmark_dir, "smt2"));
+      ofstream file(get_random_filename(config::smt_benchmark_dir, "smt2", query_name));
       if (!file.is_open()) {
         dbg() << "Alive2: Couldn't open smtlib benchmark file!" << endl;
         exit(1);
@@ -501,8 +501,13 @@ Result Solver::check() const {
   }
 
   ++num_queries;
-  if (print_queries)
-    dbg() << "\nSMT query:\n" << Z3_solver_to_string(ctx(), s) << endl;
+  if (print_queries) {
+    dbg() << "\nSMT query";
+    if (query_name != nullptr) {
+      dbg() << " (" << query_name << ")";
+    }
+    dbg() << ":\n" << Z3_solver_to_string(ctx(), s) << endl;
+  }
 
   tactic->check();
 
@@ -527,10 +532,10 @@ Result Solver::check() const {
   }
 }
 
-Result check_expr(const expr &e) {
+Result check_expr(const expr &e, const char *query_name) {
   Solver s;
   s.add(e);
-  return s.check();
+  return s.check(query_name);
 }
 
 

--- a/smt/solver.h
+++ b/smt/solver.h
@@ -162,12 +162,12 @@ public:
 
   expr assertions() const;
 
-  Result check() const;
+  Result check(const char *query_name = nullptr) const;
 
   friend class SolverPush;
 };
 
-Result check_expr(const expr &e);
+Result check_expr(const expr &e, const char *query_name = nullptr);
 
 
 class SolverPush {

--- a/tools/transform.cpp
+++ b/tools/transform.cpp
@@ -45,7 +45,7 @@ static void print_single_varval(ostream &os, const State &st, const Model &m,
 
   // Best effort detection of poison if model is partial
   if (auto v = m.eval(val.non_poison);
-      (v.isFalse() || check_expr(!v).isSat())) {
+      (v.isFalse() || check_expr(!v, "val_is_poison").isSat())) {
     os << "poison";
     return;
   }
@@ -172,7 +172,7 @@ static bool error(Errors &errs, State &src_state, State &tgt_state,
     {
       SolverPush push(solver);
       solver.add(e);
-      auto tmpr = solver.check();
+      auto tmpr = solver.check("reduce");
       if (tmpr.isSat()) {
         ok   = true;
         newr = std::move(tmpr);
@@ -512,7 +512,7 @@ check_refinement(Errors &errs, const Transform &t, State &src_state,
     axioms_expr = std::move(axioms)();
   }
 
-  if (check_expr(axioms_expr && fndom_a).isUnsat()) {
+  if (check_expr(axioms_expr && fndom_a, "ub_src").isUnsat()) {
     if (config::fail_if_src_is_ub) {
       errs.add("Source function is always UB", false);
       return;
@@ -526,7 +526,8 @@ check_refinement(Errors &errs, const Transform &t, State &src_state,
 
   {
     auto sink_src = src_state.sinkDomain(false);
-    if (!sink_src.isFalse() && check_expr(axioms_expr && !sink_src).isUnsat()) {
+    if (!sink_src.isFalse() &&
+        check_expr(axioms_expr && !sink_src, "return_src").isUnsat()) {
       errs.add("The source program doesn't reach a return instruction.\n"
                "Consider increasing the unroll factor if it has loops", false);
       return;
@@ -535,7 +536,7 @@ check_refinement(Errors &errs, const Transform &t, State &src_state,
     if (auto sink_tgt = tgt_state.sinkDomain(false);
         !sink_src.eq(sink_tgt) &&
         !sink_tgt.isFalse() &&
-        check_expr(axioms_expr && (!sink_tgt || sink_src)).isUnsat()) {
+        check_expr(axioms_expr && (!sink_tgt || sink_src), "return_tgt").isUnsat()) {
       errs.add("The target program doesn't reach a return instruction.\n"
                "Consider increasing the unroll factor if it has loops", false);
       return;
@@ -560,7 +561,7 @@ check_refinement(Errors &errs, const Transform &t, State &src_state,
       pre_tgt = pre_tgt_and();
     }
 
-    if (check_expr(axioms_expr && (pre_src && pre_tgt)).isUnsat()) {
+    if (check_expr(axioms_expr && (pre_src && pre_tgt), "pre").isUnsat()) {
       errs.add("Precondition is always false", false);
       return;
     }
@@ -591,11 +592,11 @@ check_refinement(Errors &errs, const Transform &t, State &src_state,
             preprocess(t, qvars, uvars, pre && pre_src_forall.implies(refines));
   };
 
-  auto check = [&](expr &&e, auto &&printer, const char *msg) {
+  auto check = [&](expr &&e, const char *name, auto &&printer, const char *msg) {
     Solver s;
     s.add(mk_fml(std::move(e)));
     e = expr();
-    auto res = s.check();
+    auto res = s.check(name);
 
     // Some non-deterministic vars have preconditions. These preconditions are
     // under the forall quantifier, hence they have no effect when we fetch
@@ -603,7 +604,7 @@ check_refinement(Errors &errs, const Transform &t, State &src_state,
     // are implicitly existentially quantified).
     if (res.isSat()) {
       s.add(pre_src_forall);
-      res = s.check();
+      res = s.check(name);
       assert(!res.isUnsat());
     }
 
@@ -614,8 +615,8 @@ check_refinement(Errors &errs, const Transform &t, State &src_state,
     return true;
   };
 
-#define CHECK(fml, printer, msg) \
-  if (!check(fml, printer, msg)) \
+#define CHECK(fml, name, printer, msg) \
+  if (!check(fml, name, printer, msg)) \
     return
 
   if (config::disallow_ub_exploitation) {
@@ -623,14 +624,16 @@ check_refinement(Errors &errs, const Transform &t, State &src_state,
       errs.add("Null is not dereferenceable", false);
 
     CHECK(retdom_a && src_state.getGuardableUB(),
-          [](ostream&, const Model&){}, "Source has guardable UB");
+          "guardable_ub_src", [](ostream&, const Model&){},
+          "Source has guardable UB");
     CHECK(retdom_a && retdom_b && tgt_state.getGuardableUB(),
-          [](ostream&, const Model&){}, "Target has guardable UB");
+          "guardable_ub_tgt", [](ostream&, const Model&){},
+          "Target has guardable UB");
 
     // disallow reaching unreachable instructions
-    CHECK(src_state.getUnreachable()(),
+    CHECK(src_state.getUnreachable()(), "unreachable_src",
           [](ostream&, const Model&){}, "Source has reachable unreachable");
-    CHECK(tgt_state.getUnreachable()(),
+    CHECK(tgt_state.getUnreachable()(), "unreachable_tgt",
           [](ostream&, const Model&){}, "Target has reachable unreachable");
   }
 
@@ -641,7 +644,8 @@ check_refinement(Errors &errs, const Transform &t, State &src_state,
 
     // 1. Check UB
     CHECK(fndom_a.notImplies(fndom_b),
-          [](ostream&, const Model&){}, "Source is more defined than target");
+          "ub", [](ostream&, const Model&){},
+          "Source is more defined than target");
 
     pre = std::move(pre_old);
   }
@@ -655,7 +659,8 @@ check_refinement(Errors &errs, const Transform &t, State &src_state,
       dom_constr = (fndom_a && fndom_b) && retdom_a != retdom_b;
     }
 
-    CHECK(std::move(dom_constr), [](ostream&, const Model&){},
+    CHECK(std::move(dom_constr),
+          "retdom", [](ostream&, const Model&){},
           "Source and target don't have the same return domain");
   }
 
@@ -669,8 +674,10 @@ check_refinement(Errors &errs, const Transform &t, State &src_state,
 
   // Src function can't return poison
   if (config::disallow_ub_exploitation) {
-    CHECK(retdom_a && !a.non_poison, print_value, "Source returns poison");
-    CHECK(retdom_b && !b.non_poison, print_value, "Target returns poison");
+    CHECK(retdom_a && !a.non_poison,
+          "poison_src", print_value, "Source returns poison");
+    CHECK(retdom_b && !b.non_poison,
+          "poison_tgt", print_value, "Target returns poison");
   }
 
   auto [poison_cnstr, value_cnstr] = type.refines(src_state, tgt_state, a, b);
@@ -680,23 +687,23 @@ check_refinement(Errors &errs, const Transform &t, State &src_state,
 
   if (!config::disallow_ub_exploitation) {
     CHECK(dom && !poison_cnstr,
-          print_value, "Target is more poisonous than source");
+          "poison", print_value, "Target is more poisonous than source");
   }
   poison_cnstr = {};
 
   // 4. Check undef
   if (config::disallow_ub_exploitation) {
     CHECK(retdom_a && encode_undef_refinement(src_state, tgt_state, type,ap,bp),
-          print_value, "Source returns undef");
+          "undef_src", print_value, "Source returns undef");
     CHECK(retdom_b && encode_undef_refinement(tgt_state, src_state, type,bp,ap),
-          print_value, "Target returns undef");
+          "undef_tgt", print_value, "Target returns undef");
   } else {
     CHECK(dom && encode_undef_refinement(src_state, tgt_state, type, ap, bp),
-          print_value, "Target's return value is more undefined");
+          "undef", print_value, "Target's return value is more undefined");
   }
 
   // 5. Check value
-  CHECK(dom && !value_cnstr, print_value, "Value mismatch");
+  CHECK(dom && !value_cnstr, "value", print_value, "Value mismatch");
 
   // 6. Check memory
   auto &src_mem = src_state.returnMemory();
@@ -727,7 +734,7 @@ check_refinement(Errors &errs, const Transform &t, State &src_state,
 
   CHECK(dom && !(memory_cnstr0.isTrue() ? memory_cnstr0
                                         : value_cnstr && memory_cnstr0),
-        print_ptr_load, "Mismatch in memory");
+        "memory", print_ptr_load, "Mismatch in memory");
 
 #undef CHECK
 }
@@ -1447,7 +1454,7 @@ TypingAssignments::TypingAssignments(const expr &e) : s(true), sneg(true) {
     EnableSMTQueriesTMP tmp;
     s.add(e);
     sneg.add(!e);
-    r = s.check();
+    r = s.check("typing");
   }
 }
 
@@ -1461,7 +1468,7 @@ void TypingAssignments::operator++(void) {
   } else {
     EnableSMTQueriesTMP tmp;
     s.block(r.getModel(), &sneg);
-    r = s.check();
+    r = s.check("typing");
     assert(r.isSat() || r.isUnsat());
   }
 }

--- a/util/file.cpp
+++ b/util/file.cpp
@@ -35,7 +35,7 @@ string get_random_filename(const string &dir, const char *extension, const char 
       name << prefix << '_';
     }
     name << get_random_str(12) << '.' << extension;
-    return name.str();
+    return std::move(name).str();
   };
   fs::path path = fs::path(dir) / newname();
   while (fs::exists(path)) {

--- a/util/file.cpp
+++ b/util/file.cpp
@@ -6,6 +6,7 @@
 #include <cstring>
 #include <filesystem>
 #include <fstream>
+#include <sstream>
 
 using namespace std;
 namespace fs = std::filesystem;
@@ -26,9 +27,16 @@ file_reader::file_reader(const char *filename, unsigned padding) {
 }
 
 
-string get_random_filename(const string &dir, const char *extension) {
+string get_random_filename(const string &dir, const char *extension, const char *prefix) {
   // there's a low probability of race here
-  auto newname = [&]() { return get_random_str(12) + '.' + extension; };
+  auto newname = [&]() {
+    ostringstream name;
+    if (prefix) {
+      name << prefix << '_';
+    }
+    name << get_random_str(12) << '.' << extension;
+    return name.str();
+  };
   fs::path path = fs::path(dir) / newname();
   while (fs::exists(path)) {
     path.replace_filename(newname());

--- a/util/file.h
+++ b/util/file.h
@@ -23,6 +23,6 @@ public:
 
 struct FileIOException {};
 
-std::string get_random_filename(const std::string &dir, const char *extension);
+std::string get_random_filename(const std::string &dir, const char *extension, const char *prefix = nullptr);
 
 }

--- a/util/file.h
+++ b/util/file.h
@@ -23,6 +23,7 @@ public:
 
 struct FileIOException {};
 
-std::string get_random_filename(const std::string &dir, const char *extension, const char *prefix = nullptr);
+std::string get_random_filename(const std::string &dir, const char *extension,
+                                const char *prefix = nullptr);
 
 }


### PR DESCRIPTION
Adds prefixes to the output files of `--smt-bench` in order to make it easier to find the query you are looking for. Output files are named `<QUERY_NAME>_<RANDOM_STRING>.smt2`. The query names are also shown when using `--smt-verbose`.