### PR TITLE
[freeze/state] Restrict freeze nondet pointers to source-visible range (#1232)

### DIFF
--- a/ir/memory.h
+++ b/ir/memory.h
@@ -321,6 +321,9 @@ public:
   // Start lifetime of a local block.
   void startLifetime(const StateValue &ptr);
 
+  // Constrain freeze pointer to currently used blocks for POR optimization
+  void constrainFreezePointer(const Pointer &ptr);
+
   // If unconstrained is true, the pointer offset, liveness, and block kind
   // are not checked.
   void free(const StateValue &ptr, bool unconstrained);

--- a/ir/state.cpp
+++ b/ir/state.cpp
@@ -671,14 +671,11 @@ StateValue State::freeze(const Type &ty, const StateValue &v) {
   expr nondet = expr::mkFreshVar("nondet", v.value);
   addQuantVar(nondet);
 
-  // limit the output of freeze when the input is undef/poison
-  if (ty.isPtrType() && !isSource()) {
+  if (ty.isPtrType()) {
     Pointer p(memory, nondet);
-    auto bid = p.getShortBid();
-    expr limit = expr::mkUInt(num_nonlocals_src, bid);
-    // Constrain non-local pointers to source-visible range
-    addAxiom((!p.isLocal()).implies(bid.ult(limit)));
+    memory.constrainFreezePointer(p);
   }
+
   return { expr::mkIf(v.non_poison, v.value, nondet), true };
 }
 

--- a/ir/state.cpp
+++ b/ir/state.cpp
@@ -670,6 +670,15 @@ StateValue State::freeze(const Type &ty, const StateValue &v) {
 
   expr nondet = expr::mkFreshVar("nondet", v.value);
   addQuantVar(nondet);
+
+  // limit the output of freeze when the input is undef/poison
+  if (ty.isPtrType() && !isSource()) {
+    Pointer p(memory, nondet);
+    auto bid = p.getShortBid();
+    expr limit = expr::mkUInt(num_nonlocals_src, bid);
+    // Constrain non-local pointers to source-visible range
+    addAxiom((!p.isLocal()).implies(bid.ult(limit)));
+  }
   return { expr::mkIf(v.non_poison, v.value, nondet), true };
 }
 


### PR DESCRIPTION
## Description
This patch bounds nondet pointer block IDs by `num_nonlocals_src`.
It ensures that freeze only selects pointers within the source-visible range, preventing the selection of target-only globals.

Related to #1232