### PR TITLE
Fix benchmark script to support macOS (fallback for nproc)

### DIFF
--- a/scripts/benchmark-clang-tv.in
+++ b/scripts/benchmark-clang-tv.in
@@ -14,13 +14,21 @@ EOM
     exit -1
 fi
 
+OS="$(uname -s)"
+
 WORK=$1
 REPORTS=$WORK/reports
 
 # TODO give alivecc a mode where it doesn't invoke alive at all, so we
 # can test scripts like this more quickly and easily
 
-CORES=`nproc`
+if [[ "$OS" == "Linux" ]]; then
+    CORES="$(nproc)"
+elif [[ "$OS" == "Darwin" ]]; then
+    CORES="$(sysctl -n hw.logicalcpu)"
+else # default
+    CORES=1
+fi
 
 ALIVECC=@PROJECT_BINARY_DIR@/alivecc
 

--- a/scripts/benchmark-llvm-test-suite.in
+++ b/scripts/benchmark-llvm-test-suite.in
@@ -12,9 +12,17 @@ EOM
     exit -1
 fi
 
+OS="$(uname -s)"
+
 WORK=$1
 
-CORES=`nproc`
+if [[ "$OS" == "Linux" ]]; then
+    CORES="$(nproc)"
+elif [[ "$OS" == "Darwin" ]]; then
+    CORES="$(sysctl -n hw.logicalcpu)"
+else # default
+    CORES=1
+fi
 
 ALIVECC=@PROJECT_BINARY_DIR@/alivecc
 JOBSERVER=@PROJECT_BINARY_DIR@/alive-jobserver


### PR DESCRIPTION
## Summary

macOS does not include the `nproc` command by default.  
This patch updates the benchmark shell script to detect the OS and use `sysctl -n hw.logicalcpu` on macOS as a fallback.

![스크린샷 2025-06-23 오전 9 59 17](https://github.com/user-attachments/assets/c470be0d-6ac5-4f6e-96d6-acaef2b4d2db)


## Changes

- Added `uname`-based OS check.
- On `Darwin`, use `sysctl` to determine logical CPU count.
- Retain `nproc` for Linux-based environments.