### PR TITLE
Fix build error on AppleClang due to lambda capture of structured bin…

### DIFF
--- a/ir/state.cpp
+++ b/ir/state.cpp
@@ -753,9 +753,10 @@ void State::copyUBFromBB(
 
   for (auto *src_bb : I->second) {
     bool all_paths_ok = true;
-    for (auto &[_, src_data] : src_state->predecessor_data.at(src_bb)) {
+    for (const auto &entry : src_state->predecessor_data.at(src_bb)) {
+      const auto &src_data = entry.second;
       auto I = ranges::find_if(tgt_data, [&](const auto &p) {
-        return is_eq(p.second.path <=> src_data.path);
+      return is_eq(p.second.path <=> src_data.path);
       });
       if (I == tgt_data.end() ||
           !I->second.analysis.ranges_fn_calls.isLargerThanInclReads(


### PR DESCRIPTION
OS AppleClang does not support capturing structured bindings (e.g., `src_data`) by reference in lambdas, which leads to compilation errors.

This ``patch refactors`` the ``affected loop`` by introducing a named reference variable outside the lambda, and ``capturing that reference`` instead. This improves compatibility across multiple compilers,`` including AppleClang``, `GCC`, `Clang`, and `MSVC`, while preserving the original behaviour.

No functional change is intended his is a portability fix.
