### PR TITLE
Add Phi::setValue and Phi::setSource

### DIFF
--- a/ir/instr.cpp
+++ b/ir/instr.cpp
@@ -2939,6 +2939,14 @@ void Phi::replaceSourceWith(const string &from, const string &to) {
   }
 }
 
+void Phi::setValue(size_t index, Value &val) {
+  values[index].first = &val;
+}
+
+void Phi::setSource(size_t index, string &&BB_name) {
+  values[index].second = std::move(BB_name);
+}
+
 vector<Value*> Phi::operands() const {
   vector<Value*> v;
   for (auto &[val, bb] : values) {

--- a/ir/instr.h
+++ b/ir/instr.h
@@ -512,6 +512,9 @@ public:
   void removeValue(const std::string &BB_name);
   void replaceSourceWith(const std::string &from, const std::string &to);
 
+  void setValue(size_t index, Value &val);
+  void setSource(size_t index, std::string &&BB_name);
+
   const auto& getValues() const { return values; }
   std::vector<std::string> sources() const;
 


### PR DESCRIPTION
This PR adds `Phi::setValue` and `Phi::setSource` methods, that allow setting the incoming value / basic block for a specific index. In contrast to `replaceSourceWith` and `replace` to they run in $O(1)$ instead of $O(n)$.

Related: https://github.com/AliveToolkit/alive2/issues/1075