### PR TITLE
README: recommend grep -F rather than fgrep

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ We run this command on the main LLVM branch each day, and keep track of the resu
 [here](https://web.ist.utl.pt/nuno.lopes/alive2/).  To detect unsound transformations in a local run:
 
 ```
-fgrep -r "(unsound)" ~/alive2/build/logs/
+grep -Fr "(unsound)" ~/alive2/build/logs/
 ```
 
 


### PR DESCRIPTION
As per the manpage: 

Debian  also  includes  the  variant  programs  egrep,  fgrep and rgrep.  These programs are the same as grep -E, grep -F, and grep -r, respectively.  These variants are deprecated upstream [...]