### PR TITLE
vector/test: pre-commit tests for vscale support

### DIFF
--- a/tests/alive-tv/vector/vscale/dse-scalable-fixed-neg.srctgt.ll
+++ b/tests/alive-tv/vector/vscale/dse-scalable-fixed-neg.srctgt.ll
@@ -1,0 +1,15 @@
+; SKIP-IDENTITY
+
+define void @src(ptr %ptr) vscale_range(1, 2) {
+  %gep.ptr.16 = getelementptr i64, ptr %ptr, i64 16
+  store <2 x i64> zeroinitializer, ptr %gep.ptr.16
+  store <vscale x 4 x i64> zeroinitializer, ptr %ptr
+  ret void
+}
+
+define void @tgt(ptr %ptr) vscale_range(1, 2) {
+  store <vscale x 4 x i64> zeroinitializer, ptr %ptr
+  ret void
+}
+
+; ERROR: Unsupported type: <vscale x 4 x i64>

--- a/tests/alive-tv/vector/vscale/dse-scalable-fixed.srctgt.ll
+++ b/tests/alive-tv/vector/vscale/dse-scalable-fixed.srctgt.ll
@@ -1,0 +1,15 @@
+; SKIP-IDENTITY
+
+define void @src(ptr %ptr) vscale_range(1, 2) {
+  %gep.ptr.2 = getelementptr i64, ptr %ptr, i64 2
+  store <2 x i64> zeroinitializer, ptr %gep.ptr.2
+  store <vscale x 4 x i64> zeroinitializer, ptr %ptr
+  ret void
+}
+
+define void @tgt(ptr %ptr) vscale_range(1, 2) {
+  store <vscale x 4 x i64> zeroinitializer, ptr %ptr
+  ret void
+}
+
+; ERROR: Unsupported type: <vscale x 4 x i64>

--- a/tests/alive-tv/vector/vscale/dse-scalable-scalable-neg.srctgt.ll
+++ b/tests/alive-tv/vector/vscale/dse-scalable-scalable-neg.srctgt.ll
@@ -1,0 +1,15 @@
+; SKIP-IDENTITY
+
+define void @src(ptr %ptr) vscale_range(1, 4) {
+  %gep.ptr.8 = getelementptr i64, ptr %ptr, i64 8
+  store <vscale x 4 x i64> zeroinitializer, ptr %gep.ptr.8
+  store <vscale x 2 x i64> zeroinitializer, ptr %ptr
+  ret void
+}
+
+define void @tgt(ptr %ptr) vscale_range(1, 4) {
+  store <vscale x 2 x i64> zeroinitializer, ptr %ptr
+  ret void
+}
+
+; ERROR: Unsupported type: <vscale x 4 x i64>

--- a/tests/alive-tv/vector/vscale/dse-scalable-scalable.srctgt.ll
+++ b/tests/alive-tv/vector/vscale/dse-scalable-scalable.srctgt.ll
@@ -1,0 +1,15 @@
+; SKIP-IDENTITY
+
+define void @src(ptr %ptr) vscale_range(1, 4) {
+  %gep.ptr.2 = getelementptr i64, ptr %ptr, i64 2
+  store <vscale x 2 x i64> zeroinitializer, ptr %gep.ptr.2
+  store <vscale x 4 x i64> zeroinitializer, ptr %ptr
+  ret void
+}
+
+define void @tgt(ptr %ptr) vscale_range(1, 4) {
+  store <vscale x 4 x i64> zeroinitializer, ptr %ptr
+  ret void
+}
+
+; ERROR: Unsupported type: <vscale x 2 x i64>

