### PR TITLE
Add environment variables to control loop unroll

### DIFF
--- a/scripts/alivecc.in
+++ b/scripts/alivecc.in
@@ -108,6 +108,14 @@ if (compiling()) {
         push @ARGV, ("-mllvm", "-tv-save-ir");
     }
 
+    if (my $unroll = getenv("ALIVECC_SRC_UNROLL")) {
+        push @ARGV, ("-mllvm", "-tv-src-unroll=".$unroll);
+    }
+
+    if (my $unroll = getenv("ALIVECC_TGT_UNROLL")) {
+        push @ARGV, ("-mllvm", "-tv-tgt-unroll=".$unroll);
+    }
+
     # sanity check: make sure we intercepted all environment variables
     # of the form ALIVECC_*
     foreach my $e (keys %ENV) {


### PR DESCRIPTION
e.g.

```bash
export ALIVECC_SRC_UNROLL=10
export ALIVECC_TGT_UNROLL=10
```

That allows alivecc to verify `-O2` for

```cpp
int main() {
  for (int i = 0; i < 2; ++i) {
    if (i == 3) return 1;
  }
  return 2;
}
```