### PR TITLE
tests/memory: cover memmove

### DIFF
--- a/tests/alive-tv/memory/memmove-memset-poison.srctgt.ll
+++ b/tests/alive-tv/memory/memmove-memset-poison.srctgt.ll
@@ -1,0 +1,14 @@
+define void @src(ptr %src, ptr %dst) {
+  %load.src = load i32, ptr %src
+  store i32 poison, ptr %dst
+  %gep.dst.1 = getelementptr i32, ptr %dst, i64 1
+  store i32 %load.src, ptr %gep.dst.1
+  ret void
+}
+
+define void @tgt(ptr %src, ptr %dst) {
+  %gep.dst.1 = getelementptr i32, ptr %dst, i64 1
+  call void @llvm.memmove.p0.p0.i64(ptr %gep.dst.1, ptr %src, i64 4, i1 false)
+  call void @llvm.memset.p0.i64(ptr %dst, i8 poison, i64 4, i1 false)
+  ret void
+}

--- a/tests/alive-tv/memory/memmove.srctgt.ll
+++ b/tests/alive-tv/memory/memmove.srctgt.ll
@@ -1,0 +1,10 @@
+define void @src(ptr %src, ptr %dst) {
+  %load.src = load i32, ptr %src
+  store i32 %load.src, ptr %dst
+  ret void
+}
+
+define void @tgt(ptr %src, ptr %dst) {
+  call void @llvm.memmove.p0.p0.i64(ptr %dst, ptr %src, i64 4, i1 false)
+  ret void
+}


### PR DESCRIPTION
The test suite suffers from the deficiency that the memmove is not covered, even though it is supported. Fix this deficiency by checking in a couple of examples of optimizations performed by MemCpyOpt in LLVM.