### PR TITLE
keep up with LLVM API change

### DIFF
--- a/llvm_util/llvm2alive.cpp
+++ b/llvm_util/llvm2alive.cpp
@@ -412,8 +412,9 @@ public:
       assert(!approx);
       if (!iasm->canThrow())
         attrs.set(FnAttrs::NoThrow);
-      call = make_unique<InlineAsm>(*ty, value_name(i), iasm->getAsmString(),
-                                    iasm->getConstraintString(),
+      call = make_unique<InlineAsm>(*ty, value_name(i),
+                                    (std::string)iasm->getAsmString(),
+                                    (std::string)iasm->getConstraintString(),
                                     std::move(attrs));
     } else {
       if (!fn) {


### PR DESCRIPTION
explicit cast needed because LLVM changed the InlineAsm API to return StringRefs instead of std::strings