### PR TITLE
ignore tbaa metadata when constructing ir

### DIFF
--- a/llvm_util/llvm2alive.cpp
+++ b/llvm_util/llvm2alive.cpp
@@ -1463,6 +1463,7 @@ public:
       case LLVMContext::MD_nosanitize:
       case LLVMContext::MD_prof:
       case LLVMContext::MD_unpredictable:
+      case LLVMContext::MD_tbaa:
         break;
 
       default:


### PR DESCRIPTION
`alive-tv` fails in `llvm2alive.cpp` when it sees TBAA metadata 
information.

Instead of requiring folks to strip this metadata themselves, we can just ignore it.
I've added it to the list of "irrelevant for correctness".