### PR TITLE
Simplify applying bitwise operators on sign extended values

### DIFF
--- a/smt/expr.cpp
+++ b/smt/expr.cpp
@@ -497,10 +497,6 @@ bool expr::isSignExt(expr &val) const {
   return isUnOp(val, Z3_OP_SIGN_EXT);
 }
 
-bool expr::isZeroExt(expr &val) const {
-  return isUnOp(val, Z3_OP_ZERO_EXT);
-}
-
 bool expr::isAShr(expr &a, expr &b) const {
   return isBinOp(a, b, Z3_OP_BASHR);
 }
@@ -1356,11 +1352,6 @@ expr expr::operator&(const expr &rhs) const {
         lhsVal.bits() == rhsVal.bits()) {
       return (lhsVal & rhsVal).sext(bits() - lhsVal.bits());
     }
-
-    if (isZeroExt(lhsVal) && rhs.isZeroExt(rhsVal) &&
-        lhsVal.bits() == rhsVal.bits()) {
-      return (lhsVal & rhsVal).zext(bits() - lhsVal.bits());
-    }
   }
 
   auto fold_extract = [](auto &a, auto &b) {
@@ -1414,11 +1405,6 @@ expr expr::operator|(const expr &rhs) const {
         lhsVal.bits() == rhsVal.bits()) {
       return (lhsVal | rhsVal).sext(bits() - lhsVal.bits());
     }
-
-    if (isZeroExt(lhsVal) && rhs.isZeroExt(rhsVal) &&
-        lhsVal.bits() == rhsVal.bits()) {
-      return (lhsVal | rhsVal).zext(bits() - lhsVal.bits());
-    }
   }
 
   if (bits() == 1) {
@@ -1445,11 +1431,6 @@ expr expr::operator^(const expr &rhs) const {
     if (isSignExt(lhsVal) && rhs.isSignExt(rhsVal) &&
         lhsVal.bits() == rhsVal.bits()) {
       return (lhsVal ^ rhsVal).sext(bits() - lhsVal.bits());
-    }
-
-    if (isZeroExt(lhsVal) && rhs.isZeroExt(rhsVal) &&
-        lhsVal.bits() == rhsVal.bits()) {
-      return (lhsVal ^ rhsVal).zext(bits() - lhsVal.bits());
     }
   }
 

--- a/smt/expr.h
+++ b/smt/expr.h
@@ -135,6 +135,7 @@ public:
   bool isConcat(expr &a, expr &b) const;
   bool isExtract(expr &e, unsigned &high, unsigned &low) const;
   bool isSignExt(expr &val) const;
+  bool isZeroExt(expr &val) const;
   bool isAShr(expr &a, expr &b) const;
   bool isAnd(expr &a, expr &b) const;
   bool isNot(expr &neg) const;

--- a/smt/expr.h
+++ b/smt/expr.h
@@ -135,7 +135,6 @@ public:
   bool isConcat(expr &a, expr &b) const;
   bool isExtract(expr &e, unsigned &high, unsigned &low) const;
   bool isSignExt(expr &val) const;
-  bool isZeroExt(expr &val) const;
   bool isAShr(expr &a, expr &b) const;
   bool isAnd(expr &a, expr &b) const;
   bool isNot(expr &neg) const;


### PR DESCRIPTION
Since the result of comparison and logical operators in C is of type `int`, complex logical expressions may result in expression trees where sext, extract and logical operators are used together (especially when the programmer uses temporary variables of type `int` to store boolean values and instcombine has not been executed).

This PR introduces the following simplifications for bit vectors of the same width `a` and `b`:

```
sext(a) & sext(b) -> sext(a & b)
sext(a) | sext(b) -> sext(a | b)
sext(a) ^ sext(b) -> sext(a ^ b)
~sext(a) -> sext(~a)
```

The pattern `extract(sext(x), ...)` is already handled by the existing simplifications.

If this breaks other important cases, it might be possible to enforce that `a.bits() = b.bits() = 1`, although I have personally seen a major impact anywhere else yet.