### PR TITLE
print floats more accurately

### DIFF
--- a/llvm_util/utils.cpp
+++ b/llvm_util/utils.cpp
@@ -4,6 +4,7 @@
 #include "llvm_util/utils.h"
 #include "ir/constant.h"
 #include "ir/function.h"
+#include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/IR/Constants.h"
 #include "llvm/IR/DataLayout.h"
@@ -328,10 +329,16 @@ Value* get_operand(llvm::Value *v,
 
   if (auto cnst = dyn_cast<llvm::ConstantFP>(v)) {
     auto &apfloat = cnst->getValueAPF();
-    auto c
-     = make_unique<FloatConst>(*ty,
-                               toString(apfloat.bitcastToAPInt(), 10, false),
-                               true);
+    unique_ptr<FloatConst> c;
+    if (apfloat.isFinite()) {
+      llvm::SmallString<32> str;
+      apfloat.toString(str);
+      c = make_unique<FloatConst>(*ty, string(str), false);
+    } else {
+      c = make_unique<FloatConst>(*ty,
+                                  toString(apfloat.bitcastToAPInt(), 10, false),
+                                  true);
+    }
     auto ret = c.get();
     current_fn->addConstant(std::move(c));
     RETURN_CACHE(ret);


### PR DESCRIPTION
earlier today I was working with this example:
```
define i1 @src(i16 %x, i16 %y) {
    %x1 = uitofp i16 %x to float
    %y1 = uitofp i16 %y to float
    %sub = fsub float %x1, %y1
    %abs = tail call float @llvm.fabs.f32(float %sub)
    %ext = fpext float %abs to double
    %cmp = fcmp olt double %ext, 1.000000e-15
    ret i1 %cmp
}

define i1 @tgt(i16 %x, i16 %y) {
    %cmp = icmp eq i16 %x, %y
    ret i1 %cmp
}
```

Alive verifies it but prints the float as `0.000000`. with this patch we print the float as `1.0000000000000001E-15`

also works for other float types, let me know if you want tests on this