### PR TITLE
Handle fnattr for all arithmetic intrinsics

### DIFF
--- a/tests/alive-tv/attrs/noundef-ret5.srctgt.ll
+++ b/tests/alive-tv/attrs/noundef-ret5.srctgt.ll
@@ -1,0 +1,11 @@
+define i64 @src(i64 %x) {
+  %rotl = call noundef i64 @llvm.fshl.i64(i64 %x, i64 %x, i64 3) 
+  %masked = and i64 %rotl, -4
+  ret i64 %masked
+}
+
+define noundef i64 @tgt(i64 %x) {
+  %rotl = call noundef i64 @llvm.fshl.i64(i64 %x, i64 %x, i64 3) 
+  %masked = and i64 %rotl, -4
+  ret i64 %masked
+}


### PR DESCRIPTION
Fixes a false positive result with `noundef` on the return value of `llvm.fshl`: https://alive2.llvm.org/ce/z/OfZuDi

```
define i64 @src(i64 %x) {
%282 = call noundef i64 @llvm.fshl.i64(i64 %x, i64 %x, i64 3) 
%283 = and i64 %282, -4
ret i64 %283
}

define noundef i64 @tgt(i64 %x) {
%282 = call noundef i64 @llvm.fshl.i64(i64 %x, i64 %x, i64 3) 
%283 = and i64 %282, -4
ret i64 %283
}
```
```

----------------------------------------
define i64 @src(i64 %x) {
#0:
  %#1 = fshl i64 %x, i64 %x, i64 3
  %#2 = and i64 %#1, -4
  ret i64 %#2
}
=>
define i64 @tgt(i64 %x) noundef {
#0:
  %#1 = fshl i64 %x, i64 %x, i64 3
  %#2 = and i64 %#1, -4
  ret i64 %#2
}
Transformation doesn't verify!

ERROR: Source is more defined than target

Example:
i64 %x = poison

Source:
i64 %#1 = poison
i64 %#2 = poison

Target:
i64 %#1 = poison
i64 %#2 = poison
```