### PR TITLE
copy the PtrCmpMode when copying an icmp

### DIFF
--- a/ir/instr.cpp
+++ b/ir/instr.cpp
@@ -3032,7 +3032,10 @@ expr ICmp::getTypeConstraints(const Function &f) const {
 }
 
 unique_ptr<Instr> ICmp::dup(Function &f, const string &suffix) const {
-  return make_unique<ICmp>(getType(), getName() + suffix, cond, *a, *b, flags);
+  auto dup = make_unique<ICmp>(getType(), getName() + suffix, cond, *a, *b,
+                               flags);
+  dup->setPtrCmpMode(pcmode);
+  return dup;
 }
 
 


### PR DESCRIPTION
fix a sibling of our bug from this morning