### PR TITLE
config: introduce use_exact_fp option

### DIFF
--- a/ir/type.cpp
+++ b/ir/type.cpp
@@ -6,6 +6,7 @@
 #include "ir/state.h"
 #include "smt/solver.h"
 #include "util/compiler.h"
+#include "util/config.h"
 #include <array>
 #include <cassert>
 #include <numeric>
@@ -450,7 +451,7 @@ expr FloatType::fromFloat(State &s, const expr &fp, const Type &from_type0,
   expr isnan = fp.isNaN();
   expr val = fp.float2BV();
 
-  if (isnan.isFalse())
+  if (config::use_exact_fp || isnan.isFalse())
     return val;
 
   unsigned fraction_bits = fractionBits();

--- a/util/config.cpp
+++ b/util/config.cpp
@@ -15,6 +15,7 @@ bool skip_smt = false;
 string smt_benchmark_dir;
 bool disable_poison_input = false;
 bool disable_undef_input = false;
+bool use_exact_fp = false;
 bool tgt_is_asm = false;
 bool fail_if_src_is_ub = false;
 bool disallow_ub_exploitation = false;

--- a/util/config.h
+++ b/util/config.h
@@ -19,6 +19,8 @@ extern bool disable_poison_input;
 
 extern bool disable_undef_input;
 
+extern bool use_exact_fp;
+
 extern bool tgt_is_asm;
 
 extern bool fail_if_src_is_ub;


### PR DESCRIPTION
The configuration option is useful for returning the exact fp from FloatType::fromFloat, ignoring NaN, and is required by Minotaur [https://arxiv.org/abs/2306.00229] to synthesize correctly. use_exact_fp is turned off by default, and should pose no correctness issue when turned on.