### PR TITLE
ir: don't rely on class template arg deduction

### DIFF
--- a/ir/memory.cpp
+++ b/ir/memory.cpp
@@ -2392,7 +2392,7 @@ void Memory::copy(const Pointer &src, const Pointer &dst) {
 
   unsigned has_bv_val = 0;
   auto offset = expr::mkUInt(0, Pointer::bitsShortOffset());
-  DisjointExpr val(Byte::mkPoisonByte(*this)());
+  DisjointExpr<expr> val(Byte::mkPoisonByte(*this)());
 
   auto fn = [&](MemBlock &blk, const Pointer &ptr, expr &&cond) {
     // we assume src != dst

--- a/ir/state.cpp
+++ b/ir/state.cpp
@@ -255,7 +255,7 @@ State::State(const Function &f, bool source)
   : f(f), source(source), memory(*this),
     fp_rounding_mode(expr::mkVar("fp_rounding_mode", 3)),
     fp_denormal_mode(expr::mkVar("fp_denormal_mode", 2)),
-    return_val(DisjointExpr(f.getType().getDummyValue(false))) {}
+    return_val(DisjointExpr<StateValue>(f.getType().getDummyValue(false))) {}
 
 void State::resetGlobals() {
   Memory::resetGlobals();
@@ -697,7 +697,7 @@ bool State::isAsmMode() const {
 expr State::getPath(BasicBlock &bb) const {
   if (&f.getFirstBB() == &bb)
     return true;
-  
+
   auto I = predecessor_data.find(&bb);
   if (I == predecessor_data.end())
     return false; // Block is unreachable
@@ -1327,7 +1327,7 @@ void State::finishInitializer() {
     assert(predecessor_data.size() == 1);
     mem = &predecessor_data.begin()->second.begin()->second.mem.begin()->first;
   }
-  return_memory = DisjointExpr(mem->dup());
+  return_memory = DisjointExpr<Memory>(mem->dup());
 
   if (auto *ret = getFn().getReturnedInput()) {
     returned_input = (*this)[*ret];

--- a/llvm_util/llvm2alive.cpp
+++ b/llvm_util/llvm2alive.cpp
@@ -55,7 +55,6 @@ FpExceptionMode parse_exceptions(llvm::Instruction &i) {
   case llvm::fp::ebIgnore:  return FpExceptionMode::Ignore;
   case llvm::fp::ebMayTrap: return FpExceptionMode::MayTrap;
   case llvm::fp::ebStrict:  return FpExceptionMode::Strict;
-  default: UNREACHABLE();
   }
 }
 

--- a/smt/solver.cpp
+++ b/smt/solver.cpp
@@ -527,9 +527,8 @@ Result Solver::check(const char *query_name) const {
     ++num_errors;
     return { Result::ERROR, string(reason) };
   }
-  default:
-    UNREACHABLE();
   }
+  UNREACHABLE();
 }
 
 Result check_expr(const expr &e, const char *query_name) {


### PR DESCRIPTION
Class template argument deduction has the potential to hide bugs, and the compiler emits a -Wctad-maybe-unsupported warning. Although no bugs were found, don't rely on class template argument deduction, squelching these warnings.

While at it, also squelch the remaining -Wcovered-switch-default warnings.