### PR TITLE
Fix false positive on icmp ptr with samesign flag

### DIFF
--- a/ir/instr.cpp
+++ b/ir/instr.cpp
@@ -2791,16 +2791,12 @@ StateValue ICmp::toSMT(State &s) const {
     expr np = true;
     if (flags & SameSign) {
       if (isPtrCmp()) {
-        assert(pcmode == INTEGRAL || pcmode == OFFSETONLY);
         auto &m = s.getMemory();
         Pointer lhs(m, a.value);
         Pointer rhs(m, b.value);
         m.observesAddr(lhs);
         m.observesAddr(rhs);
-        if (pcmode == INTEGRAL)
-          np = lhs.getAddress().sign() == rhs.getAddress().sign();
-        else
-          np = lhs.getOffset().sign() == rhs.getOffset().sign();
+        np = lhs.getAddress().sign() == rhs.getAddress().sign();
       } else {
         np = a.value.sign() == b.value.sign();
       }

--- a/ir/instr.cpp
+++ b/ir/instr.cpp
@@ -2794,6 +2794,8 @@ StateValue ICmp::toSMT(State &s) const {
         auto &m = s.getMemory();
         Pointer lhs(m, a.value);
         Pointer rhs(m, b.value);
+        m.observesAddr(lhs);
+        m.observesAddr(rhs);
         np = lhs.getAddress().sign() == rhs.getAddress().sign();
       } else {
         np = a.value.sign() == b.value.sign();

--- a/ir/instr.cpp
+++ b/ir/instr.cpp
@@ -2791,13 +2791,16 @@ StateValue ICmp::toSMT(State &s) const {
     expr np = true;
     if (flags & SameSign) {
       if (isPtrCmp()) {
-        assert(pcmode == INTEGRAL);
+        assert(pcmode == INTEGRAL || pcmode == OFFSETONLY);
         auto &m = s.getMemory();
         Pointer lhs(m, a.value);
         Pointer rhs(m, b.value);
         m.observesAddr(lhs);
         m.observesAddr(rhs);
-        np = lhs.getAddress().sign() == rhs.getAddress().sign();
+        if (pcmode == INTEGRAL)
+          np = lhs.getAddress().sign() == rhs.getAddress().sign();
+        else
+          np = lhs.getOffset().sign() == rhs.getOffset().sign();
       } else {
         np = a.value.sign() == b.value.sign();
       }

--- a/ir/instr.cpp
+++ b/ir/instr.cpp
@@ -2794,8 +2794,6 @@ StateValue ICmp::toSMT(State &s) const {
         auto &m = s.getMemory();
         Pointer lhs(m, a.value);
         Pointer rhs(m, b.value);
-        m.observesAddr(lhs);
-        m.observesAddr(rhs);
         np = lhs.getAddress().sign() == rhs.getAddress().sign();
       } else {
         np = a.value.sign() == b.value.sign();

--- a/tests/alive-tv/samesign-ptr.srctgt.ll
+++ b/tests/alive-tv/samesign-ptr.srctgt.ll
@@ -13,3 +13,12 @@ define i1 @tgt(ptr %a, ptr %b) {
   %cmp = icmp samesign eq ptr %b, null
   ret i1 %cmp
 }
+
+define i1 @src_offsetonly() {
+  %cmp = icmp samesign eq ptr null, null
+  ret i1 %cmp
+}
+
+define i1 @tgt_offsetonly() {
+  ret i1 true
+}

--- a/tests/alive-tv/samesign-ptr.srctgt.ll
+++ b/tests/alive-tv/samesign-ptr.srctgt.ll
@@ -1,0 +1,15 @@
+target datalayout = "p:8:8:8"
+
+define i1 @src(ptr %a, ptr %b) {
+  %pa = ptrtoint ptr %a to i8
+  %pb = ptrtoint ptr %b to i8
+  %sub = sub i8 %pb, %pa
+  %gep = getelementptr i8, ptr %a, i8 %sub
+  %cmp = icmp samesign eq ptr %gep, null
+  ret i1 %cmp
+}
+
+define i1 @tgt(ptr %a, ptr %b) {
+  %cmp = icmp samesign eq ptr %b, null
+  ret i1 %cmp
+}

--- a/tests/alive-tv/samesign-ptr.srctgt.ll
+++ b/tests/alive-tv/samesign-ptr.srctgt.ll
@@ -22,3 +22,13 @@ define i1 @src_offsetonly() {
 define i1 @tgt_offsetonly() {
   ret i1 true
 }
+
+define i1 @src_provenance(ptr %base) {
+  %gep = getelementptr inbounds i8, ptr %base, i64 1
+  %cnd = icmp samesign eq ptr %gep, null
+  ret i1 %cnd
+}
+
+define i1 @tgt_provenance(ptr %base) {
+  ret i1 false
+}


### PR DESCRIPTION
Pointers should be interpreted as integral before extracting the sign bit.

Alive2: https://alive2.llvm.org/ce/z/GnWJ9H
```
----------------------------------------
define i1 @src(ptr %a, ptr %b) {
#0:
  %pa = ptrtoint ptr %a to i8
  %pb = ptrtoint ptr %b to i8
  %sub = sub i8 %pb, %pa
  %gep = gep ptr %a, 1 x i8 %sub
  %cmp = icmp samesign eq ptr %gep, null
  ret i1 %cmp
}
=>
define i1 @tgt(ptr %a, ptr %b) {
#0:
  %cmp = icmp samesign eq ptr %b, null
  ret i1 %cmp
}
Transformation doesn't verify!

ERROR: Target is more poisonous than source

Example:
ptr %a = null
ptr %b = pointer(non-local, block_id=2, offset=0) / Address=#x01

Source:
i8 %pa = #x00 (0)
i8 %pb = #x01 (1)
i8 %sub = #x01 (1)
ptr %gep = pointer(non-local, block_id=0, offset=1) / Address=#x01
i1 %cmp = #x0 (0)

SOURCE MEMORY STATE
===================
NON-LOCAL BLOCKS:
Block 0 >	size: 0	align: 1	alloc type: 0	alive: false	address: 0
Block 1 >	size: 2	align: 1	alloc type: 0	alive: true	address: 64
Block 2 >	size: 0	align: 1	alloc type: 0	alive: true	address: 1

Target:
i1 %cmp = poison
Source value: #x0 (0)
Target value: poison
```