### PR TITLE
Add support for individual loop unroll bounds

### DIFF
--- a/ir/function.cpp
+++ b/ir/function.cpp
@@ -702,8 +702,7 @@ void Function::unroll(vector<unsigned> unroll_bounds) {
       }
     }
 
-    if (unroll_bounds.size()>1)
-    {
+    if (unroll_bounds.size() > 1) {
       unroll_bounds.erase(unroll_bounds.begin());
     }
 

--- a/ir/function.cpp
+++ b/ir/function.cpp
@@ -11,6 +11,7 @@
 #include <fstream>
 #include <set>
 #include <unordered_set>
+#include <iostream>
 
 using namespace smt;
 using namespace util;
@@ -575,8 +576,8 @@ static auto getPhiPredecessors(const Function &F) {
   return map;
 }
 
-void Function::unroll(unsigned k) {
-  if (k == 0)
+void Function::unroll(vector<unsigned> unroll_bounds) {
+  if (unroll_bounds.size() == 0)
     return;
 
   LoopAnalysis la(*this);
@@ -599,6 +600,40 @@ void Function::unroll(unsigned k) {
   // grab all value users before duplication so the list is shorter
   auto users = getUsers();
   auto phi_preds = getPhiPredecessors(*this);
+
+  vector<BasicBlock *> loop_headers_in_order;
+
+  for (auto *bb : BB_order) { // BB_order maintains the code order
+    auto it = forest.find(bb);
+    if (it != forest.end()) {
+      // bb is a loop header
+      loop_headers_in_order.emplace_back(bb);
+    }
+  }
+
+  // check size of loop unroll bounds is valid
+  if (loop_headers_in_order.size() != unroll_bounds.size()) {
+
+    // check if unroll_bounds has only one element, if so, use that for all loop
+    // headers
+    if (unroll_bounds.size() == 1) {
+      unsigned bound = unroll_bounds.front();
+      unroll_bounds.clear();
+      unroll_bounds.resize(loop_headers_in_order.size(), bound);
+    } else {
+        std::cerr << "Error: Number of loop headers does not match number of unroll bounds.\n"
+          << "Number of loop headers: " << loop_headers_in_order.size() << "\n"
+          << "Number of unroll bounds: " << unroll_bounds.size() << std::endl;
+        exit(1);
+    }
+  }
+
+  // map loop header -> unroll bound
+  unordered_map<BasicBlock *, unsigned> unroll_bound_map;
+  for (size_t i = 0; i < loop_headers_in_order.size(); ++i) {
+    auto *header = loop_headers_in_order[i];
+    unroll_bound_map[header] = unroll_bounds[i];
+  }
 
   // traverse each loop tree in post-order
   while (!worklist.empty()) {
@@ -658,13 +693,18 @@ void Function::unroll(unsigned k) {
     for (unsigned i = 0; i < height; ++i) {
       name_prefix += "#1";
     }
-    for (unsigned unroll = 2; unroll <= k; ++unroll) {
+    for (unsigned unroll = 2; unroll <= unroll_bound_map[header]; ++unroll) {
       string suffix = name_prefix + '#' + to_string(unroll);
       for (auto *bb : loop_bbs) {
         auto &copies = bbmap.at(bb);
         copies.emplace_back(&cloneBB(*this, *bb, suffix.c_str(), bbmap, vmap));
         unrolled_bbs.emplace_back(copies.back());
       }
+    }
+
+    if (unroll_bounds.size()>1)
+    {
+      unroll_bounds.erase(unroll_bounds.begin());
     }
 
     // Clone the header once more so that the last iteration of the loop can

--- a/ir/function.cpp
+++ b/ir/function.cpp
@@ -9,9 +9,9 @@
 #include "util/unionfind.h"
 #include <algorithm>
 #include <fstream>
+#include <iostream>
 #include <set>
 #include <unordered_set>
-#include <iostream>
 
 using namespace smt;
 using namespace util;

--- a/ir/function.h
+++ b/ir/function.h
@@ -224,7 +224,7 @@ public:
                          const std::vector<std::string_view> &src_glbs);
 
   void topSort();
-  void unroll(unsigned k);
+  void unroll(std::vector<unsigned> unroll_bounds);
 
   void print(std::ostream &os, bool print_header = true) const;
   friend std::ostream &operator<<(std::ostream &os, const Function &f);

--- a/llvm_util/cmd_args_def.h
+++ b/llvm_util/cmd_args_def.h
@@ -2,15 +2,11 @@
 // Distributed under the MIT license that can be found in the LICENSE file.
 
 #ifdef ARGS_SRC_TGT
-std::vector<unsigned> unroll_src(opt_src_unrolling_factor.begin(), opt_src_unrolling_factor.end());
-std::vector<unsigned> unroll_tgt(opt_tgt_unrolling_factor.begin(), opt_tgt_unrolling_factor.end());
-config::src_unroll_bounds = unroll_src;
-config::tgt_unroll_bounds = unroll_tgt;
+config::src_unroll_bounds = std::vector<unsigned>(opt_src_unrolling_factor.begin(), opt_src_unrolling_factor.end());
+config::tgt_unroll_bounds = std::vector<unsigned>(opt_tgt_unrolling_factor.begin(), opt_tgt_unrolling_factor.end());
 #else
-std::vector<unsigned> unroll_src = {opt_unrolling_factor};
-std::vector<unsigned> unroll_tgt = {opt_unrolling_factor};
-config::src_unroll_bounds = unroll_src;
-config::tgt_unroll_bounds = unroll_tgt;
+config::src_unroll_bounds = std::vector<unsigned>({opt_unrolling_factor});
+config::tgt_unroll_bounds = std::vector<unsigned>({opt_unrolling_factor});
 #endif
 config::disable_undef_input = opt_disable_undef;
 config::disable_poison_input = opt_disable_poison;

--- a/llvm_util/cmd_args_def.h
+++ b/llvm_util/cmd_args_def.h
@@ -2,11 +2,15 @@
 // Distributed under the MIT license that can be found in the LICENSE file.
 
 #ifdef ARGS_SRC_TGT
-config::src_unroll_cnt = opt_src_unrolling_factor;
-config::tgt_unroll_cnt = opt_tgt_unrolling_factor;
+std::vector<unsigned> unroll_src(opt_src_unrolling_factor.begin(), opt_src_unrolling_factor.end());
+std::vector<unsigned> unroll_tgt(opt_tgt_unrolling_factor.begin(), opt_tgt_unrolling_factor.end());
+config::src_unroll_bounds = unroll_src;
+config::tgt_unroll_bounds = unroll_tgt;
 #else
-config::src_unroll_cnt = opt_unrolling_factor;
-config::tgt_unroll_cnt = opt_unrolling_factor;
+std::vector<unsigned> unroll_src = {opt_unrolling_factor};
+std::vector<unsigned> unroll_tgt = {opt_unrolling_factor};
+config::src_unroll_bounds = unroll_src;
+config::tgt_unroll_bounds = unroll_tgt;
 #endif
 config::disable_undef_input = opt_disable_undef;
 config::disable_poison_input = opt_disable_poison;

--- a/llvm_util/cmd_args_list.h
+++ b/llvm_util/cmd_args_list.h
@@ -29,8 +29,8 @@ llvm::cl::list<unsigned> opt_tgt_unrolling_factor(LLVM_ARGS_PREFIX "tgt-unroll",
   llvm::cl::CommaSeparated,
   llvm::cl::cat(alive_cmdargs));
 #else
-  llvm::cl::opt<unsigned> opt_unrolling_factor(LLVM_ARGS_PREFIX "unroll",
-  llvm::cl::desc("Unrolling factor (default=0)"), 
+llvm::cl::opt<unsigned> opt_unrolling_factor(LLVM_ARGS_PREFIX "unroll",
+  llvm::cl::desc("Unrolling factor (default=0)"),
   llvm::cl::cat(alive_cmdargs));
 #endif
 

--- a/llvm_util/cmd_args_list.h
+++ b/llvm_util/cmd_args_list.h
@@ -19,17 +19,19 @@ llvm::cl::list<std::string> opt_funcs(LLVM_ARGS_PREFIX "func",
 set<string> func_names;
 
 #ifdef ARGS_SRC_TGT
-llvm::cl::opt<unsigned> opt_src_unrolling_factor(LLVM_ARGS_PREFIX "src-unroll",
-  llvm::cl::desc("Unrolling factor for src function (default=0)"),
-  llvm::cl::init(0), llvm::cl::cat(alive_cmdargs));
+llvm::cl::list<unsigned> opt_src_unrolling_factor(LLVM_ARGS_PREFIX "src-unroll",
+  llvm::cl::desc("Unrolling factors for src function (default=0)"), 
+  llvm::cl::CommaSeparated,
+  llvm::cl::cat(alive_cmdargs));
 
-llvm::cl::opt<unsigned> opt_tgt_unrolling_factor(LLVM_ARGS_PREFIX "tgt-unroll",
-  llvm::cl::desc("Unrolling factor for tgt function (default=0)"),
-  llvm::cl::init(0), llvm::cl::cat(alive_cmdargs));
+llvm::cl::list<unsigned> opt_tgt_unrolling_factor(LLVM_ARGS_PREFIX "tgt-unroll",
+  llvm::cl::desc("Unrolling factors for tgt function (default=0)"),
+  llvm::cl::CommaSeparated,
+  llvm::cl::cat(alive_cmdargs));
 #else
-llvm::cl::opt<unsigned> opt_unrolling_factor(LLVM_ARGS_PREFIX "unroll",
-  llvm::cl::desc("Unrolling factor (default=0)"),
-  llvm::cl::init(0), llvm::cl::cat(alive_cmdargs));
+  llvm::cl::opt<unsigned> opt_unrolling_factor(LLVM_ARGS_PREFIX "unroll",
+  llvm::cl::desc("Unrolling factor (default=0)"), 
+  llvm::cl::cat(alive_cmdargs));
 #endif
 
 llvm::cl::opt<bool> opt_disable_undef(LLVM_ARGS_PREFIX "disable-undef-input",

--- a/llvm_util/cmd_args_list.h
+++ b/llvm_util/cmd_args_list.h
@@ -31,7 +31,7 @@ llvm::cl::list<unsigned> opt_tgt_unrolling_factor(LLVM_ARGS_PREFIX "tgt-unroll",
 #else
 llvm::cl::opt<unsigned> opt_unrolling_factor(LLVM_ARGS_PREFIX "unroll",
   llvm::cl::desc("Unrolling factor (default=0)"),
-  llvm::cl::cat(alive_cmdargs));
+  llvm::cl::init(0), llvm::cl::cat(alive_cmdargs));
 #endif
 
 llvm::cl::opt<bool> opt_disable_undef(LLVM_ARGS_PREFIX "disable-undef-input",

--- a/tools/transform.cpp
+++ b/tools/transform.cpp
@@ -1976,8 +1976,8 @@ void Transform::preprocess() {
   // bits_program_pointer is used by unroll. Initialize it in advance
   initBitsProgramPointer(*this);
 
-  src.unroll(config::src_unroll_cnt);
-  tgt.unroll(config::tgt_unroll_cnt);
+  src.unroll(config::src_unroll_bounds);
+  tgt.unroll(config::tgt_unroll_bounds);
 }
 
 void Transform::print(ostream &os, const TransformPrintOpts &opt) const {

--- a/util/config.cpp
+++ b/util/config.cpp
@@ -3,6 +3,7 @@
 
 #include "util/config.h"
 #include <iostream>
+#include <vector>
 
 using namespace std;
 
@@ -20,8 +21,8 @@ bool fail_if_src_is_ub = false;
 bool disallow_ub_exploitation = false;
 bool debug = false;
 bool quiet = false;
-unsigned src_unroll_cnt = 0;
-unsigned tgt_unroll_cnt = 0;
+std::vector<unsigned> src_unroll_bounds;
+std::vector<unsigned> tgt_unroll_bounds;
 unsigned max_offset_bits = 64;
 unsigned max_sizet_bits = 64;
 

--- a/util/config.h
+++ b/util/config.h
@@ -3,8 +3,8 @@
 // Copyright (c) 2018-present The Alive2 Authors.
 // Distributed under the MIT license that can be found in the LICENSE file.
 
-#include <string>
 #include <ostream>
+#include <string>
 #include <vector>
 
 namespace util::config {

--- a/util/config.h
+++ b/util/config.h
@@ -5,6 +5,7 @@
 
 #include <string>
 #include <ostream>
+#include <vector>
 
 namespace util::config {
 
@@ -33,9 +34,9 @@ extern bool debug;
 
 extern bool quiet;
 
-extern unsigned src_unroll_cnt;
+extern std::vector<unsigned> src_unroll_bounds;
 
-extern unsigned tgt_unroll_cnt;
+extern std::vector<unsigned> tgt_unroll_bounds;
 
 // The maximum number of bits to use for offset computations. Note that this may
 // impact correctness, if values involved in offset computations exceed the


### PR DESCRIPTION
These changes allow setting individual loop unroll bounds from the command line. This is useful if we want to check a property for a single loop in a multi-loop function, where a single loop unroll bound may lead to code blow-up.

Usage: If `src` and `tgt` have two loops each then individual loop unroll bounds can be used as follows:`alive-tv test.ll --src-unroll=1,2 --tgt-unroll=1,2`
The unroll bounds are applied to loops in the order they appear in code. These changes preserve backwards compatability; if a single loop unroll bound is provided then it is applied to all loops in the function.
-Alborz