### PR TITLE
Correct Grammar, Spelling, and Capitalization in Documentation

### DIFF
--- a/BugList.md
+++ b/BugList.md
@@ -95,7 +95,7 @@ Please contact us or submit a PR if something is missing or inaccurate.
 88. VectorCombine: shufflevector reorder leads to srem by poison (https://llvm.org/PR89390)
 89. InstCombine: incorrect srem rewrite (https://llvm.org/PR89516)
 90. InstCombine: incorrect swap of select vector operands (https://llvm.org/89669)
-91. SimplifyCFG: coallesced store retains the wrong alignment (https://llvm.org/PR89672)
+91. SimplifyCFG: coalesced store retains the wrong alignment (https://llvm.org/PR89672)
 92. LoopVectorize introduces division by zero (https://llvm.org/PR89958)
 93. InstCombine: align attribute doesn't dereferenceability (https://llvm.org/PR90446)
 94. Reassociate: invalid propagation of overflow attributes at low bit-width (https://llvm.org/PR91417)

--- a/scripts/perf-testing/README.md
+++ b/scripts/perf-testing/README.md
@@ -2,12 +2,12 @@ Solver efficiency testing
 =========================
 
 The `test.pl` script is intended to evaluate how well some particular
-version of alive-tv works together with some particular version of
+version of Alive-tv works together with some particular version of
 Z3. The strategy is to have a collection of test cases that are
 parameterized by a value and then to see how high this value can be
 pushed without triggering a solver timeout.
 
-The m4 macro processor is used to replace every occurrence of `X` in a
+The M4 macro processor is used to replace every occurrence of `X` in a
 test case with the value of the parameter. Since m4 considers `iX` to
 be a single token, we use a special case to replace, for example, `iX`
 with `i32` when the value of X is 32.

--- a/scripts/perf-testing/README.md
+++ b/scripts/perf-testing/README.md
@@ -2,12 +2,12 @@ Solver efficiency testing
 =========================
 
 The `test.pl` script is intended to evaluate how well some particular
-version of Alive-tv works together with some particular version of
+version of alive-tv works together with some particular version of
 Z3. The strategy is to have a collection of test cases that are
 parameterized by a value and then to see how high this value can be
 pushed without triggering a solver timeout.
 
-The M4 macro processor is used to replace every occurrence of `X` in a
+The m4 macro processor is used to replace every occurrence of `X` in a
 test case with the value of the parameter. Since m4 considers `iX` to
 be a single token, we use a special case to replace, for example, `iX`
 with `i32` when the value of X is 32.

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,7 +1,7 @@
 Alive2 unit tests
 =================
 
-three test file formats are supported:
+Three test file formats are supported:
 
 - if a unit test has the suffix ".srctgt.ll" then this file will be sent to
   alive-tv. it should stand on its own.

--- a/tests/alive-tv/bugs/README.md
+++ b/tests/alive-tv/bugs/README.md
@@ -1,3 +1,3 @@
 This folder maintains a set of tests to check that Alive2 does not miss any
-miscompilation that have been reported to Bugzilla (either reported by us or
+miscompilations that have been reported to Bugzilla (either reported by us or
 others).


### PR DESCRIPTION
Description: This PR includes the following corrections:

Corrected "miscompilation" to "miscompilations" to match the plural form.
Capitalized the first letter of the sentence starting with "three test file formats are supported:".
Fixed the spelling of "coallesced" to "coalesced".
