### PR TITLE
float printing was lossy in 2 places, fix this

### DIFF
--- a/ir/constant.cpp
+++ b/ir/constant.cpp
@@ -6,6 +6,7 @@
 #include "util/compiler.h"
 #include <bit>
 #include <cassert>
+#include <charconv>
 #include <cmath>
 // TODO: remove cstring when migrated to std::bit_cast
 #include <cstring>
@@ -66,8 +67,13 @@ static string bits_to_float(Type &type, const string &val) {
   uint64_t num = strtoull(val.c_str(), nullptr, 10);
   TO fp = mbit_cast<TI, TO>(num);
   auto fpclass = fpclassify(fp);
-  return fpclass == FP_NAN || fpclass == FP_SUBNORMAL ? to_hex(type, val)
-                                                      : to_string(fp);
+  if (fpclass == FP_NAN || fpclass == FP_SUBNORMAL)
+    return to_hex(type, val);
+  char buf[64];
+  auto [ptr, ec] = to_chars(buf, buf + sizeof(buf), fp,
+                            chars_format::scientific);
+  *ptr = '\0';
+  return buf;
 }
 
 static string int_to_readable_float(Type &type, const string &val) {

--- a/ir/type.cpp
+++ b/ir/type.cpp
@@ -8,6 +8,8 @@
 #include "util/compiler.h"
 #include <array>
 #include <cassert>
+#include <charconv>
+#include <cstring>
 #include <numeric>
 #include <sstream>
 
@@ -639,7 +641,26 @@ void FloatType::printVal(ostream &os, const State &s, const expr &e) const {
   } else if (f.isInf().isTrue()) {
     os << (f.isFPNegative().isTrue() ? "-oo" : "+oo");
   } else {
-    os << f.float2Real().numeral_string();
+    uint64_t bits = strtoull(e.numeral_string().data(), nullptr, 10);
+    if (fpType == Float) {
+      float fp;
+      memcpy(&fp, &bits, sizeof(fp));
+      char buf[64];
+      auto [p, ec] = to_chars(buf, buf + sizeof(buf), fp,
+                              chars_format::scientific);
+      *p = '\0';
+      os << buf;
+    } else if (fpType == Double) {
+      double fp;
+      memcpy(&fp, &bits, sizeof(fp));
+      char buf[64];
+      auto [p, ec] = to_chars(buf, buf + sizeof(buf), fp,
+                              chars_format::scientific);
+      *p = '\0';
+      os << buf;
+    } else {
+      os << f.float2Real().numeral_string();
+    }
   }
   os << ')';
 }


### PR DESCRIPTION
ok let's try this again. the problem was in `to_string(fp)` -- this is lossy, it does not faithfully print the value. this patch should result in fully round-trippable float printing. 

there was an analogous problem in CEX printing, this fixes that too