### PR TITLE
[objectsize] Without allocsize, use leftoverSize if valid, else unknown. (#1238)

### DIFF
--- a/ir/instr.cpp
+++ b/ir/instr.cpp
@@ -1461,9 +1461,14 @@ StateValue TernaryOp::toSMT(State &s) const {
       expr ty = getType().getDummyValue(false).value;
       expr unknown = expr::mkIf(b.value == 1, expr::mkUInt(0, ty),
                                 expr::mkInt(-1, ty));
-      v.value = expr::mkIf(is_unknown || (ptr.isNull() && c.value == 1),
+      if(ptr.leftoverSize().isValid()) {
+        v.value = expr::mkIf(is_unknown || (ptr.isNull() && c.value == 1),
                            unknown,
                            ptr.leftoverSize().zextOrTrunc(ty.bits()));
+      } else {
+        v.value = unknown;
+      }     
+      
       break;
     }
     }

--- a/tests/alive-tv/allockind_without_allocsize.srctgt.ll
+++ b/tests/alive-tv/allockind_without_allocsize.srctgt.ll
@@ -1,0 +1,13 @@
+define i64 @src() {
+  %stack = call ptr @myalloc()
+  %sz = call i64 @llvm.objectsize.i64.p0(ptr %stack, i1 false, i1 false, i1 false)
+  ret i64 %sz
+}
+
+define i64 @tgt() {
+  ret i64 -1
+}
+
+declare ptr @myalloc() allockind("alloc")
+declare i64 @llvm.objectsize.i64.p0(ptr, i1, i1, i1)
+


### PR DESCRIPTION
This change updates `objectsize` to handle cases without `allocsize`.  
When `allocsize` is not provided, the function uses `leftoverSize` if it is valid; otherwise, it returns `unknown`.  

Fixes #1238