### PR TITLE
Make `dead_on_return` optionally sized

### DIFF
--- a/ir/attrs.cpp
+++ b/ir/attrs.cpp
@@ -55,8 +55,12 @@ ostream& operator<<(ostream &os, const ParamAttrs &attr) {
     os << "allocalign ";
   if (attr.has(ParamAttrs::DeadOnUnwind))
     os << "dead_on_unwind ";
-  if (attr.has(ParamAttrs::DeadOnReturn))
-    os << "dead_on_return ";
+  if (attr.has(ParamAttrs::DeadOnReturn)) {
+    os << "dead_on_return";
+    if (attr.deadOnReturnBytes.has_value())
+      os << "(" << *attr.deadOnReturnBytes << ")";
+    os << " ";
+  }
   if (attr.has(ParamAttrs::Writable))
     os << "writable ";
   if (!attr.initializes.empty()) {

--- a/ir/attrs.h
+++ b/ir/attrs.h
@@ -81,6 +81,7 @@ public:
   uint64_t blockSize = 0;        // exact block size for e.g. byval args
   uint64_t align = 1;
   uint16_t nofpclass = 0;
+  std::optional<uint64_t> deadOnReturnBytes; // bytes for dead_on_return, if exist
 
   std::vector<std::pair<uint64_t, uint64_t>> initializes;
 

--- a/llvm_util/llvm2alive.cpp
+++ b/llvm_util/llvm2alive.cpp
@@ -1638,9 +1638,13 @@ public:
         attrs.set(ParamAttrs::DeadOnUnwind);
         break;
 
-      case llvm::Attribute::DeadOnReturn:
+      case llvm::Attribute::DeadOnReturn: {
         attrs.set(ParamAttrs::DeadOnReturn);
+        const auto &info = llvmattr.getDeadOnReturnInfo();
+        if (!info.coversAllReachableMemory())
+          attrs.deadOnReturnBytes = info.getNumberOfDeadBytes();
         break;
+      }
 
       case llvm::Attribute::Initializes:
         for (auto &CR : llvmattr.getInitializes()) {

--- a/tests/alive-tv/attrs/dead-on-return-param2.srctgt.ll
+++ b/tests/alive-tv/attrs/dead-on-return-param2.srctgt.ll
@@ -1,0 +1,10 @@
+define void @src(ptr dead_on_return(8) %0) {
+  call void @llvm.memset.p0.i64(ptr %0, i8 0, i64 8, i1 false)
+  ret void
+}
+
+define void @tgt(ptr dead_on_return(8) %0) {
+  ret void
+}
+
+declare void @llvm.memset.p0.i64(ptr, i8, i64, i1)

--- a/tests/alive-tv/attrs/dead-on-return-param3.srctgt.ll
+++ b/tests/alive-tv/attrs/dead-on-return-param3.srctgt.ll
@@ -1,0 +1,12 @@
+define void @src(ptr dead_on_return(8) %0) {
+  call void @llvm.memset.p0.i64(ptr %0, i8 0, i64 16, i1 false)
+  ret void
+}
+
+define void @tgt(ptr dead_on_return(8) %0) {
+  ret void
+}
+
+declare void @llvm.memset.p0.i64(ptr, i8, i64, i1)
+
+; ERROR: Mismatch in memory


### PR DESCRIPTION
LLVM `dead_on_return` attribute now supports an optional size.