### PR TITLE
docs: clarify LLVM_ENABLE_EH requirement in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ actual location to that in the resultant error message may help.
 cd $LLVM2_HOME
 mkdir build
 cd build
-cmake -GNinja -DLLVM_ENABLE_RTTI=ON -DBUILD_SHARED_LIBS=ON -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_ASSERTIONS=ON -DLLVM_ENABLE_PROJECTS="llvm;clang" ../llvm
+cmake -GNinja -DLLVM_ENABLE_RTTI=ON -DLLVM_ENABLE_EH=ON -DBUILD_SHARED_LIBS=ON -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_ASSERTIONS=ON -DLLVM_ENABLE_PROJECTS="llvm;clang" ../llvm
 ninja
 ```
 


### PR DESCRIPTION
Error message : 
```
CMake Error at CMakeLists.txt:183 (message):
LLVM must be built with '-DLLVM_ENABLE_EH=ON'
```