### PR TITLE
Fix : Copy missing local_blk_align, local_blk_size, local_blk_kind in dupNoRead function.

### DIFF
--- a/ir/memory.cpp
+++ b/ir/memory.cpp
@@ -1453,6 +1453,9 @@ Memory Memory::dupNoRead() const {
   Memory ret(*state);
   // minimal state to allow fn calls to compare input fn ptrs that can't be read
   ret.local_blk_addr = local_blk_addr;
+  ret.local_blk_align = local_blk_align;
+  ret.local_blk_size = local_blk_size;
+  ret.local_blk_kind = local_blk_kind;
   return ret;
 }
 

--- a/tests/alive-tv/memory/function_call_with_memory_attribute.srctgt.ll
+++ b/tests/alive-tv/memory/function_call_with_memory_attribute.srctgt.ll
@@ -1,0 +1,15 @@
+declare void @use_writeonly(ptr) memory(write)
+
+define void @src() {
+  %src = alloca i32, align 4
+  %dest = alloca i32, align 4
+  call void @use_writeonly(ptr %dest)
+  ret void
+}
+
+define void @tgt() {
+  %src = alloca i32, align 4
+  %dest = alloca i32, align 4
+  call void @use_writeonly(ptr %dest)
+  ret void
+}


### PR DESCRIPTION
Fixes https://github.com/AliveToolkit/alive2/issues/1087.


