### PR TITLE
Memset to poison `dead_on_return` ptr arguments

### DIFF
--- a/ir/attrs.cpp
+++ b/ir/attrs.cpp
@@ -55,6 +55,8 @@ ostream& operator<<(ostream &os, const ParamAttrs &attr) {
     os << "allocalign ";
   if (attr.has(ParamAttrs::DeadOnUnwind))
     os << "dead_on_unwind ";
+  if (attr.has(ParamAttrs::DeadOnReturn))
+    os << "dead_on_return ";
   if (attr.has(ParamAttrs::Writable))
     os << "writable ";
   if (!attr.initializes.empty()) {

--- a/ir/attrs.h
+++ b/ir/attrs.h
@@ -70,7 +70,7 @@ public:
                    AllocPtr = 1<<11, AllocAlign = 1<<12,
                    ZeroExt = 1<<13, SignExt = 1<<14, InReg = 1<<15,
                    NoFPClass = 1<<16, DeadOnUnwind = 1<<17,
-                   Writable = 1<<18,
+                   Writable = 1<<18, DeadOnReturn = 1<<19,
                    IsArg = 1<<31 // used internally to make values as arguments
                   };
 

--- a/ir/memory.cpp
+++ b/ir/memory.cpp
@@ -2445,8 +2445,7 @@ void Memory::memset(const expr &p, const StateValue &val, const expr &bytesize,
     store(ptr, to_store, undef_vars, align);
   } else {
     expr offset = expr::mkQVar(0, Pointer::bitsShortOffset());
-    expr sz = full_write ? ptr.blockSizeAligned() : bytesize;
-    storeLambda(ptr, offset, std::move(sz), {{0, raw_byte}}, undef_vars, align,
+    storeLambda(ptr, offset, bytesize, {{0, raw_byte}}, undef_vars, align,
                 full_write);
   }
 }

--- a/ir/memory.h
+++ b/ir/memory.h
@@ -231,7 +231,8 @@ class Memory {
   void storeLambda(const Pointer &ptr, const smt::expr &offset,
                    const smt::expr &bytes,
                    const std::vector<std::pair<unsigned, smt::expr>> &data,
-                   const std::set<smt::expr> &undef, uint64_t align);
+                   const std::set<smt::expr> &undef, uint64_t align,
+                   bool full_write = false);
 
   // to implement the 'initializes' parameter attribute
   smt::expr hasStored(const Pointer &p, const smt::expr &bytes) const;
@@ -341,7 +342,8 @@ public:
 
   void memset(const smt::expr &ptr, const StateValue &val,
               const smt::expr &bytesize, uint64_t align,
-              const std::set<smt::expr> &undef_vars, bool deref_check = true);
+              const std::set<smt::expr> &undef_vars, bool deref_check = true,
+              bool full_write = false);
 
   void memset_pattern(const smt::expr &ptr, const smt::expr &pattern,
                       const smt::expr &bytesize, unsigned pattern_length);

--- a/llvm_util/llvm2alive.cpp
+++ b/llvm_util/llvm2alive.cpp
@@ -1620,6 +1620,10 @@ public:
         attrs.set(ParamAttrs::DeadOnUnwind);
         break;
 
+      case llvm::Attribute::DeadOnReturn:
+        attrs.set(ParamAttrs::DeadOnReturn);
+        break;
+
       case llvm::Attribute::Initializes:
         for (auto &CR : llvmattr.getInitializes()) {
           auto l = CR.getLower().tryZExtValue();

--- a/tests/alive-tv/attrs/dead-on-return-param.srctgt.ll
+++ b/tests/alive-tv/attrs/dead-on-return-param.srctgt.ll
@@ -1,0 +1,12 @@
+define void @src(ptr %0, ptr dead_on_return %1) {
+  call void @llvm.memset.p0.i64(ptr %0, i8 0, i64 1024, i1 false)
+  call void @llvm.memset.p0.i64(ptr %1, i8 0, i64 1024, i1 false)
+  ret void
+}
+
+define void @tgt(ptr %0, ptr dead_on_return %1) {
+  call void @llvm.memset.p0.i64(ptr %0, i8 0, i64 1024, i1 false)
+  ret void
+}
+
+declare void @llvm.memset.p0.i64(ptr, i8, i64, i1)


### PR DESCRIPTION
`dead_on_return` attribute was recently introduced in LLVM.