### PR TITLE
Fix crash from optimized null pointer access

### DIFF
--- a/llvm_util/llvm2alive.cpp
+++ b/llvm_util/llvm2alive.cpp
@@ -1902,11 +1902,13 @@ public:
           attrlist.getAttributes(llvm::AttributeList::FirstArgIndex + idx);
 
       auto ty = llvm_type2alive(arg.getType());
+      if (!ty)
+        return {};
       ParamAttrs attrs;
       auto val = make_unique<Input>(*ty, value_name(arg));
       Value *newval = val.get();
 
-      if (!ty || !handleParamAttrs(argattr, attrs, &newval, false))
+      if (!handleParamAttrs(argattr, attrs, &newval, false))
         return {};
       val->setAttributes(std::move(attrs));
       add_identifier(arg, *newval);


### PR DESCRIPTION
- Resolves a null pointer dereference error observed in Clang v19.1.5 where the check is optimized away
- Add a separate null pointer check for the pointer returned by llvm_type2alive in llvm2alive_::run()