### PR TITLE
Use Triple overload for target machine creation

### DIFF
--- a/llvm_util/llvm_optimizer.cpp
+++ b/llvm_util/llvm_optimizer.cpp
@@ -29,7 +29,7 @@ string optimize_module(llvm::Module &M, string_view optArgs) {
   Triple ModuleTriple(M.getTargetTriple());
   unique_ptr<llvm::TargetMachine> TM;
   if (ModuleTriple.getArch()) {
-    auto ETM = codegen::createTargetMachineForTriple(ModuleTriple.str());
+    auto ETM = codegen::createTargetMachineForTriple(ModuleTriple);
     if (auto E = ETM.takeError())
       return toString(std::move(E));
     TM = std::move(*ETM);


### PR DESCRIPTION
## Summary

Use the non-deprecated `llvm::Triple` overload of `codegen::createTargetMachineForTriple` in `llvm_util::optimize_module`.

## Root Cause

Current LLVM headers deprecate the `StringRef` overload of `createTargetMachineForTriple` in favor of the `Triple` overload. Alive2 builds with `-Werror`, so the deprecation warning stops the build in `llvm_util/llvm_optimizer.cpp`.

## Impact

This keeps Alive2 building against current LLVM without changing target machine selection behavior.

## Validation

- `cmake --build build`
- `ctest --test-dir build --show-only` showed no configured CTest tests in this build tree.