### PR TITLE
Make memcpy/memset/memcmp inherit from `FnCall`

### DIFF
--- a/ir/instr.cpp
+++ b/ir/instr.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT license that can be found in the LICENSE file.
 
 #include "ir/instr.h"
+#include "ir/attrs.h"
 #include "ir/function.h"
 #include "ir/globals.h"
 #include "ir/type.h"
@@ -4148,7 +4149,8 @@ expr Memset::getTypeConstraints(const Function &f) const {
 }
 
 unique_ptr<Instr> Memset::dup(Function &f, const string &suffix) const {
-  return make_unique<Memset>(*ptr, *val, *bytes, align);
+  return make_unique<Memset>(*ptr, *val, *bytes, align,
+                             FnAttrs(getAttributes()));
 }
 
 
@@ -4156,8 +4158,9 @@ DEFINE_AS_RETZEROALIGN(MemsetPattern, getMaxAllocSize);
 DEFINE_AS_RETZERO(MemsetPattern, getMaxGEPOffset);
 
 MemsetPattern::MemsetPattern(Value &ptr, Value &pattern, Value &bytes,
-                             unsigned pattern_length)
-  : MemInstr(Type::voidTy, "memset_pattern" + to_string(pattern_length)),
+                             unsigned pattern_length, FnAttrs &&attrs)
+  : FnCall(Type::voidTy, "memset_pattern" + to_string(pattern_length),
+            "memset_pattern", std::move(attrs)),
     ptr(&ptr), pattern(&pattern), bytes(&bytes),
     pattern_length(pattern_length) {}
 
@@ -4207,7 +4210,8 @@ expr MemsetPattern::getTypeConstraints(const Function &f) const {
 }
 
 unique_ptr<Instr> MemsetPattern::dup(Function &f, const string &suffix) const {
-  return make_unique<MemsetPattern>(*ptr, *pattern, *bytes, pattern_length);
+  return make_unique<MemsetPattern>(*ptr, *pattern, *bytes, pattern_length,
+                                    FnAttrs(getAttributes()));
 }
 
 
@@ -4333,7 +4337,8 @@ expr Memcpy::getTypeConstraints(const Function &f) const {
 }
 
 unique_ptr<Instr> Memcpy::dup(Function &f, const string &suffix) const {
-  return make_unique<Memcpy>(*dst, *src, *bytes, align_dst, align_src, move);
+  return make_unique<Memcpy>(*dst, *src, *bytes, align_dst, align_src,
+                             FnAttrs(getAttributes()), move);
 }
 
 
@@ -4441,7 +4446,7 @@ expr Memcmp::getTypeConstraints(const Function &f) const {
 
 unique_ptr<Instr> Memcmp::dup(Function &f, const string &suffix) const {
   return make_unique<Memcmp>(getType(), getName() + suffix, *ptr1, *ptr2, *num,
-                             is_bcmp);
+                             FnAttrs(getAttributes()), is_bcmp);
 }
 
 

--- a/llvm_util/known_fns.cpp
+++ b/llvm_util/known_fns.cpp
@@ -522,24 +522,27 @@ known_call(llvm::CallInst &i, const llvm::TargetLibraryInfo &TLI,
 
   switch (libfn) {
   case llvm::LibFunc_memset: // void* memset(void *ptr, int val, size_t bytes)
-    BB.addInstr(make_unique<Memset>(*args[0], *args[1], *args[2], 1));
+    BB.addInstr(make_unique<Memset>(*args[0], *args[1], *args[2], 1, std::move(attrs)));
     RETURN_VAL(make_unique<UnaryOp>(*ty, value_name(i), *args[0],
                                     UnaryOp::Copy));
 
   // void memset_pattern4(void *ptr, void *pattern, size_t bytes)
   case llvm::LibFunc_memset_pattern4:
-    RETURN_VAL(make_unique<MemsetPattern>(*args[0], *args[1], *args[2], 4));
+    RETURN_VAL(make_unique<MemsetPattern>(*args[0], *args[1], *args[2], 4,
+                                          std::move(attrs)));
   case llvm::LibFunc_memset_pattern8:
-    RETURN_VAL(make_unique<MemsetPattern>(*args[0], *args[1], *args[2], 8));
+    RETURN_VAL(make_unique<MemsetPattern>(*args[0], *args[1], *args[2], 8,
+                                          std::move(attrs)));
   case llvm::LibFunc_memset_pattern16:
-    RETURN_VAL(make_unique<MemsetPattern>(*args[0], *args[1], *args[2], 16));
+    RETURN_VAL(make_unique<MemsetPattern>(*args[0], *args[1], *args[2], 16,
+                                          std::move(attrs)));
   case llvm::LibFunc_strlen:
     RETURN_VAL(make_unique<Strlen>(*ty, value_name(i), *args[0]));
   case llvm::LibFunc_memcmp:
   case llvm::LibFunc_bcmp: {
-    RETURN_VAL(
-      make_unique<Memcmp>(*ty, value_name(i), *args[0], *args[1], *args[2],
-                          libfn == llvm::LibFunc_bcmp));
+    RETURN_VAL(make_unique<Memcmp>(*ty, value_name(i), *args[0], *args[1],
+                                   *args[2], std::move(attrs),
+                                   libfn == llvm::LibFunc_bcmp));
   }
   case llvm::LibFunc_ffs:
   case llvm::LibFunc_ffsl:

--- a/llvm_util/llvm2alive.cpp
+++ b/llvm_util/llvm2alive.cpp
@@ -470,8 +470,14 @@ public:
     if (!ptr || !val || !bytes)
       return error(i);
 
+    FnAttrs attrs;
+    parse_fn_attrs(i, attrs);
+    attrs.set(FnAttrs::WillReturn);
+    attrs.set(FnAttrs::NoThrow);
+
     return make_unique<Memset>(*ptr, *val, *bytes,
-                               i.getDestAlign().valueOrOne().value());
+                               i.getDestAlign().valueOrOne().value(),
+                               std::move(attrs));
   }
 
   RetTy visitMemTransferInst(llvm::MemTransferInst &i) {
@@ -482,10 +488,15 @@ public:
     if (!dst || !src || !bytes)
       return error(i);
 
+    FnAttrs attrs;
+    parse_fn_attrs(i, attrs);
+    attrs.set(FnAttrs::WillReturn);
+    attrs.set(FnAttrs::NoThrow);
+
     return make_unique<Memcpy>(*dst, *src, *bytes,
                                i.getDestAlign().valueOrOne().value(),
                                i.getSourceAlign().valueOrOne().value(),
-                               isa<llvm::MemMoveInst>(&i));
+                               std::move(attrs), isa<llvm::MemMoveInst>(&i));
   }
 
   RetTy visitICmpInst(llvm::ICmpInst &i) {


### PR DESCRIPTION
Let memcpy et alia, which are intrinsically call instructions, inherit from FnCall so as to extend FnCall attributes to their subclasses as well. This is a preparatory change for supporting tail calls.