### PR TITLE
Build alive-tv with MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ set(CMAKE_INSTALL_RPATH_USE_LINK_PATH ON)
 set(CMAKE_BUILD_WITH_INSTALL_RPATH ON)
 
 if (MSVC)
-  set(CMAKE_CXX_FLAGS                "/GL /EHsc /W2 ${CMAKE_CXX_FLAGS}")
+  set(CMAKE_CXX_FLAGS                "/GL /EHsc /W2 /Zc:__cplusplus ${CMAKE_CXX_FLAGS}")
   set(CMAKE_CXX_FLAGS_DEBUG          "/Od /Zi ${CMAKE_CXX_FLAGS_DEBUG}")
   set(CMAKE_CXX_FLAGS_RELEASE        "/O2 /Oi /Oy /Zc:inline ${CMAKE_CXX_FLAGS_RELEASE}")
   set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "/O2 /Oi /Zi ${CMAKE_CXX_FLAGS_RELWITHDEBINFO}")
@@ -130,10 +130,6 @@ set(UTIL_SRCS
   util/crc.cpp
   util/errors.cpp
   util/file.cpp
-  util/parallel.cpp
-  util/parallel_fifo.cpp
-  util/parallel_null.cpp
-  util/parallel_unrestricted.cpp
   util/random.cpp
   util/sort.cpp
   util/stopwatch.cpp
@@ -141,6 +137,16 @@ set(UTIL_SRCS
   util/unionfind.cpp
   util/version.cpp
 )
+
+if (BUILD_TV)
+  set(UTIL_SRCS
+    ${UTIL_SRCS}
+    util/parallel.cpp
+    util/parallel_fifo.cpp
+    util/parallel_null.cpp
+    util/parallel_unrestricted.cpp
+  )
+endif()
 
 add_library(util STATIC ${UTIL_SRCS})
 add_dependencies(util generate_version)

--- a/llvm_util/cmd_args_def.h
+++ b/llvm_util/cmd_args_def.h
@@ -67,7 +67,7 @@ if (!report_dir_created && !opt_report_dir.empty()) {
   if (opt_smt_log) {
     fs::path path_z3log = path;
     path_z3log.replace_extension("z3_log.txt");
-    smt::start_logging(path_z3log.c_str());
+    smt::start_logging(path_z3log.string().c_str());
   }
 } else if (opt_report_dir.empty()) {
   out = &cout;

--- a/llvm_util/llvm2alive.cpp
+++ b/llvm_util/llvm2alive.cpp
@@ -1915,7 +1915,7 @@ public:
       const char *chrs = name.data();
       char *end_ptr;
       auto numeric_id = strtoul(chrs, &end_ptr, 10);
-      if (end_ptr != name.end())
+      if (end_ptr != &*name.end())
         return M->getGlobalVariable(name, true);
       else {
         auto itr = M->global_begin(), end = M->global_end();

--- a/util/compiler.cpp
+++ b/util/compiler.cpp
@@ -5,6 +5,10 @@
 #include <algorithm>
 #include <bit>
 
+#ifdef _MSC_VER
+#include <intrin.h>
+#endif
+
 using namespace std;
 
 #if defined(__clang__) && __clang_major__ < 13 && defined(__apple_build_version__)
@@ -43,6 +47,17 @@ unsigned num_sign_bits(uint64_t n) {
   return max(countl_zero(n), countl_one(n)) -1;
 }
 
+#ifdef _MSC_VER
+uint64_t add_saturate(uint64_t a, uint64_t b) {
+  unsigned __int64 res;
+  static_assert(sizeof(res) == sizeof(uint64_t));
+  return _addcarry_u64(0, a, b, &res) ? UINT64_MAX : res;
+}
+
+uint64_t mul_saturate(uint64_t a, uint64_t b) {
+  return __umulh(a, b) ? UINT64_MAX : a * b;
+}
+#else
 uint64_t add_saturate(uint64_t a, uint64_t b) {
   unsigned long long res;
   static_assert(sizeof(res) == sizeof(uint64_t));
@@ -54,6 +69,7 @@ uint64_t mul_saturate(uint64_t a, uint64_t b) {
   static_assert(sizeof(res) == sizeof(uint64_t));
   return __builtin_umulll_overflow(a, b, &res) ? UINT64_MAX : res;
 }
+#endif
 
 uint64_t divide_up(uint64_t n, uint64_t amount) {
   return (n + amount - 1) / amount;

--- a/util/file.cpp
+++ b/util/file.cpp
@@ -41,7 +41,7 @@ string get_random_filename(const string &dir, const char *extension, const char 
   while (fs::exists(path)) {
     path.replace_filename(newname());
   }
-  return path;
+  return path.string();
 }
 
 }


### PR DESCRIPTION
These are some changes I had to make to build `alive-tv` with MSVC.

- `/Zc:__cplusplus` Sets the `__cplusplus` macro to the correct value.
- Since `parallel.hpp` uses UNIX APIs, we cannot build it. However this is not really an issue as it is only used when `BUILD_TV` is enabled, which is not supported on windows anyways.
- GCC intrinsics are of course not supported
- `std::filesystem::path` does not implicitly cast to string