### PR TITLE
Use new triple API

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -256,7 +256,7 @@ install(TARGETS alive alive-jobserver)
 #add_library(alive2 SHARED ${IR_SRCS} ${SMT_SRCS} ${TOOLS_SRCS} ${UTIL_SRCS} ${LLVM_UTIL_SRCS})
 
 if (BUILD_LLVM_UTILS OR BUILD_TV)
-  llvm_map_components_to_libnames(llvm_libs support core irreader bitwriter analysis passes transformutils codegen AllTargetsCodeGens AllTargetsDescs AllTargetsInfos)
+  llvm_map_components_to_libnames(llvm_libs support core irreader bitwriter analysis passes transformutils codegen targetparser AllTargetsCodeGens AllTargetsDescs AllTargetsInfos)
 #  target_link_libraries(alive2 PRIVATE ${llvm_libs})
   target_link_libraries(alive-tv PRIVATE ${ALIVE_LIBS_LLVM} ${Z3_LIBRARIES} ${HIREDIS_LIBRARIES} ${llvm_libs})
   target_link_libraries(quick-fuzz PRIVATE ${ALIVE_LIBS_LLVM} ${Z3_LIBRARIES} ${HIREDIS_LIBRARIES} ${llvm_libs})

--- a/llvm_util/llvm_optimizer.cpp
+++ b/llvm_util/llvm_optimizer.cpp
@@ -29,7 +29,7 @@ string optimize_module(llvm::Module &M, string_view optArgs) {
   Triple ModuleTriple(M.getTargetTriple());
   unique_ptr<llvm::TargetMachine> TM;
   if (ModuleTriple.getArch()) {
-    auto ETM = codegen::createTargetMachineForTriple(ModuleTriple.str());
+    auto ETM = codegen::createTargetMachineForTriple(ModuleTriple);
     if (auto E = ETM.takeError())
       return toString(std::move(E));
     TM = std::move(*ETM);


### PR DESCRIPTION
`createTargetMachineForTriple(StringRef TargetTriple, CodeGenOptLevel OptLevel)` has been deprecated in https://github.com/llvm/llvm-project/pull/205889.
