### PR TITLE
Remove frem approximation

### DIFF
--- a/ir/instr.cpp
+++ b/ir/instr.cpp
@@ -881,7 +881,7 @@ StateValue FpBinOp::toSMT(State &s) const {
                      .float2BV()
                      .copysign(a.float2BV())
                      .BV2float(a);
-      auto invalid = a.isInf() || b.isZero();
+      auto invalid = a.isInf() || b == 0;
       return expr::mkIf(invalid, expr::mkNaN(a), expr::mkIf(b.isInf(), a, res));
     };
     break;

--- a/ir/instr.cpp
+++ b/ir/instr.cpp
@@ -874,10 +874,15 @@ StateValue FpBinOp::toSMT(State &s) const {
 
   case FRem:
     fn = [&](const expr &a, const expr &b, const expr &rm) {
-      // TODO; Z3 has no support for LLVM's frem which is actually an fmod
-      auto val = a.frem(b);
-      s.doesApproximation("frem", val);
-      return val;
+      auto rhs = b.fabs();
+      auto rem = a.fabs().frem(rhs);
+      auto signbit = rem.float2BV().sign() == 1;
+      auto res = expr::mkIf(signbit, rem.fadd(rhs, rm), rem)
+                     .float2BV()
+                     .copysign(a.float2BV())
+                     .BV2float(a);
+      auto invalid = a.isInf() || b.isZero();
+      return expr::mkIf(invalid, expr::mkNaN(a), expr::mkIf(b.isInf(), a, res));
     };
     break;
 

--- a/tests/unit/fp/frem.opt
+++ b/tests/unit/fp/frem.opt
@@ -1,0 +1,92 @@
+Name: frem, constant prop.
+%t = frem double 1.5, 1.0
+  =>
+%t = double 0.5
+
+Name: frem, constant prop.
+%t = frem double 0.5, 1.0
+  =>
+%t = double 0.5
+
+Name: frem, constant prop.
+%t = frem double 0.3, 0.01
+  =>
+%t = double 0.009999999999999983
+
+Name: frem, constant prop.
+%t = frem double -4.0, -2.0
+  =>
+%t = double -0.0
+
+Name: frem, constant prop.
+%t = frem double -4.0, 2.0
+  =>
+%t = double -0.0
+
+Name: frem, constant prop.
+%t = frem double 3.0, 2.0
+  =>
+%t = double 1.0
+
+Name: frem, constant prop.
+%t = frem double 5.0, 3.0
+  =>
+%t = double 2.0
+
+Name: frem, constant prop.
+%t = frem double -5.0, 3.0
+  =>
+%t = double -2.0
+
+Name: frem, constant prop.
+%t = frem double 5.0, -3.0
+  =>
+%t = double 2.0
+
+Name: frem, constant prop.
+%t = frem double -5.0, -3.0
+  =>
+%t = double -2.0
+
+Name: frem, rhs zero
+%t = frem double 1.0, 0.0
+  =>
+%v = fdiv double 0.0, 0.0
+%t = double %v
+
+Name: frem, lhs inf, rhs normal
+%v = fdiv double 1.0, 0.0
+%t = frem double %v, 1.0
+  =>
+%s = fdiv double 0.0, 0.0
+%t = double %s
+
+Name: frem, lhs pzero, rhs normal
+%t = frem double 0.0, 1.0
+  =>
+%t = double 0.0
+
+Name: frem, lhs nzero, rhs normal
+%t = frem double -0.0, 1.0
+  =>
+%t = double -0.0
+
+Name: frem, lhs finite, rhs inf
+%v = fdiv double 1.0, 0.0
+%t = frem double 5.0, %v
+  =>
+%t = double 5.0
+
+Name: frem, lhs nan
+%v = fdiv double 0.0, 0.0
+%t = frem double %v, %a
+  =>
+%v = fdiv double 0.0, 0.0
+%t = double %v
+
+Name: frem, rhs nan
+%v = fdiv double 0.0, 0.0
+%t = frem double %a, %v
+  =>
+%v = fdiv double 0.0, 0.0
+%t = double %v


### PR DESCRIPTION
This patch implements `fmod` by using `remainder` as suggested by https://en.cppreference.com/w/c/numeric/math/fmod:
```
double fmod(double x, double y)
{
#pragma STDC FENV_ACCESS ON
    double result = remainder(x), (y = fabs(y)));
    if (signbit(result))
        result += y;
    return copysign(result, x);
}
```

Test cases are derived from https://en.cppreference.com/w/c/numeric/math/fmod and https://github.com/llvm/llvm-project/blob/0252d338fa9f4f2f1262b5f7d8158e3f5857fcaf/llvm/unittests/ADT/APFloatTest.cpp#L4377.

Closes https://github.com/AliveToolkit/alive2/issues/1175.
