### PR TITLE
Check shamt before extracting bits from an ashr

### DIFF
--- a/smt/expr.cpp
+++ b/smt/expr.cpp
@@ -1890,10 +1890,8 @@ expr expr::extract(unsigned high, unsigned low, unsigned depth) const {
     expr a, b;
     if (isAShr(a, b)) {
       uint64_t shift;
-      if (b.isUInt(shift) && high + shift < a.bits()) {
-        assert(shift < a.bits());
+      if (b.isUInt(shift) && shift < a.bits() && high + shift < a.bits())
         return a.extract(high + shift, low + shift);
-      }
     }
   }
   {

--- a/tests/alive-tv/samesign.srctgt.ll
+++ b/tests/alive-tv/samesign.srctgt.ll
@@ -7,3 +7,13 @@ define i1 @tgt(i8 %x, i8 %y) {
   %cmp = icmp samesign ult i8 %x, %y
   ret i1 %cmp
 }
+
+define i1 @src1(i64 %x) {
+  %ashr = ashr i64 %x, -1
+  %cmp = icmp samesign ugt i64 %ashr, 0
+  ret i1 %cmp
+}
+
+define i1 @tgt1(i64 %x) {
+  ret i1 poison
+}


### PR DESCRIPTION
`high + shift` may overflow when the shamt is invalid: https://alive2.llvm.org/ce/z/AT9VHM
Fix an assertion failure introduced by https://github.com/AliveToolkit/alive2/pull/1105.
