### PR TITLE
[objectsize] Without allocsize, create a fresh variable for the allocation size. (#1238)

### DIFF
--- a/ir/instr.cpp
+++ b/ir/instr.cpp
@@ -2685,7 +2685,15 @@ StateValue FnCall::toSMT(State &s) const {
   if (attrs.has(AllocKind::Alloc) ||
       attrs.has(AllocKind::Realloc) ||
       attrs.has(FnAttrs::AllocSize)) {
-    auto [size, np_size] = attrs.computeAllocSize(s, args);
+    auto [comput_size, np_size] = attrs.computeAllocSize(s, args);
+    
+    expr size;
+    if(!comput_size.isValid()) {
+      size = expr::mkFreshVar("malloc_size", expr::mkUInt(0, bits_size_t));
+    } else {
+      size = std::move(comput_size);
+    }
+
     expr nonnull = attrs.isNonNull() ? expr(true)
                                      : expr::mkBoolVar("malloc_never_fails");
     // FIXME: alloc-family below


### PR DESCRIPTION
> It's already allocating a new block. It's just it's setting the size as null instead of creating a fresh var in src, and reusing the same var in tgt. It requires some changes in state.cpp & memory.cpp.

Since in this case execution never reaches `addFnCall`, it seems that the suggested modifications to `state.cpp` and `memory.cpp` are not necessary. Am I misunderstanding this? Also, would it be incorrect to introduce a fresh variable when the computed size is invalid?

https://github.com/AliveToolkit/alive2/blob/55cc4bb5c2aa2eb77bd8105685d0f07f75b40af1/ir/instr.cpp#L2758-L2760

Fixes https://github.com/AliveToolkit/alive2/issues/1238