### PR TITLE
Fix nested loop unroll exit value repair

### DIFF
--- a/ir/function.cpp
+++ b/ir/function.cpp
@@ -1238,4 +1238,4 @@ void LoopAnalysis::printDot(ostream &os) const {
   os << "}\n";
 }
 
-} 
+}

--- a/ir/function.cpp
+++ b/ir/function.cpp
@@ -608,10 +608,6 @@ void Function::unroll(unsigned k) {
   // computed bottom-up during the post-order traversal below
   unordered_map<BasicBlock*, vector<BasicBlock*>> loop_nodes;
 
-  // grab all value users before duplication so the list is shorter
-  auto users = getUsers();
-  auto phi_preds = getPhiPredecessors(*this);
-
   // traverse each loop tree in post-order
   while (!worklist.empty()) {
     auto [header, height, flag] = worklist.back();
@@ -643,6 +639,12 @@ void Function::unroll(unsigned k) {
         own_loop_bbs.emplace_back(bb);
       }
     }
+
+    // Grab value users before duplicating the current loop so the list stays
+    // shorter. This must be refreshed per loop because unrolling an inner loop
+    // can introduce phis that outer-loop exits now use.
+    auto users = getUsers();
+    auto phi_preds = getPhiPredecessors(*this);
 
     // map: original BB -> {BB} U copies-of-BB
     unordered_map<const BasicBlock*, vector<BasicBlock*>> bbmap;
@@ -1237,4 +1239,3 @@ void LoopAnalysis::printDot(ostream &os) const {
 }
 
 } 
-

--- a/tests/alive-tv/loops/nested-exit-phi.srctgt.ll
+++ b/tests/alive-tv/loops/nested-exit-phi.srctgt.ll
@@ -1,0 +1,27 @@
+; TEST-ARGS: -src-unroll=2 -tgt-unroll=2
+
+define i32 @src() {
+  br label %1
+
+1:
+  %2 = phi i32 [ 0, %0 ], [ 1, %6 ]
+  br label %3
+
+3:
+  %4 = mul i32 %2, 1
+  br label %5
+
+5:
+  br i1 false, label %3, label %6
+
+6:
+  %7 = icmp slt i32 %2, 1
+  br i1 %7, label %1, label %8
+
+8:
+  ret i32 %4
+}
+
+define i32 @tgt() {
+  ret i32 1
+}


### PR DESCRIPTION
## Summary

- Refresh loop unroll user and phi-predecessor snapshots per loop so outer-loop exit repair sees phis introduced while unrolling inner loops.
- Add a regression test for the nested loop exit phi case from #1264.

Fixes #1264.

## Testing

- `ninja check`

Result: 1428 passed, 1 expected failure.