--- a/tests/alive-tv/vector/vscale/inbounds-poison.srctgt.ll
+++ b/tests/alive-tv/vector/vscale/inbounds-poison.srctgt.ll
@@ -1,0 +1,12 @@
+; SKIP-IDENTITY
+
+define <vscale x 1 x i8> @src(<vscale x 1 x i8> %a) vscale_range(2, 4) {
+  %v = insertelement <vscale x 1 x i8> %a, i8 -1, i64 2
+  ret <vscale x 1 x i8> %v
+}
+
+define <vscale x 1 x i8> @tgt(<vscale x 1 x i8> %a) vscale_range(2, 4) {
+  ret <vscale x 1 x i8> poison
+}
+
+; ERROR: Unsupported type: <vscale x 1 x i8>

--- a/tests/alive-tv/vector/vscale/insert-extract-constvscale.srctgt.ll
+++ b/tests/alive-tv/vector/vscale/insert-extract-constvscale.srctgt.ll
@@ -1,0 +1,13 @@
+; SKIP-IDENTITY
+
+define i8 @src(<vscale x 1 x i8> %a) vscale_range(4, 4) {
+  %v = insertelement <vscale x 1 x i8> %a, i8 -1, i64 2
+  %r = extractelement <vscale x 1 x i8> %v, i64 2
+  ret i8 %r
+}
+
+define i8 @tgt(<vscale x 1 x i8> %a) vscale_range(4, 4) {
+  ret i8 -1
+}
+
+; ERROR: Unsupported type: <vscale x 1 x i8>

--- a/tests/alive-tv/vector/vscale/insert-extract.srctgt.ll
+++ b/tests/alive-tv/vector/vscale/insert-extract.srctgt.ll
@@ -1,0 +1,13 @@
+; SKIP-IDENTITY
+
+define i8 @src(<vscale x 1 x i8> %a) vscale_range(2, 4) {
+  %v = insertelement <vscale x 1 x i8> %a, i8 -1, i64 2
+  %r = extractelement <vscale x 1 x i8> %v, i64 2
+  ret i8 %r
+}
+
+define i8 @tgt(<vscale x 1 x i8> %a) vscale_range(2, 4) {
+  ret i8 -1
+}
+
+; ERROR: Unsupported type: <vscale x 1 x i8>

--- a/tests/alive-tv/vector/vscale/out-of-bounds-poison.srctgt.ll
+++ b/tests/alive-tv/vector/vscale/out-of-bounds-poison.srctgt.ll
@@ -1,0 +1,12 @@
+; SKIP-IDENTITY
+
+define <vscale x 1 x i8> @src(<vscale x 1 x i8> %a) vscale_range(1, 2) {
+  %v = insertelement <vscale x 1 x i8> %a, i8 -2, i64 3
+  ret <vscale x 1 x i8> %v
+}
+
+define <vscale x 1 x i8> @tgt(<vscale x 1 x i8> %a) vscale_range(1, 2) {
+  ret <vscale x 1 x i8> poison
+}
+
+; ERROR: Unsupported type: <vscale x 1 x i8>

--- a/tests/alive-tv/vector/vscale/poison-constvscale.srctgt.ll
+++ b/tests/alive-tv/vector/vscale/poison-constvscale.srctgt.ll
@@ -1,0 +1,16 @@
+; SKIP-IDENTITY
+
+define i32 @src(i32 %a) vscale_range(4, 4) {
+  %poison = add nsw i32 2147483647, 100
+  %v = insertelement <vscale x 2 x i32> poison, i32 %a, i64 0
+  %v2 = insertelement <vscale x 2 x i32> %v, i32 %poison, i64 1
+  %w = extractelement <vscale x 2 x i32> %v2, i64 0
+  ret i32 %w
+}
+
+define i32 @tgt(i32 %a) vscale_range(4, 4) {
+  %poison = add nsw i32 2147483647, 100
+  ret i32 %poison
+}
+
+; ERROR: Unsupported type: <vscale x 2 x i32>

