### PR TITLE
Allow ScalableVectorType in llvm2alive and replace llvm.vscale() with one

### DIFF
--- a/llvm_util/llvm2alive.cpp
+++ b/llvm_util/llvm2alive.cpp
@@ -1179,6 +1179,14 @@ public:
       PARSE_BINOP();
       return make_unique<VaCopy>(*a, *b);
     }
+    case llvm::Intrinsic::vscale: {
+      auto ty = llvm_type2alive(i.getType());
+      if (!ty)
+        return error(i);
+      // llvm.vscale() always returns 1
+      auto val = make_intconst(1, ty->bits());
+      return make_unique<UnaryOp>(*ty, value_name(i), *val, UnaryOp::Copy);
+    }
 
     // do nothing intrinsics
     case llvm::Intrinsic::dbg_declare:

--- a/llvm_util/utils.cpp
+++ b/llvm_util/utils.cpp
@@ -198,8 +198,8 @@ Type* llvm_type2alive(const llvm::Type *ty) {
     }
     return cache.get();
   }
-  // TODO: non-fixed sized vectors
-  case llvm::Type::FixedVectorTyID: {
+  case llvm::Type::FixedVectorTyID:
+  case llvm::Type::ScalableVectorTyID: {
     auto &cache = type_cache[ty];
     if (!cache) {
       auto vty = cast<llvm::VectorType>(ty);

--- a/tests/alive-tv/vector/scalable/logical_or_implies_scalablevec.srctgt.ll
+++ b/tests/alive-tv/vector/scalable/logical_or_implies_scalablevec.srctgt.ll
@@ -1,0 +1,13 @@
+define <vscale x 2 x i1> @src(<vscale x 2 x i32> %x) {
+  %c1 = icmp eq <vscale x 2 x i32> %x, zeroinitializer
+  %c2 = icmp eq <vscale x 2 x i32> %x, splat (i32 42)
+  %res = select <vscale x 2 x i1> %c1, <vscale x 2 x i1> splat (i1 true), <vscale x 2 x i1> %c2
+  ret <vscale x 2 x i1> %res
+}
+
+define <vscale x 2 x i1> @tgt(<vscale x 2 x i32> %x) {
+  %c1 = icmp eq <vscale x 2 x i32> %x, zeroinitializer
+  %c2 = icmp eq <vscale x 2 x i32> %x, splat (i32 42)
+  %res = or <vscale x 2 x i1> %c1, %c2
+  ret <vscale x 2 x i1> %res
+}

--- a/tests/alive-tv/vector/scalable/mul_scalable_splat_zero.srctgt.ll
+++ b/tests/alive-tv/vector/scalable/mul_scalable_splat_zero.srctgt.ll
@@ -1,0 +1,9 @@
+define <vscale x 2 x i64> @src(<vscale x 2 x i64> %z) {
+  %shuf = shufflevector <vscale x 2 x i64> insertelement (<vscale x 2 x i64> poison, i64 0, i32 0), <vscale x 2 x i64> poison, <vscale x 2 x i32> zeroinitializer
+  %t3 = mul <vscale x 2 x i64> %shuf, %z
+  ret <vscale x 2 x i64> %t3
+}
+
+define <vscale x 2 x i64> @tgt(<vscale x 2 x i64> %z) {
+  ret <vscale x 2 x i64> zeroinitializer
+}

--- a/tests/alive-tv/vector/scalable/vscale-i32.srctgt.ll
+++ b/tests/alive-tv/vector/scalable/vscale-i32.srctgt.ll
@@ -1,0 +1,10 @@
+declare i32 @llvm.vscale.i32()
+
+define i32 @src() {
+  %v = call i32 @llvm.vscale.i32()
+  ret i32 %v
+}
+
+define i32 @tgt() {
+  ret i32 1
+}

--- a/tests/alive-tv/vector/scalable/vscale-i64.srctgt.ll
+++ b/tests/alive-tv/vector/scalable/vscale-i64.srctgt.ll
@@ -1,0 +1,10 @@
+declare i64 @llvm.vscale.i64()
+
+define i64 @src() {
+  %v = call i64 @llvm.vscale.i64()
+  ret i64 %v
+}
+
+define i64 @tgt() {
+  ret i64 1
+}

--- a/tests/alive-tv/vector/scalable/widening_shuffle_add_scalable.srctgt.ll
+++ b/tests/alive-tv/vector/scalable/widening_shuffle_add_scalable.srctgt.ll
@@ -1,0 +1,11 @@
+define <vscale x 4 x i8> @src(<vscale x 2 x i8> %x) {
+  %widex = shufflevector <vscale x 2 x i8> %x, <vscale x 2 x i8> poison, <vscale x 4 x i32> zeroinitializer
+  %r = add <vscale x 4 x i8> %widex, splat (i8 42)
+  ret <vscale x 4 x i8> %r
+}
+
+define <vscale x 4 x i8> @tgt(<vscale x 2 x i8> %x) {
+  %1 = add <vscale x 2 x i8> %x, splat (i8 42)
+  %r = shufflevector <vscale x 2 x i8> %1, <vscale x 2 x i8> poison, <vscale x 4 x i32> zeroinitializer
+  ret <vscale x 4 x i8> %r
+}


### PR DESCRIPTION
This PR tries to add support of scalable vectors to Alive2. Intuitively, vector operations that verifiy in vscale=1 should also verify for the other vscales. Thus, this patch assumes vscale=1 when running TV, and a constant one will be returned for llvm.vscales() calls.

I attached a few unit test cases.

I am still running TV on the test/Transforms folder. I'll paste diffs after the run finishes.

CC: @regehr 