### PR TITLE
Add Instr::isTerminator

### DIFF
--- a/ir/instr.cpp
+++ b/ir/instr.cpp
@@ -107,6 +107,9 @@ expr Instr::getTypeConstraints() const {
   return {};
 }
 
+bool Instr::isTerminator() const {
+  return false;
+}
 
 BinOp::BinOp(Type &type, string &&name, Value &lhs, Value &rhs, Op op,
              unsigned flags)
@@ -3048,6 +3051,10 @@ JumpInstr::target_iterator JumpInstr::it_helper::end() const {
   return { instr, idx };
 }
 
+bool JumpInstr::isTerminator() const {
+  return true;
+}
+
 
 void Branch::replaceTargetWith(const BasicBlock *from, const BasicBlock *to) {
   if (dst_true == from)
@@ -3249,6 +3256,9 @@ unique_ptr<Instr> Return::dup(Function &f, const string &suffix) const {
   return make_unique<Return>(getType(), *val);
 }
 
+bool Return::isTerminator() const {
+  return true;
+}
 
 Assume::Assume(Value &cond, Kind kind)
     : Instr(Type::voidTy, "assume"), args({&cond}), kind(kind) {

--- a/ir/instr.h
+++ b/ir/instr.h
@@ -21,6 +21,7 @@ public:
   virtual std::vector<Value*> operands() const = 0;
   virtual bool propagatesPoison() const = 0;
   virtual bool hasSideEffects() const = 0;
+  virtual bool isTerminator() const;
   smt::expr getTypeConstraints() const override;
   virtual smt::expr getTypeConstraints(const Function &f) const = 0;
   virtual std::unique_ptr<Instr> dup(Function &f,
@@ -519,6 +520,7 @@ public:
   it_helper targets() const { return this; }
   virtual void replaceTargetWith(const BasicBlock *From,
                                  const BasicBlock *To) = 0;
+  bool isTerminator() const override;
 };
 
 
@@ -585,6 +587,7 @@ public:
   smt::expr getTypeConstraints(const Function &f) const override;
   std::unique_ptr<Instr>
     dup(Function &f, const std::string &suffix) const override;
+  bool isTerminator() const override;
 };
 
 


### PR DESCRIPTION
As proposed previously in https://github.com/AliveToolkit/alive2/issues/1075, this PR adds the `Instr::isTerminator` method.

It currently does not consider `unreachable` a terminator, as it is represented as `assume i1 0` in Alive2 IR. This instruction may also be generated by `__builtin_assume(false)`, in which case it is not a terminator in LLVM IR. Thus not every basic block in alive2 necessarily ends with a terminator (at least as it is implemented currently).