--- a/tests/alive-tv/vector/vscale/rem-constvscale.srctgt.ll
+++ b/tests/alive-tv/vector/vscale/rem-constvscale.srctgt.ll
@@ -1,0 +1,16 @@
+; SKIP-IDENTITY
+
+define <vscale x 2 x i8> @src(<vscale x 2 x i8> %x) vscale_range(2, 2) {
+  %rem.i = srem <vscale x 2 x i8> %x, splat(i8 2)
+  %cmp.i = icmp slt <vscale x 2 x i8> %rem.i, zeroinitializer
+  %add.i = select <vscale x 2 x i1> %cmp.i, <vscale x 2 x i8> splat(i8 2), <vscale x 2 x i8> zeroinitializer
+  ret <vscale x 2 x i8> %add.i
+}
+
+define <vscale x 2 x i8> @tgt(<vscale x 2 x i8> %x) vscale_range(2, 2) {
+  %rem.i = srem <vscale x 2 x i8> %x, splat(i8 2)
+  %tmp1 = and <vscale x 2 x i8> %rem.i, splat(i8 2)
+  ret <vscale x 2 x i8> %tmp1
+}
+
+; ERROR: Unsupported type: <vscale x 2 x i8>

--- a/tests/alive-tv/vector/vscale/rem.srctgt.ll
+++ b/tests/alive-tv/vector/vscale/rem.srctgt.ll
@@ -1,0 +1,16 @@
+; SKIP-IDENTITY
+
+define <vscale x 2 x i8> @src(<vscale x 2 x i8> %x) vscale_range(1, 2) {
+  %rem.i = srem <vscale x 2 x i8> %x, splat(i8 2)
+  %cmp.i = icmp slt <vscale x 2 x i8> %rem.i, zeroinitializer
+  %add.i = select <vscale x 2 x i1> %cmp.i, <vscale x 2 x i8> splat(i8 2), <vscale x 2 x i8> zeroinitializer
+  ret <vscale x 2 x i8> %add.i
+}
+
+define <vscale x 2 x i8> @tgt(<vscale x 2 x i8> %x) vscale_range(1, 2) {
+  %rem.i = srem <vscale x 2 x i8> %x, splat(i8 2)
+  %tmp1 = and <vscale x 2 x i8> %rem.i, splat(i8 2)
+  ret <vscale x 2 x i8> %tmp1
+}
+
+; ERROR: Unsupported type: <vscale x 2 x i8>

--- a/tests/alive-tv/vector/vscale/typecheck-missing-vscale-range.srctgt.ll
+++ b/tests/alive-tv/vector/vscale/typecheck-missing-vscale-range.srctgt.ll
@@ -1,0 +1,12 @@
+; SKIP-IDENTITY
+
+define <vscale x 1 x i8> @src(<vscale x 1 x i8> %a) {
+  %v = insertelement <vscale x 1 x i8> %a, i8 -2, i64 3
+  ret <vscale x 1 x i8> %v
+}
+
+define <vscale x 1 x i8> @tgt(<vscale x 1 x i8> %a) {
+  ret <vscale x 1 x i8> poison
+}
+
+; ERROR: Unsupported type: <vscale x 1 x i8>

--- a/tests/alive-tv/vector/vscale/typecheck-scalable-non-scalable.srctgt.ll
+++ b/tests/alive-tv/vector/vscale/typecheck-scalable-non-scalable.srctgt.ll
@@ -1,0 +1,12 @@
+; SKIP-IDENTITY
+
+define <vscale x 1 x i8> @src(<vscale x 1 x i8> %a) vscale_range(1, 2) {
+  %v = insertelement <vscale x 1 x i8> %a, i8 -2, i64 3
+  ret <vscale x 1 x i8> %v
+}
+
+define <1 x i8> @tgt(<1 x i8> %a) vscale_range(1, 2) {
+  ret <1 x i8> poison
+}
+
+; ERROR: Unsupported type: <vscale x 1 x i8>


### PR DESCRIPTION
Pre-commit some tests with the vscale syntax, in preparation to add support for scalable vectors.