### PR TITLE
Refactor llvm_util

### DIFF
--- a/ir/type.cpp
+++ b/ir/type.cpp
@@ -24,6 +24,12 @@ namespace IR {
 
 VoidType Type::voidTy;
 
+FloatType Type::halfTy("half", FloatType::Half);
+FloatType Type::floatTy("float", FloatType::Float);
+FloatType Type::doubleTy("double", FloatType::Double);
+FloatType Type::quadTy("fp128", FloatType::Quad);
+FloatType Type::bfloatTy("bfloat", FloatType::BFloat);
+
 unsigned Type::np_bits(bool fromInt) const {
   if (!fromInt)
     return 1;

--- a/ir/type.h
+++ b/ir/type.h
@@ -127,6 +127,11 @@ public:
   std::string toString() const;
 
   static VoidType voidTy;
+  static FloatType halfTy;
+  static FloatType floatTy;
+  static FloatType doubleTy;
+  static FloatType quadTy;
+  static FloatType bfloatTy;
 
   virtual ~Type();
 };

--- a/llvm_util/known_fns.cpp
+++ b/llvm_util/known_fns.cpp
@@ -507,9 +507,11 @@ bool llvm_implict_attrs(llvm::Function &f, const llvm::TargetLibraryInfo &TLI,
 #define RETURN_APPROX() return { nullptr, true }
 
 pair<unique_ptr<Instr>, bool>
-known_call(llvm::CallInst &i, const llvm::TargetLibraryInfo &TLI,
-           BasicBlock &BB, const vector<Value*> &args, FnAttrs &&attrs,
-           vector<ParamAttrs> &param_attrs) {
+known_call(llvm::CallInst &i, string &&value_name,
+           const llvm::TargetLibraryInfo &TLI, BasicBlock &BB,
+           const vector<Value*> &args, FnAttrs &&attrs,
+           vector<ParamAttrs> &param_attrs,
+           std::function<Value*(uint64_t val, int bits)> make_intconst) {
 
   auto ty = llvm_type2alive(i.getType());
   if (!ty)
@@ -523,7 +525,7 @@ known_call(llvm::CallInst &i, const llvm::TargetLibraryInfo &TLI,
   switch (libfn) {
   case llvm::LibFunc_memset: // void* memset(void *ptr, int val, size_t bytes)
     BB.addInstr(make_unique<Memset>(*args[0], *args[1], *args[2], 1));
-    RETURN_VAL(make_unique<UnaryOp>(*ty, value_name(i), *args[0],
+    RETURN_VAL(make_unique<UnaryOp>(*ty, std::move(value_name), *args[0],
                                     UnaryOp::Copy));
 
   // void memset_pattern4(void *ptr, void *pattern, size_t bytes)
@@ -534,11 +536,11 @@ known_call(llvm::CallInst &i, const llvm::TargetLibraryInfo &TLI,
   case llvm::LibFunc_memset_pattern16:
     RETURN_VAL(make_unique<MemsetPattern>(*args[0], *args[1], *args[2], 16));
   case llvm::LibFunc_strlen:
-    RETURN_VAL(make_unique<Strlen>(*ty, value_name(i), *args[0]));
+    RETURN_VAL(make_unique<Strlen>(*ty, std::move(value_name), *args[0]));
   case llvm::LibFunc_memcmp:
   case llvm::LibFunc_bcmp: {
     RETURN_VAL(
-      make_unique<Memcmp>(*ty, value_name(i), *args[0], *args[1], *args[2],
+      make_unique<Memcmp>(*ty, std::move(value_name), *args[0], *args[1], *args[2],
                           libfn == llvm::LibFunc_bcmp));
   }
   case llvm::LibFunc_ffs:
@@ -546,71 +548,71 @@ known_call(llvm::CallInst &i, const llvm::TargetLibraryInfo &TLI,
   case llvm::LibFunc_ffsll: {
     bool needs_trunc = &args[0]->getType() != ty;
     auto *Op = new UnaryOp(args[0]->getType(),
-                           value_name(i) + (needs_trunc ? "#beftrunc" : ""),
+                           value_name + (needs_trunc ? "#beftrunc" : ""),
                            *args[0], UnaryOp::FFS);
     if (!needs_trunc)
       RETURN_VAL(unique_ptr<UnaryOp>(Op));
 
     BB.addInstr(unique_ptr<UnaryOp>(Op));
     RETURN_VAL(
-      make_unique<ConversionOp>(*ty, value_name(i), *Op, ConversionOp::Trunc));
+      make_unique<ConversionOp>(*ty, std::move(value_name), *Op, ConversionOp::Trunc));
   }
 
   case llvm::LibFunc_abs:
   case llvm::LibFunc_labs:
   case llvm::LibFunc_llabs:
-    RETURN_VAL(make_unique<BinOp>(*ty, value_name(i), *args[0],
+    RETURN_VAL(make_unique<BinOp>(*ty, std::move(value_name), *args[0],
                                   *make_intconst(1, 1), BinOp::Abs));
 
   case llvm::LibFunc_fabs:
   case llvm::LibFunc_fabsf:
-    RETURN_VAL(make_unique<FpUnaryOp>(*ty, value_name(i), *args[0],
+    RETURN_VAL(make_unique<FpUnaryOp>(*ty, std::move(value_name), *args[0],
                                       FpUnaryOp::FAbs, parse_fmath(i)));
 
   case llvm::LibFunc_ceil:
   case llvm::LibFunc_ceilf:
-    RETURN_VAL(make_unique<FpUnaryOp>(*ty, value_name(i), *args[0],
+    RETURN_VAL(make_unique<FpUnaryOp>(*ty, std::move(value_name), *args[0],
                                       FpUnaryOp::Ceil, parse_fmath(i)));
 
   case llvm::LibFunc_floor:
   case llvm::LibFunc_floorf:
-    RETURN_VAL(make_unique<FpUnaryOp>(*ty, value_name(i), *args[0],
+    RETURN_VAL(make_unique<FpUnaryOp>(*ty, std::move(value_name), *args[0],
                                       FpUnaryOp::Floor, parse_fmath(i)));
 
   case llvm::LibFunc_nearbyint:
   case llvm::LibFunc_nearbyintf:
-    RETURN_VAL(make_unique<FpUnaryOp>(*ty, value_name(i), *args[0],
+    RETURN_VAL(make_unique<FpUnaryOp>(*ty, std::move(value_name), *args[0],
                                       FpUnaryOp::NearbyInt, parse_fmath(i)));
 
   case llvm::LibFunc_rint:
   case llvm::LibFunc_rintf:
-    RETURN_VAL(make_unique<FpUnaryOp>(*ty, value_name(i), *args[0],
+    RETURN_VAL(make_unique<FpUnaryOp>(*ty, std::move(value_name), *args[0],
                                       FpUnaryOp::RInt, parse_fmath(i)));
 
   case llvm::LibFunc_round:
   case llvm::LibFunc_roundf:
-    RETURN_VAL(make_unique<FpUnaryOp>(*ty, value_name(i), *args[0],
+    RETURN_VAL(make_unique<FpUnaryOp>(*ty, std::move(value_name), *args[0],
                                       FpUnaryOp::Round, parse_fmath(i)));
 
   case llvm::LibFunc_roundeven:
   case llvm::LibFunc_roundevenf:
-    RETURN_VAL(make_unique<FpUnaryOp>(*ty, value_name(i), *args[0],
+    RETURN_VAL(make_unique<FpUnaryOp>(*ty, std::move(value_name), *args[0],
                                       FpUnaryOp::RoundEven, parse_fmath(i)));
 
   case llvm::LibFunc_trunc:
   case llvm::LibFunc_truncf:
-    RETURN_VAL(make_unique<FpUnaryOp>(*ty, value_name(i), *args[0],
+    RETURN_VAL(make_unique<FpUnaryOp>(*ty, std::move(value_name), *args[0],
                                       FpUnaryOp::Trunc, parse_fmath(i)));
 
   case llvm::LibFunc_copysign:
   case llvm::LibFunc_copysignf:
-    RETURN_VAL(make_unique<FpBinOp>(*ty, value_name(i), *args[0], *args[1],
+    RETURN_VAL(make_unique<FpBinOp>(*ty, std::move(value_name), *args[0], *args[1],
                                     FpBinOp::CopySign, parse_fmath(i)));
 
   case llvm::LibFunc_sqrt:
   case llvm::LibFunc_sqrtf:
     BB.addInstr(make_unique<Assume>(*args[0], Assume::WellDefined));
-    RETURN_VAL(make_unique<FpUnaryOp>(*ty, value_name(i), *args[0],
+    RETURN_VAL(make_unique<FpUnaryOp>(*ty, std::move(value_name), *args[0],
                                       FpUnaryOp::Sqrt, parse_fmath(i)));
   case llvm::LibFunc_fwrite: {
     auto size = getInt(*args[1]);
@@ -619,7 +621,7 @@ known_call(llvm::CallInst &i, const llvm::TargetLibraryInfo &TLI,
       // size_t fwrite(const void *ptr, 0, 0, FILE *stream) -> 0
       if ((size && *size == 0) || (count && *count == 0))
         RETURN_VAL(
-          make_unique<UnaryOp>(*ty, value_name(i),
+          make_unique<UnaryOp>(*ty, std::move(value_name),
                                *make_intconst(0, ty->bits()), UnaryOp::Copy));
     }
     if (size && count) {
@@ -630,15 +632,15 @@ known_call(llvm::CallInst &i, const llvm::TargetLibraryInfo &TLI,
         auto &byteTy = get_int_type(8); // FIXME
         auto &i32 = get_int_type(32);
         auto load
-          = make_unique<Load>(byteTy, value_name(i) + "#load", *args[0], 1);
+          = make_unique<Load>(byteTy, value_name + "#load", *args[0], 1);
         auto load_zext
-           = make_unique<ConversionOp>(i32, value_name(i) + "#zext", *load,
+           = make_unique<ConversionOp>(i32, value_name + "#zext", *load,
                                        ConversionOp::ZExt);
 
         ENSURE(!implict_attrs_(llvm::LibFunc_fputc, attrs, param_attrs, false,
                                {load_zext.get(), args[3]}));
         auto call
-          = make_unique<FnCall>(i32, value_name(i), "@fputc", std::move(attrs));
+          = make_unique<FnCall>(i32, std::move(value_name), "@fputc", std::move(attrs));
         call->addArg(*load_zext, std::move(param_attrs[0]));
         call->addArg(*args[3], std::move(param_attrs[1]));
         BB.addInstr(std::move(load));

--- a/llvm_util/known_fns.h
+++ b/llvm_util/known_fns.h
@@ -5,6 +5,7 @@
 
 #include <memory>
 #include <vector>
+#include <functional>
 
 namespace llvm {
 class CallInst;
@@ -30,8 +31,10 @@ bool llvm_implict_attrs(llvm::Function &f, const llvm::TargetLibraryInfo &TLI,
 
 // returns true if it's a known function call
 std::pair<std::unique_ptr<IR::Instr>, bool>
-known_call(llvm::CallInst &i, const llvm::TargetLibraryInfo &TLI,
-           IR::BasicBlock &BB, const std::vector<IR::Value*> &args,
-           IR::FnAttrs &&attrs, std::vector<IR::ParamAttrs> &param_attr);
+known_call(llvm::CallInst &i, std::string &&value_name,
+           const llvm::TargetLibraryInfo &TLI, IR::BasicBlock &BB,
+           const std::vector<IR::Value*> &args, IR::FnAttrs &&attrs,
+           std::vector<IR::ParamAttrs> &param_attr,
+           std::function<IR::Value*(uint64_t val, int bits)> make_intconst);
 
 }

--- a/llvm_util/llvm2alive.cpp
+++ b/llvm_util/llvm2alive.cpp
@@ -682,6 +682,10 @@ public:
     return phi;
   }
 
+  IR::BasicBlock& getBB(const llvm::BasicBlock *bb) {
+    return alive_fn->getBB(value_name(*bb));
+  }
+
   RetTy visitBranchInst(llvm::BranchInst &i) {
     auto &dst_true = getBB(i.getSuccessor(0));
     if (i.isUnconditional())

--- a/llvm_util/llvm2alive.cpp
+++ b/llvm_util/llvm2alive.cpp
@@ -206,7 +206,7 @@ class llvm2alive_ : public llvm::InstVisitor<llvm2alive_, unique_ptr<Instr>> {
     return ret;
   }
 
-  IR::Value* make_intconst(const llvm::APInt &val) {
+  Value* make_intconst(const llvm::APInt &val) {
     unique_ptr<IntConst> c;
     auto bw = val.getBitWidth();
     auto &ty = get_int_type(bw);
@@ -219,7 +219,7 @@ class llvm2alive_ : public llvm::InstVisitor<llvm2alive_, unique_ptr<Instr>> {
     return ret;
   }
 
-  IR::Value* get_poison(Type &ty) {
+  Value* get_poison(Type &ty) {
     auto val = make_unique<PoisonValue>(ty);
     auto ret = val.get();
     alive_fn->addConstant(std::move(val));
@@ -908,7 +908,7 @@ public:
     return phi;
   }
 
-  IR::BasicBlock& getBB(const llvm::BasicBlock *bb) {
+  BasicBlock& getBB(const llvm::BasicBlock *bb) {
     return alive_fn->getBB(value_name(*bb));
   }
 

--- a/llvm_util/utils.cpp
+++ b/llvm_util/utils.cpp
@@ -32,11 +32,6 @@ unsigned value_id_counter = 0; // for %0, %1, etc..
 
 vector<unique_ptr<IntType>> int_types;
 vector<unique_ptr<PtrType>> ptr_types;
-FloatType half_type("half", FloatType::Half);
-FloatType float_type("float", FloatType::Float);
-FloatType double_type("double", FloatType::Double);
-FloatType quad_type("fp128", FloatType::Quad);
-FloatType bfloat_type("bfloat", FloatType::BFloat);
 
 // cache complex types
 unordered_map<const llvm::Type*, unique_ptr<Type>> type_cache;
@@ -116,15 +111,15 @@ Type* llvm_type2alive(const llvm::Type *ty) {
   case llvm::Type::IntegerTyID:
     return &get_int_type(cast<llvm::IntegerType>(ty)->getBitWidth());
   case llvm::Type::HalfTyID:
-    return &half_type;
+    return &Type::halfTy;
   case llvm::Type::FloatTyID:
-    return &float_type;
+    return &Type::floatTy;
   case llvm::Type::DoubleTyID:
-    return &double_type;
+    return &Type::doubleTy;
   case llvm::Type::FP128TyID:
-    return &quad_type;
+    return &Type::quadTy;
   case llvm::Type::BFloatTyID:
-    return &bfloat_type;
+    return &Type::bfloatTy;
 
   case llvm::Type::PointerTyID: {
     // TODO: support for non-64 bits pointers

--- a/llvm_util/utils.cpp
+++ b/llvm_util/utils.cpp
@@ -90,10 +90,6 @@ FastMathFlags parse_fmath(llvm::Instruction &i) {
   return fmath;
 }
 
-BasicBlock& getBB(const llvm::BasicBlock *bb) {
-  return current_fn->getBB(value_name(*bb));
-}
-
 string value_name(const llvm::Value &v) {
   auto &name = value_names[&v];
   if (!name.empty())

--- a/llvm_util/utils.h
+++ b/llvm_util/utils.h
@@ -32,22 +32,9 @@ class Value;
 namespace llvm_util {
 
 IR::FastMathFlags parse_fmath(llvm::Instruction &i);
-std::string value_name(const llvm::Value &v);
 
 IR::Type& get_int_type(unsigned bits);
 IR::Type* llvm_type2alive(const llvm::Type *ty);
-
-IR::Value* make_intconst(uint64_t val, int bits);
-IR::Value* make_intconst(const llvm::APInt &val);
-IR::Value* get_poison(IR::Type &ty);
-IR::Value* get_operand(llvm::Value *v,
-  std::function<IR::Value*(llvm::ConstantExpr *)> constexpr_conv,
-  std::function<IR::Value*(IR::AggregateValue *)> copy_inserter,
-  std::function<bool(llvm::Function*)> register_fn_decl);
-
-void add_identifier(const llvm::Value &llvm, IR::Value &v);
-void replace_identifier(const llvm::Value &llvm, IR::Value &v);
-IR::Value* get_identifier(const llvm::Value &llvm);
 
 #define PRINT(T) std::ostream& operator<<(std::ostream &os, const T &x);
 PRINT(llvm::Type)
@@ -59,8 +46,7 @@ void init_llvm_utils(std::ostream &os, const llvm::DataLayout &DL);
 std::ostream& get_outs();
 void set_outs(std::ostream &os);
 
-void reset_state();
-void reset_state(IR::Function &f);
+bool hasOpaqueType(llvm::Type *ty);
 
 std::unique_ptr<llvm::Module> openInputFile(llvm::LLVMContext &Context,
                                             const std::string &InputFilename);

--- a/llvm_util/utils.h
+++ b/llvm_util/utils.h
@@ -32,9 +32,6 @@ class Value;
 namespace llvm_util {
 
 IR::FastMathFlags parse_fmath(llvm::Instruction &i);
-
-IR::BasicBlock& getBB(const llvm::BasicBlock *bb);
-
 std::string value_name(const llvm::Value &v);
 
 IR::Type& get_int_type(unsigned bits);


### PR DESCRIPTION
Reduces the amount of global state by moving `value_cache`, `value_names` and `value_id_counter` to the `llvm2alive_` visitor.