### PR TITLE
[test-suite] Add XFAIL test case for issue #1222 (-tgt-is-asm alignme…

### DIFF
--- a/tests/alive-tv/asm/infer-alignment.srctgt.ll
+++ b/tests/alive-tv/asm/infer-alignment.srctgt.ll
@@ -1,0 +1,16 @@
+; TEST-ARGS: -tgt-is-asm
+; XFAIL: ERROR: Source is more defined than target
+; https://github.com/AliveToolkit/alive2/issues/1222
+
+define void @src(ptr %0, ptr %1) {
+  store i16 0, ptr %0, align 4
+  store i16 0, ptr %1, align 8
+  ret void
+}
+
+define void @tgt(ptr %0, ptr %1) {
+arm_tv_entry:
+  store i16 0, ptr %1, align 8  
+  store i16 0, ptr %0, align 4
+  ret void
+}


### PR DESCRIPTION
…nt inference)

This patch adds a regression test to reproduce the issue described in issue #1222. The test is currently marked as XFAIL since the failure is expected due to the known bug. Once the underlying problem is fixed, the XFAIL directive should be removed.