### PR TITLE
Simplify extract from ashr

### DIFF
--- a/smt/expr.cpp
+++ b/smt/expr.cpp
@@ -497,6 +497,10 @@ bool expr::isSignExt(expr &val) const {
   return isUnOp(val, Z3_OP_SIGN_EXT);
 }
 
+bool expr::isAShr(expr &a, expr &b) const {
+  return isBinOp(a, b, Z3_OP_BASHR);
+}
+
 bool expr::isAnd(expr &a, expr &b) const {
   return isBinOp(a, b, Z3_OP_AND);
 }
@@ -1849,6 +1853,15 @@ expr expr::extract(unsigned high, unsigned low, unsigned depth) const {
       if (high < val_bits)
         return val.extract(high, 0);
       return val.sext(high - val_bits + 1);
+    }
+  }
+  {
+    expr a, b;
+    if (isAShr(a, b)) {
+      uint64_t shift;
+      if (b.isUInt(shift) && high + shift < a.bits()) {
+        return a.extract(high + shift, low + shift);
+      }
     }
   }
   {

--- a/smt/expr.h
+++ b/smt/expr.h
@@ -135,6 +135,7 @@ public:
   bool isConcat(expr &a, expr &b) const;
   bool isExtract(expr &e, unsigned &high, unsigned &low) const;
   bool isSignExt(expr &val) const;
+  bool isAShr(expr &a, expr &b) const;
   bool isAnd(expr &a, expr &b) const;
   bool isNot(expr &neg) const;
   bool isAdd(expr &a, expr &b) const;


### PR DESCRIPTION
Similar to `sext`, `ashr` is also not rewritten to a combination of `extract` and `concat`s. The `extract` method already simplifies `extract(sext(...), ...)`. This PR extends `extract` to also simpliy `extract(ashr(...), ...)`. It adds the following rewrite:

`extract(ashr(x, shift), high, low) -> extract(x, high + shift, low + shift) if high + shift < x.bits()`
