### PR TITLE
support captures(none) instead of nocapture

### DIFF
--- a/llvm_util/llvm2alive.cpp
+++ b/llvm_util/llvm2alive.cpp
@@ -1570,8 +1570,11 @@ public:
         attrs.set(ParamAttrs::NonNull);
         break;
 
-      case llvm::Attribute::NoCapture:
-        attrs.set(ParamAttrs::NoCapture);
+      case llvm::Attribute::Captures:
+        if (capturesNothing(llvmattr.getCaptureInfo().getOtherComponents()))
+          attrs.set(ParamAttrs::NoCapture);
+        else
+          errorAttr(llvmattr); // TODO: support other captures
         break;
 
       case llvm::Attribute::ReadOnly:


### PR DESCRIPTION
this gets Alive to build against current LLVM by mapping the new captures(none) to Alive's NoCapture.

this PR leaves undone two additional items
- upgrade our test cases correspondingly (right now this is taken care of by the parser, so no rush)
-  support captures() other than none -- this is more work

