### PR TITLE
replace nocapture in tests

### DIFF
--- a/scripts/perf-testing/negative/memcpy1.ll
+++ b/scripts/perf-testing/negative/memcpy1.ll
@@ -1,5 +1,5 @@
 declare void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
-declare i32 @memcmp(i8* nocapture, i8* nocapture, i64)
+declare i32 @memcmp(i8* captures(none), i8* captures(none), i64)
 
 define i32 @src(i8*) {
   %p1 = alloca [X x i8]

--- a/scripts/perf-testing/negative/memcpy2.ll
+++ b/scripts/perf-testing/negative/memcpy2.ll
@@ -1,5 +1,5 @@
 declare void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
-declare i32 @memcmp(i8* nocapture, i8* nocapture, i64)
+declare i32 @memcmp(i8* captures(none), i8* captures(none), i64)
 
 define i32 @src(i8*) {
   %p1 = alloca [X x i8]

--- a/scripts/perf-testing/negative/memcpy3.ll
+++ b/scripts/perf-testing/negative/memcpy3.ll
@@ -1,5 +1,5 @@
 declare void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
-declare i32 @memcmp(i8* nocapture, i8* nocapture, i64)
+declare i32 @memcmp(i8* captures(none), i8* captures(none), i64)
 
 define i32 @src(i8*) {
   %p2 = alloca i8, i32 X

--- a/scripts/perf-testing/negative/memcpy4.ll
+++ b/scripts/perf-testing/negative/memcpy4.ll
@@ -1,5 +1,5 @@
 declare void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
-declare i32 @memcmp(i8* nocapture, i8* nocapture, i64)
+declare i32 @memcmp(i8* captures(none), i8* captures(none), i64)
 
 define i32 @src(i8*) {
   %p1 = alloca [X x i8]

--- a/scripts/perf-testing/negative/memcpy5.ll
+++ b/scripts/perf-testing/negative/memcpy5.ll
@@ -1,5 +1,5 @@
 declare void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
-declare i32 @memcmp(i8* nocapture, i8* nocapture, i64)
+declare i32 @memcmp(i8* captures(none), i8* captures(none), i64)
 
 @a = external global [X x i8]
 @b = external global [X x i8]

--- a/scripts/perf-testing/negative/memcpy6.ll
+++ b/scripts/perf-testing/negative/memcpy6.ll
@@ -1,5 +1,5 @@
 declare void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
-declare i32 @memcmp(i8* nocapture, i8* nocapture, i64)
+declare i32 @memcmp(i8* captures(none), i8* captures(none), i64)
 
 define i32 @src(i8*, i8*) {
   %sub = sub i32 X, 2

--- a/scripts/perf-testing/positive/memcpy1.ll
+++ b/scripts/perf-testing/positive/memcpy1.ll
@@ -1,5 +1,5 @@
 declare void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
-declare i32 @memcmp(i8* nocapture, i8* nocapture, i64)
+declare i32 @memcmp(i8* captures(none), i8* captures(none), i64)
 
 define i32 @src(i8*) {
   %p1 = alloca [X x i8]

--- a/scripts/perf-testing/positive/memcpy2.ll
+++ b/scripts/perf-testing/positive/memcpy2.ll
@@ -1,5 +1,5 @@
 declare void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
-declare i32 @memcmp(i8* nocapture, i8* nocapture, i64)
+declare i32 @memcmp(i8* captures(none), i8* captures(none), i64)
 
 define i32 @src(i8*) {
   %p1 = alloca [X x i8]

--- a/scripts/perf-testing/positive/memcpy3.ll
+++ b/scripts/perf-testing/positive/memcpy3.ll
@@ -1,5 +1,5 @@
 declare void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
-declare i32 @memcmp(i8* nocapture, i8* nocapture, i64)
+declare i32 @memcmp(i8* captures(none), i8* captures(none), i64)
 
 define i32 @src(i8*) {
   %p2 = alloca i8, i32 X

--- a/scripts/perf-testing/positive/memcpy4.ll
+++ b/scripts/perf-testing/positive/memcpy4.ll
@@ -1,5 +1,5 @@
 declare void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
-declare i32 @memcmp(i8* nocapture, i8* nocapture, i64)
+declare i32 @memcmp(i8* captures(none), i8* captures(none), i64)
 
 define i32 @src(i8*) {
   %p1 = alloca [X x i8]

--- a/scripts/perf-testing/positive/memcpy5.ll
+++ b/scripts/perf-testing/positive/memcpy5.ll
@@ -1,5 +1,5 @@
 declare void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
-declare i32 @memcmp(i8* nocapture, i8* nocapture, i64)
+declare i32 @memcmp(i8* captures(none), i8* captures(none), i64)
 
 @a = external global [X x i8]
 @b = external global [X x i8]

--- a/scripts/perf-testing/positive/memcpy6.ll
+++ b/scripts/perf-testing/positive/memcpy6.ll
@@ -1,5 +1,5 @@
 declare void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
-declare i32 @memcmp(i8* nocapture, i8* nocapture, i64)
+declare i32 @memcmp(i8* captures(none), i8* captures(none), i64)
 
 define i32 @src(i8*, i8*) {
   call void @llvm.memcpy.p0i8.p0i8.i32(i8* %0, i8* %1, i32 X, i1 0)

--- a/tests/alive-tv/attrs/argmemonly-byval.srctgt.ll
+++ b/tests/alive-tv/attrs/argmemonly-byval.srctgt.ll
@@ -3,7 +3,7 @@ define void @src(ptr byval(i32) %0) {
   ret void
 }
 
-define void @tgt(ptr byval(i32) nocapture %0) memory(argmem:readwrite) {
+define void @tgt(ptr byval(i32) captures(none) %0) memory(argmem:readwrite) {
   %3 = load i32, ptr %0
   ret void
 }

--- a/tests/alive-tv/attrs/nocapture-call-fail.srctgt.ll
+++ b/tests/alive-tv/attrs/nocapture-call-fail.srctgt.ll
@@ -1,13 +1,13 @@
 ; ERROR: Source is more defined
 
-define void @src(ptr nocapture %p) {
+define void @src(ptr captures(none) %p) {
   call ptr @g(ptr %p)
   ret void
 }
 
-define void @tgt(ptr nocapture %p) {
+define void @tgt(ptr captures(none) %p) {
   call ptr @g(ptr poison)
   ret void
 }
 
-declare ptr @g(ptr nocapture)
+declare ptr @g(ptr captures(none))

--- a/tests/alive-tv/attrs/nocapture-call.srctgt.ll
+++ b/tests/alive-tv/attrs/nocapture-call.srctgt.ll
@@ -1,9 +1,9 @@
-define void @src(ptr nocapture %p) {
+define void @src(ptr captures(none) %p) {
   call ptr @g(ptr %p)
   ret void
 }
 
-define void @tgt(ptr nocapture %p) {
+define void @tgt(ptr captures(none) %p) {
   call ptr @g(ptr poison)
   ret void
 }

--- a/tests/alive-tv/attrs/nocapture-capture.srctgt.ll
+++ b/tests/alive-tv/attrs/nocapture-capture.srctgt.ll
@@ -1,8 +1,8 @@
-define i64 @src(ptr nocapture %p) {
+define i64 @src(ptr captures(none) %p) {
   %v = ptrtoint ptr %p to i64
   ret i64 %v
 }
 
-define i64 @tgt(ptr nocapture %p) {
+define i64 @tgt(ptr captures(none) %p) {
   unreachable
 }

--- a/tests/alive-tv/attrs/nocapture-fail.srctgt.ll
+++ b/tests/alive-tv/attrs/nocapture-fail.srctgt.ll
@@ -2,13 +2,13 @@
 
 @x = global ptr null
 
-define void @src(ptr nocapture %p) {
+define void @src(ptr captures(none) %p) {
   %poison = getelementptr inbounds i8, ptr null, i32 1
   store ptr %poison, ptr @x
   ret void
 }
 
-define void @tgt(ptr nocapture %p) {
+define void @tgt(ptr captures(none) %p) {
   store ptr %p, ptr @x
   ret void
 }

--- a/tests/alive-tv/attrs/nocapture-icmp.srctgt.ll
+++ b/tests/alive-tv/attrs/nocapture-icmp.srctgt.ll
@@ -1,8 +1,8 @@
-define i1 @src(ptr nocapture %p, ptr %q) {
+define i1 @src(ptr captures(none) %p, ptr %q) {
   %c = icmp eq ptr %p, %q
   ret i1 %c
 }
-define i1 @tgt(ptr nocapture %p, ptr %q) {
+define i1 @tgt(ptr captures(none) %p, ptr %q) {
   ret i1 false
 }
 ; ERROR: Value mismatch

--- a/tests/alive-tv/attrs/nocapture-noundef.srctgt.ll
+++ b/tests/alive-tv/attrs/nocapture-noundef.srctgt.ll
@@ -1,4 +1,4 @@
-define ptr @src(ptr %a, ptr nocapture %b) {
+define ptr @src(ptr %a, ptr captures(none) %b) {
   %cmp = icmp eq ptr %a, %b
   br i1 %cmp, label %t, label %f
 
@@ -10,7 +10,7 @@ f:
   ret ptr null
 }
 
-define ptr @tgt(ptr %a, ptr nocapture %b) {
+define ptr @tgt(ptr %a, ptr captures(none) %b) {
   %cmp = icmp eq ptr %a, %b
   br i1 %cmp, label %t, label %f
 
@@ -23,7 +23,7 @@ f:
 }
 
 
-declare ptr @g(ptr nocapture)
+declare ptr @g(ptr captures(none))
 
 ; If %a = %b + n, this is wrong.
 ; ERROR: Source is more defined than target

--- a/tests/alive-tv/attrs/nocapture-replace.srctgt.ll
+++ b/tests/alive-tv/attrs/nocapture-replace.srctgt.ll
@@ -1,4 +1,4 @@
-define ptr @src(ptr nocapture %p, ptr %q) {
+define ptr @src(ptr captures(none) %p, ptr %q) {
   %c = icmp eq ptr %p, %q
   br i1 %c, label %A, label %B
 A:
@@ -6,7 +6,7 @@ A:
 B:
   ret ptr null
 }
-define ptr @tgt(ptr nocapture %p, ptr %q) {
+define ptr @tgt(ptr captures(none) %p, ptr %q) {
   %c = icmp eq ptr %p, %q
   br i1 %c, label %A, label %B
 A:

--- a/tests/alive-tv/attrs/nocapture.src.ll
+++ b/tests/alive-tv/attrs/nocapture.src.ll
@@ -1,31 +1,31 @@
 @x = global ptr null
 
-define void @f1(ptr nocapture %p) {
+define void @f1(ptr captures(none) %p) {
   store ptr %p, ptr @x
   ret void
 }
 
-define void @f2(ptr nocapture %p0) {
+define void @f2(ptr captures(none) %p0) {
   %p = getelementptr i8, ptr %p0, i32 1
   store ptr %p, ptr @x
   ret void
 }
 
-define ptr @f3(ptr nocapture %p) {
+define ptr @f3(ptr captures(none) %p) {
   ret ptr %p
 }
 
-define ptr @f4(ptr nocapture %p) {
+define ptr @f4(ptr captures(none) %p) {
   %p2 = getelementptr i8, ptr %p, i32 1
   ret ptr %p2
 }
 
-define <2 x ptr> @f5(ptr nocapture %p) {
+define <2 x ptr> @f5(ptr captures(none) %p) {
   %v = insertelement <2 x ptr> undef, ptr %p, i32 1
   ret <2 x ptr> %v
 }
 
-define ptr @f6(ptr nocapture %p, ptr %q) {
+define ptr @f6(ptr captures(none) %p, ptr %q) {
   %c = icmp eq ptr %p, %q
   br i1 %c, label %A, label %B
 A:
@@ -34,7 +34,7 @@ B:
   ret ptr null
 }
 
-define ptr @f7(ptr %a, ptr nocapture %b) {
+define ptr @f7(ptr %a, ptr captures(none) %b) {
   %v = call ptr @g(ptr %a)
   ret ptr %v
 }

--- a/tests/alive-tv/attrs/nocapture.tgt.ll
+++ b/tests/alive-tv/attrs/nocapture.tgt.ll
@@ -1,34 +1,34 @@
 @x = global ptr null
 
-define void @f1(ptr nocapture %p) {
+define void @f1(ptr captures(none) %p) {
   %poison = getelementptr inbounds i8, ptr null, i64 1
   store ptr %poison, ptr @x
   ret void
 }
 
-define void @f2(ptr nocapture %p) {
+define void @f2(ptr captures(none) %p) {
   %poison = getelementptr inbounds i8, ptr null, i64 1
   store ptr %poison, ptr @x
   ret void
 }
 
-define ptr @f3(ptr nocapture %p) {
+define ptr @f3(ptr captures(none) %p) {
   %poison = getelementptr inbounds i8, ptr null, i64 1
   ret ptr %poison
 }
 
-define ptr @f4(ptr nocapture %p) {
+define ptr @f4(ptr captures(none) %p) {
   %poison = getelementptr inbounds i8, ptr null, i64 1
   ret ptr %poison
 }
 
-define <2 x ptr> @f5(ptr nocapture %p) {
+define <2 x ptr> @f5(ptr captures(none) %p) {
   %poison = getelementptr inbounds i8, ptr null, i64 1
   %v = insertelement <2 x ptr> undef, ptr %poison, i32 1
   ret <2 x ptr> %v
 }
 
-define ptr @f6(ptr nocapture %p, ptr %q) {
+define ptr @f6(ptr captures(none) %p, ptr %q) {
   %c = icmp eq ptr %p, %q
   br i1 %c, label %A, label %B
 A:
@@ -37,7 +37,7 @@ B:
   ret ptr null
 }
 
-define ptr @f7(ptr %a, ptr nocapture %b) {
+define ptr @f7(ptr %a, ptr captures(none) %b) {
   %v = call ptr @g(ptr %a)
   ret ptr %v
 }

--- a/tests/alive-tv/attrs/null_is_valid_nocapture.srctgt.ll
+++ b/tests/alive-tv/attrs/null_is_valid_nocapture.srctgt.ll
@@ -4,7 +4,7 @@ define i8 @src(i1 %C, ptr %P) null_pointer_is_valid {
   ret i8 %V
 }
 
-define i8 @tgt(i1 %C, ptr nocapture %P) null_pointer_is_valid {
+define i8 @tgt(i1 %C, ptr captures(none) %P) null_pointer_is_valid {
   %P2 = select i1 %C, ptr %P, ptr null
   %V = load i8, ptr %P2, align 1
   ret i8 %V

--- a/tests/alive-tv/bugs/D98759.srctgt.ll
+++ b/tests/alive-tv/bugs/D98759.srctgt.ll
@@ -1,6 +1,6 @@
 ; Reported by https://reviews.llvm.org/D90529#2619492
 
-define i32 @src(ptr nocapture %a) nounwind memory(read) {
+define i32 @src(ptr captures(none) %a) nounwind memory(read) {
 entry:
   call void @llvm.assume(i1 true) ["align"(ptr %a, i32 32, i32 28)]
   %arrayidx = getelementptr inbounds i32, ptr %a, i64 -1
@@ -8,7 +8,7 @@ entry:
   ret i32 %.0
 }
 
-define i32 @tgt(ptr nocapture %a) nounwind memory(read) {
+define i32 @tgt(ptr captures(none) %a) nounwind memory(read) {
 entry:
   call void @llvm.assume(i1 true) ["align"(ptr %a, i32 32, i32 28)]
   %arrayidx = getelementptr inbounds i32, ptr %a, i64 -1

--- a/tests/alive-tv/bugs/pr11390.srctgt.ll
+++ b/tests/alive-tv/bugs/pr11390.srctgt.ll
@@ -4,7 +4,7 @@
 target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f32:32:32-f64:64:64-v64:64:64-v128:128:128-a0:0:64-s0:64:64-f80:128:128-n8:16:32:64-S128"
 target triple = "x86_64-unknown-linux-gnu"
 
-define void @src(ptr nocapture %name, ptr nocapture %domain, ptr nocapture %s, i64 %call, i64 %call1) nounwind {
+define void @src(ptr captures(none) %name, ptr captures(none) %domain, ptr captures(none) %s, i64 %call, i64 %call1) nounwind {
 entry:
   %add = add i64 %call, 1
   %add2 = add i64 %add, %call1
@@ -28,7 +28,7 @@ return:                                           ; preds = %if.end, %entry
   ret void
 }
 
-define void @tgt(ptr nocapture %name, ptr nocapture %domain, ptr nocapture %s, i64 %call, i64 %call1) nounwind {
+define void @tgt(ptr captures(none) %name, ptr captures(none) %domain, ptr captures(none) %s, i64 %call, i64 %call1) nounwind {
 entry:
   %add = add i64 %call, 1
   %add2 = add i64 %add, %call1
@@ -50,9 +50,9 @@ return:                                           ; preds = %if.end, %entry
   ret void
 }
 
-declare i64 @strlen(ptr nocapture) nounwind memory(argmem: read)
-declare i64 @f(ptr nocapture)
+declare i64 @strlen(ptr captures(none)) nounwind memory(argmem: read)
+declare i64 @f(ptr captures(none))
 
 declare noalias ptr @malloc(i64) nounwind
 
-declare void @llvm.memcpy.p0i8.p0i8.i64(ptr nocapture, ptr nocapture, i64, i32, i1) nounwind
+declare void @llvm.memcpy.p0i8.p0i8.i64(ptr captures(none), ptr captures(none), i64, i32, i1) nounwind

--- a/tests/alive-tv/bugs/pr18223.srctgt.ll
+++ b/tests/alive-tv/bugs/pr18223.srctgt.ll
@@ -135,4 +135,4 @@ for.end:                                          ; preds = %for.end_us_lcssa, %
   ret i32 0
 }
 
-declare i32 @myprintf(ptr nocapture readonly, ...)
+declare i32 @myprintf(ptr captures(none) readonly, ...)

--- a/tests/alive-tv/bugs/pr23599-nolocal.srctgt.ll
+++ b/tests/alive-tv/bugs/pr23599-nolocal.srctgt.ll
@@ -5,7 +5,7 @@
 
 @glb = global %struct.ether_header zeroinitializer
 
-define void @src(ptr nocapture readonly %ether_src, ptr nocapture readonly %ether_dst) {
+define void @src(ptr captures(none) readonly %ether_src, ptr captures(none) readonly %ether_dst) {
 entry:
   %eth = alloca %struct.ether_header, align 1
   %0 = getelementptr inbounds %struct.ether_header, ptr %eth, i64 0, i32 0, i64 0
@@ -21,7 +21,7 @@ entry:
   ret void
 }
 
-define void @tgt(ptr nocapture readonly %ether_src, ptr nocapture readonly %ether_dst) {
+define void @tgt(ptr captures(none) readonly %ether_src, ptr captures(none) readonly %ether_dst) {
 entry:
   %eth = alloca %struct.ether_header, align 1
   %0 = getelementptr inbounds %struct.ether_header, ptr %eth, i64 0, i32 0, i64 0
@@ -39,10 +39,10 @@ entry:
 }
 
 
-declare void @llvm.lifetime.start(i64, ptr nocapture)
-declare void @llvm.memset.p0i8.i64(ptr nocapture, i8, i64, i32, i1)
-declare void @llvm.memcpy.p0i8.p0i8.i64(ptr nocapture, ptr nocapture readonly, i64, i32, i1)
+declare void @llvm.lifetime.start(i64, ptr captures(none))
+declare void @llvm.memset.p0i8.i64(ptr captures(none), i8, i64, i32, i1)
+declare void @llvm.memcpy.p0i8.p0i8.i64(ptr captures(none), ptr captures(none) readonly, i64, i32, i1)
 declare void @_Z5PrintRK12ether_header(ptr dereferenceable(12))
-declare void @llvm.lifetime.end(i64, ptr nocapture)
+declare void @llvm.lifetime.end(i64, ptr captures(none))
 
 ; ERROR: Mismatch in memory

--- a/tests/alive-tv/bugs/pr23599.srctgt.ll
+++ b/tests/alive-tv/bugs/pr23599.srctgt.ll
@@ -7,7 +7,7 @@ target triple = "x86_64-unknown-linux-gnu"
 %struct.ether_addr = type { [6 x i8] }
 %struct.ether_header = type { [6 x i8], [6 x i8] }
 
-define void @src(ptr nocapture readonly %ether_src, ptr nocapture readonly %ether_dst) {
+define void @src(ptr captures(none) readonly %ether_src, ptr captures(none) readonly %ether_dst) {
 entry:
   %eth = alloca %struct.ether_header, align 1
   %0 = getelementptr inbounds %struct.ether_header, ptr %eth, i64 0, i32 0, i64 0
@@ -23,7 +23,7 @@ entry:
   ret void
 }
 
-define void @tgt(ptr nocapture readonly %ether_src, ptr nocapture readonly %ether_dst) {
+define void @tgt(ptr captures(none) readonly %ether_src, ptr captures(none) readonly %ether_dst) {
 entry:
   %eth = alloca %struct.ether_header, align 1
   %0 = getelementptr inbounds %struct.ether_header, ptr %eth, i64 0, i32 0, i64 0
@@ -41,8 +41,8 @@ entry:
 }
 
 
-declare void @llvm.lifetime.start(i64, ptr nocapture)
-declare void @llvm.memset.p0i8.i64(ptr nocapture, i8, i64, i32, i1)
-declare void @llvm.memcpy.p0i8.p0i8.i64(ptr nocapture, ptr nocapture readonly, i64, i32, i1)
+declare void @llvm.lifetime.start(i64, ptr captures(none))
+declare void @llvm.memset.p0i8.i64(ptr captures(none), i8, i64, i32, i1)
+declare void @llvm.memcpy.p0i8.p0i8.i64(ptr captures(none), ptr captures(none) readonly, i64, i32, i1)
 declare void @_Z5PrintRK12ether_header(ptr dereferenceable(12))
-declare void @llvm.lifetime.end(i64, ptr nocapture)
+declare void @llvm.lifetime.end(i64, ptr captures(none))

--- a/tests/alive-tv/bugs/pr29034-unroll.src.ll
+++ b/tests/alive-tv/bugs/pr29034-unroll.src.ll
@@ -7,7 +7,7 @@
 
 @.str = external hidden unnamed_addr constant [10 x i8], align 1
 
-define void @music_task(ptr nocapture readnone %p, ptr %mapi_init) {
+define void @music_task(ptr captures(none) readnone %p, ptr %mapi_init) {
 entry:
   %mapi = alloca ptr, align 8
   %0 = bitcast ptr %mapi to ptr
@@ -79,9 +79,9 @@ return:
   ret void
 }
 
-declare void @llvm.lifetime.start(i64, ptr nocapture)
+declare void @llvm.lifetime.start(i64, ptr captures(none))
 declare i32 @music_decoder_init(ptr)
 declare i32 @music_play_api(ptr, i32, i32, i32, ptr)
-declare i32 @myprintf(ptr nocapture readonly, ...)
+declare i32 @myprintf(ptr captures(none) readonly, ...)
 
 ; ERROR: Source is more defined than target

--- a/tests/alive-tv/bugs/pr29034-unroll.tgt.ll
+++ b/tests/alive-tv/bugs/pr29034-unroll.tgt.ll
@@ -5,7 +5,7 @@
 
 @.str = external hidden unnamed_addr constant [10 x i8], align 1
 
-define void @music_task(ptr nocapture readnone %p, ptr %mapi_init) {
+define void @music_task(ptr captures(none) readnone %p, ptr %mapi_init) {
 entry:
   %mapi = alloca ptr, align 8
   %0 = bitcast ptr %mapi to ptr
@@ -67,7 +67,7 @@ return:
   ret void
 }
 
-declare void @llvm.lifetime.start(i64, ptr nocapture)
+declare void @llvm.lifetime.start(i64, ptr captures(none))
 declare i32 @music_decoder_init(ptr)
 declare i32 @music_play_api(ptr, i32, i32, i32, ptr)
-declare i32 @myprintf(ptr nocapture readonly, ...)
+declare i32 @myprintf(ptr captures(none) readonly, ...)

--- a/tests/alive-tv/bugs/pr29034.src.ll
+++ b/tests/alive-tv/bugs/pr29034.src.ll
@@ -13,7 +13,7 @@ target triple = "aarch64"
 
 @.str = external hidden unnamed_addr constant [10 x i8], align 1
 
-define void @music_task(ptr nocapture readnone %p) #0 {
+define void @music_task(ptr captures(none) readnone %p) #0 {
 entry:
   %mapi = alloca ptr, align 8
   %0 = bitcast ptr %mapi to ptr
@@ -82,10 +82,10 @@ while.cond2.backedge:                             ; preds = %sw.default, %sw.bb1
   br label %while.cond2
 }
 
-declare void @llvm.lifetime.start(i64, ptr nocapture) #1
+declare void @llvm.lifetime.start(i64, ptr captures(none)) #1
 declare i32 @music_decoder_init(ptr)
 declare i32 @music_play_api(ptr, i32, i32, i32, ptr)
-declare i32 @printf(ptr nocapture readonly, ...) #3
+declare i32 @printf(ptr captures(none) readonly, ...) #3
 
 attributes #0 = { noreturn nounwind }
 attributes #1 = { memory(argmem: readwrite) nounwind }

--- a/tests/alive-tv/bugs/pr29034.tgt.ll
+++ b/tests/alive-tv/bugs/pr29034.tgt.ll
@@ -8,7 +8,7 @@ target triple = "aarch64"
 
 @.str = external hidden unnamed_addr constant [10 x i8], align 1
 
-define void @music_task(ptr nocapture readnone %p) #0 {
+define void @music_task(ptr captures(none) readnone %p) #0 {
 entry:
   %mapi = alloca ptr, align 8
   %0 = bitcast ptr %mapi to ptr
@@ -66,10 +66,10 @@ while.cond2.backedge:                             ; preds = %sw.default, %sw.bb1
   br label %while.cond2
 }
 
-declare void @llvm.lifetime.start(i64, ptr nocapture) #1
+declare void @llvm.lifetime.start(i64, ptr captures(none)) #1
 declare i32 @music_decoder_init(ptr)
 declare i32 @music_play_api(ptr, i32, i32, i32, ptr)
-declare i32 @printf(ptr nocapture readonly, ...) #3
+declare i32 @printf(ptr captures(none) readonly, ...) #3
 
 attributes #0 = { noreturn nounwind }
 attributes #1 = { memory(argmem: readwrite) nounwind }

--- a/tests/alive-tv/bugs/pr31808.srctgt.ll
+++ b/tests/alive-tv/bugs/pr31808.srctgt.ll
@@ -42,6 +42,6 @@ define void @tgt(ptr) {
   ret void
 }
 
-declare i32 @f(ptr nocapture readonly, ...) local_unnamed_addr
+declare i32 @f(ptr captures(none) readonly, ...) local_unnamed_addr
 
 ; ERROR: Source is more defined than target

--- a/tests/alive-tv/bugs/pr3720.srctgt.ll
+++ b/tests/alive-tv/bugs/pr3720.srctgt.ll
@@ -5,7 +5,7 @@ define void @src(ptr %p) {
         ret void
 }
 
-declare void @llvm.memcpy.i32(ptr nocapture, ptr nocapture, i32, i1)
+declare void @llvm.memcpy.i32(ptr captures(none), ptr captures(none), i32, i1)
 
 define void @tgt(ptr %p) {
         store i16 1, ptr %p

--- a/tests/alive-tv/bugs/pr43616.src.ll
+++ b/tests/alive-tv/bugs/pr43616.src.ll
@@ -1,7 +1,7 @@
 ; https://bugs.llvm.org/show_bug.cgi?id=43616
 ; This miscompilation is detected by Alive2 in the past, but not now because
 ; changing a global variable into constant is not supported anymore.
-declare ptr @llvm.invariant.start.p0i8(i64 %size, ptr nocapture %ptr)
+declare ptr @llvm.invariant.start.p0i8(i64 %size, ptr captures(none) %ptr)
 
 declare void @test1(ptr)
 

--- a/tests/alive-tv/bugs/pr43616.tgt.ll
+++ b/tests/alive-tv/bugs/pr43616.tgt.ll
@@ -1,6 +1,6 @@
 @object1 = constant i32 -1
 
-declare ptr @llvm.invariant.start.p0i8(i64 immarg, ptr nocapture) memory(argmem: readwrite) nounwind willreturn
+declare ptr @llvm.invariant.start.p0i8(i64 immarg, ptr captures(none)) memory(argmem: readwrite) nounwind willreturn
 declare void @test1(ptr)
 
 define void @ctor1() {

--- a/tests/alive-tv/bugs/pr43880.srctgt.ll
+++ b/tests/alive-tv/bugs/pr43880.srctgt.ll
@@ -2,14 +2,14 @@
 
 target datalayout = "e-i8:8:8-i16:16:16"
 target triple = "x86_64-unknown-unknown"
-declare i32 @memcmp(ptr nocapture, ptr nocapture, i64)
+declare i32 @memcmp(ptr captures(none), ptr captures(none), i64)
 
-define i32 @src(ptr nocapture readonly %x, ptr nocapture readonly %y)  {
+define i32 @src(ptr captures(none) readonly %x, ptr captures(none) readonly %y)  {
   %call = tail call i32 @memcmp(ptr %x, ptr %y, i64 2)
   ret i32 %call
 }
 
-define i32 @tgt(ptr nocapture readonly %x, ptr nocapture readonly %y) {
+define i32 @tgt(ptr captures(none) readonly %x, ptr captures(none) readonly %y) {
   %1 = bitcast ptr %x to ptr
   %2 = bitcast ptr %y to ptr
   %3 = load i16, ptr %1

--- a/tests/alive-tv/bugs/pr44388.srctgt.ll
+++ b/tests/alive-tv/bugs/pr44388.srctgt.ll
@@ -1,6 +1,6 @@
 ; Found by Alive2
 
-define void @src(ptr nocapture %P) nounwind {
+define void @src(ptr captures(none) %P) nounwind {
 entry:
   %0 = bitcast ptr %P to ptr
   call void @llvm.memset.p0i8.i64(ptr %0, i8 0, i64 12, i1 false)
@@ -10,7 +10,7 @@ entry:
   ret void
 }
 
-define void @tgt(ptr nocapture %P) #0 {
+define void @tgt(ptr captures(none) %P) #0 {
 entry:
   %0 = bitcast ptr %P to ptr
   %add.ptr = getelementptr inbounds i32, ptr %P, i64 3
@@ -19,7 +19,7 @@ entry:
   call void @llvm.memset.p0i8.i64(ptr align 4 %2, i8 0, i64 24, i1 false)
   ret void
 }
-declare void @llvm.memset.p0i8.i64(ptr nocapture, i8, i64, i1 immarg) memory(argmem: write) nounwind willreturn
+declare void @llvm.memset.p0i8.i64(ptr captures(none), i8, i64, i1 immarg) memory(argmem: write) nounwind willreturn
 
 attributes #0 = { nounwind ssp }
 

--- a/tests/alive-tv/calls/indirect-call-nocapture.srctgt.ll
+++ b/tests/alive-tv/calls/indirect-call-nocapture.srctgt.ll
@@ -1,4 +1,4 @@
-define void @src(ptr nocapture %0, ptr %1) {
+define void @src(ptr captures(none) %0, ptr %1) {
   call void %1(ptr %0)
   ret void
 }

--- a/tests/alive-tv/calls/indirect-call-ptr-attributes.srctgt.ll
+++ b/tests/alive-tv/calls/indirect-call-ptr-attributes.srctgt.ll
@@ -1,9 +1,9 @@
-define i8 @src(ptr nocapture %0) {
+define i8 @src(ptr captures(none) %0) {
   %2 = call i8 %0(ptr null)
   ret i8 %2
 }
 
-define i8 @tgt(ptr nocapture %0) {
+define i8 @tgt(ptr captures(none) %0) {
   %2 = icmp eq ptr %0, @_Z3fooPi
   br i1 %2, label %then, label %else
 

--- a/tests/alive-tv/calls/indirect-specialize2.srctgt.ll
+++ b/tests/alive-tv/calls/indirect-specialize2.srctgt.ll
@@ -16,4 +16,4 @@ else:
   ret i8 %v2
 }
 
-declare i8 @fn(ptr nocapture)
+declare i8 @fn(ptr captures(none))

--- a/tests/alive-tv/calls/nocapture.srctgt.ll
+++ b/tests/alive-tv/calls/nocapture.srctgt.ll
@@ -1,4 +1,4 @@
-declare void @f_nocapture(ptr nocapture %p)
+declare void @f_nocapture(ptr captures(none) %p)
 declare ptr @g()
 
 define i8 @src() {

--- a/tests/alive-tv/memory/bcmp-identity.srctgt.ll
+++ b/tests/alive-tv/memory/bcmp-identity.srctgt.ll
@@ -10,4 +10,4 @@ define i32 @tgt(ptr %p, i64 %n) {
   ret i32 0
 }
 
-declare i32 @bcmp(ptr nocapture, ptr nocapture, i64)
+declare i32 @bcmp(ptr captures(none), ptr captures(none), i64)

--- a/tests/alive-tv/memory/memcmp-basic-fail-2.srctgt.ll
+++ b/tests/alive-tv/memory/memcmp-basic-fail-2.srctgt.ll
@@ -15,4 +15,4 @@ define i32 @tgt() {
 
 ; ERROR: Value mismatch
 
-declare i32 @memcmp(ptr nocapture, ptr nocapture, i64)
+declare i32 @memcmp(ptr captures(none), ptr captures(none), i64)

--- a/tests/alive-tv/memory/memcmp-basic-fail-3.srctgt.ll
+++ b/tests/alive-tv/memory/memcmp-basic-fail-3.srctgt.ll
@@ -15,4 +15,4 @@ define i32 @tgt() {
 
 ; ERROR: Value mismatch
 
-declare i32 @memcmp(ptr nocapture, ptr nocapture, i64)
+declare i32 @memcmp(ptr captures(none), ptr captures(none), i64)

--- a/tests/alive-tv/memory/memcmp-basic-fail.srctgt.ll
+++ b/tests/alive-tv/memory/memcmp-basic-fail.srctgt.ll
@@ -15,5 +15,5 @@ define i32 @tgt() {
 
 ; ERROR: Value mismatch
 
-declare i32 @memcmp(ptr nocapture, ptr nocapture, i64)
+declare i32 @memcmp(ptr captures(none), ptr captures(none), i64)
 

--- a/tests/alive-tv/memory/memcmp-basic.src.ll
+++ b/tests/alive-tv/memory/memcmp-basic.src.ll
@@ -63,4 +63,4 @@ define i32 @gt2() {
   ret i32 %res
 }
 
-declare i32 @memcmp(ptr nocapture, ptr nocapture, i64)
+declare i32 @memcmp(ptr captures(none), ptr captures(none), i64)

--- a/tests/alive-tv/memory/memcmp-bcmp.srctgt.ll
+++ b/tests/alive-tv/memory/memcmp-bcmp.srctgt.ll
@@ -21,5 +21,5 @@ define i1 @tgt(i64 %x, i64 %y, i64 %n) {
   ret i1 %c
 }
 
-declare i32 @bcmp(ptr nocapture, ptr nocapture, i64)
-declare i32 @memcmp(ptr nocapture, ptr nocapture, i64)
+declare i32 @bcmp(ptr captures(none), ptr captures(none), i64)
+declare i32 @memcmp(ptr captures(none), ptr captures(none), i64)

--- a/tests/alive-tv/memory/memcmp-identity.srctgt.ll
+++ b/tests/alive-tv/memory/memcmp-identity.srctgt.ll
@@ -10,4 +10,4 @@ define i32 @tgt(ptr %p, i64 %n) {
   ret i32 0
 }
 
-declare i32 @memcmp(ptr nocapture, ptr nocapture, i64)
+declare i32 @memcmp(ptr captures(none), ptr captures(none), i64)

--- a/tests/alive-tv/memory/memcmp-noub.srctgt.ll
+++ b/tests/alive-tv/memory/memcmp-noub.srctgt.ll
@@ -16,4 +16,4 @@ define i32 @tgt() {
 
 ; ERROR: Source is more defined than target
 
-declare i32 @memcmp(ptr nocapture, ptr nocapture, i64)
+declare i32 @memcmp(ptr captures(none), ptr captures(none), i64)

--- a/tests/alive-tv/memory/memcmp-noub2.srctgt.ll
+++ b/tests/alive-tv/memory/memcmp-noub2.srctgt.ll
@@ -16,4 +16,4 @@ define i32 @tgt() {
 
 ; ERROR: Source is more defined than target
 
-declare i32 @memcmp(ptr nocapture, ptr nocapture, i64)
+declare i32 @memcmp(ptr captures(none), ptr captures(none), i64)

--- a/tests/alive-tv/memory/memcmp-noub3.srctgt.ll
+++ b/tests/alive-tv/memory/memcmp-noub3.srctgt.ll
@@ -13,4 +13,4 @@ define i32 @tgt() {
 
 ; ERROR: Source is more defined than target
 
-declare i32 @memcmp(ptr nocapture, ptr nocapture, i64)
+declare i32 @memcmp(ptr captures(none), ptr captures(none), i64)

--- a/tests/alive-tv/memory/memcmp-noub4.srctgt.ll
+++ b/tests/alive-tv/memory/memcmp-noub4.srctgt.ll
@@ -12,4 +12,4 @@ define i32 @tgt() {
 
 ; ERROR: Source is more defined than target
 
-declare i32 @memcmp(ptr nocapture, ptr nocapture, i64)
+declare i32 @memcmp(ptr captures(none), ptr captures(none), i64)

--- a/tests/alive-tv/memory/memcmp-opt-bigendian.srctgt.ll
+++ b/tests/alive-tv/memory/memcmp-opt-bigendian.srctgt.ll
@@ -20,4 +20,4 @@ define i32 @tgt(i16 noundef %x, i16 noundef %y) {
   ret i32 %res
 }
 
-declare i32 @memcmp(ptr nocapture, ptr nocapture, i64)
+declare i32 @memcmp(ptr captures(none), ptr captures(none), i64)

--- a/tests/alive-tv/memory/memcmp-opt-littleendian-fail.srctgt.ll
+++ b/tests/alive-tv/memory/memcmp-opt-littleendian-fail.srctgt.ll
@@ -21,4 +21,4 @@ define i32 @tgt(i64 %x, i64 %y) {
 
 ; ERROR: Value mismatch
 
-declare i32 @memcmp(ptr nocapture, ptr nocapture, i64)
+declare i32 @memcmp(ptr captures(none), ptr captures(none), i64)

--- a/tests/alive-tv/memory/memcmp-ub.src.ll
+++ b/tests/alive-tv/memory/memcmp-ub.src.ll
@@ -23,4 +23,4 @@ define i32 @ub_oob2() {
   ret i32 %res
 }
 
-declare i32 @memcmp(ptr nocapture, ptr nocapture, i64)
+declare i32 @memcmp(ptr captures(none), ptr captures(none), i64)

--- a/tests/alive-tv/memory/memcmp-zero.srctgt.ll
+++ b/tests/alive-tv/memory/memcmp-zero.srctgt.ll
@@ -9,4 +9,4 @@ define i32 @tgt(ptr %p, ptr %q) {
   ret i32 %res
 }
 
-declare i32 @memcmp(ptr nocapture, ptr nocapture, i64)
+declare i32 @memcmp(ptr captures(none), ptr captures(none), i64)

--- a/tests/alive-tv/memory/memset-align.ident.ll
+++ b/tests/alive-tv/memory/memset-align.ident.ll
@@ -1,6 +1,6 @@
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
 
-declare void @llvm.memset.p0i8.i64(ptr nocapture writeonly, i8, i64, i1 immarg)
+declare void @llvm.memset.p0i8.i64(ptr captures(none) writeonly, i8, i64, i1 immarg)
 
 define void @f(ptr %out) {
   call void @llvm.memset.p0i8.i64(ptr align 4 %out, i8 0, i64 0, i1 false)


### PR DESCRIPTION
replace nocapture in tests

not sure if you want to do this this way, or if you rather want to use LLVM autoupgrade? anyway, just close this if you don't want it