### PR TITLE
respect range attributes on the return value of an intrinsic call

### DIFF
--- a/llvm_util/llvm2alive.cpp
+++ b/llvm_util/llvm2alive.cpp
@@ -1225,6 +1225,12 @@ public:
     if (ret) {
       FnAttrs attrs;
       parse_fn_attrs(i, attrs);
+      if (i.hasRetAttr(llvm::Attribute::Range)) {
+        auto &ptr = *ret;
+        BB->addInstr(std::move(ret));
+        ret =
+            handleRangeAttrNoInsert(i.getRetAttr(llvm::Attribute::Range), ptr);
+      }
       add_identifier(i, *ret.get());
       if (attrs.has(FnAttrs::NoUndef)) {
         auto &ptr = *ret;

--- a/tests/alive-tv/attrs/range.srctgt.ll
+++ b/tests/alive-tv/attrs/range.srctgt.ll
@@ -1,0 +1,17 @@
+; ERROR: Target is more poisonous than source
+
+define i1 @src(i32 %x) {
+entry:
+  %cmp1 = icmp ne i32 %x, 0
+  %popcnt = call range(i32 1, 33) i32 @llvm.ctpop.i32(i32 %x)
+  %cmp2 = icmp ult i32 %popcnt, 2
+  %sel = select i1 %cmp1, i1 %cmp2, i1 false
+  ret i1 %sel
+}
+
+define i1 @tgt(i32 %x) {
+entry:
+  %popcnt = call range(i32 1, 33) i32 @llvm.ctpop.i32(i32 %x)
+  %sel = icmp eq i32 %popcnt, 1
+  ret i1 %sel
+}


### PR DESCRIPTION
For historical reasons we choose to use return value range attributes for `llvm.ctpop` instead of introducing a new poison-generating parameter (See https://github.com/llvm/llvm-project/issues/95255#issuecomment-2166944909).

This patch adds support for range attributes on the return value of an intrinsic call. Fixes https://github.com/AliveToolkit/alive2/issues/1096.
