### PR TITLE
Add State::getPath

### DIFF
--- a/ir/state.cpp
+++ b/ir/state.cpp
@@ -694,6 +694,21 @@ bool State::isAsmMode() const {
   return getFn().has(FnAttrs::Asm);
 }
 
+expr State::getPath(BasicBlock &bb) const {
+  if (&f.getFirstBB() == &bb)
+    return true;
+  
+  auto I = predecessor_data.find(&bb);
+  if (I == predecessor_data.end())
+    return false; // Block is unreachable
+
+  OrExpr path;
+  for (auto &[src, data] : I->second) {
+    path.add(data.path);
+  }
+  return std::move(path)();
+}
+
 void State::cleanup(const Value &val) {
   values.erase(&val);
   seen_bbs.clear();

--- a/ir/state.h
+++ b/ir/state.h
@@ -260,6 +260,8 @@ public:
 
   bool isAsmMode() const;
 
+  smt::expr getPath(BasicBlock &bb) const;
+
   // only used by alive-exec to support execution of the same BB multiple times
   void cleanup(const Value &val);
   void cleanupPredecessorData();


### PR DESCRIPTION
As proposed previously in https://github.com/AliveToolkit/alive2/issues/1075, this PR adds the `State::getPath` method.