### PR TITLE
Add support for nofree/nofreeobj

### DIFF
--- a/ir/attrs.cpp
+++ b/ir/attrs.cpp
@@ -63,6 +63,10 @@ ostream& operator<<(ostream &os, const ParamAttrs &attr) {
   }
   if (attr.has(ParamAttrs::Writable))
     os << "writable ";
+  if (attr.has(ParamAttrs::NoFree))
+    os << "nofree ";
+  if (attr.has(ParamAttrs::NoFreeObj))
+    os << "nofreeobj ";
   if (!attr.initializes.empty()) {
     os << "initializes(";
     bool first = true;
@@ -160,6 +164,8 @@ ostream& operator<<(ostream &os, const FnAttrs &attr) {
     attr.fp_denormal32->print(os, true);
   if (attr.has(FnAttrs::Asm))
     os << " asm";
+  if (attr.has(FnAttrs::NoFreeObj))
+    os << " nofreeobj";
   return os << attr.mem;
 }
 

--- a/ir/attrs.h
+++ b/ir/attrs.h
@@ -71,6 +71,7 @@ public:
                    ZeroExt = 1<<13, SignExt = 1<<14, InReg = 1<<15,
                    NoFPClass = 1<<16, DeadOnUnwind = 1<<17,
                    Writable = 1<<18, DeadOnReturn = 1<<19,
+                   NoFree = 1<<20, NoFreeObj = 1<<21,
                    IsArg = 1<<31 // used internally to make values as arguments
                   };
 
@@ -136,7 +137,8 @@ public:
                    DereferenceableOrNull = 1 << 10,
                    NullPointerIsValid = 1 << 11,
                    AllocSize = 1 << 12, ZeroExt = 1<<13,
-                   SignExt = 1<<14, NoFPClass = 1<<15, Asm = 1<<16 };
+                   SignExt = 1<<14, NoFPClass = 1<<15, Asm = 1<<16,
+                   NoFreeObj = 1<<17 };
 
   FnAttrs(unsigned bits = None) : bits(bits) {}
 

--- a/llvm_util/known_fns.cpp
+++ b/llvm_util/known_fns.cpp
@@ -506,8 +506,8 @@ namespace llvm_util {
 bool llvm_implict_attrs(llvm::Function &f, const llvm::TargetLibraryInfo &TLI,
                         FnAttrs &attrs, vector<ParamAttrs> &param_attrs,
                         const vector<Value*> &args) {
-  llvm::LibFunc libfn;
-  if (!TLI.getLibFunc(f, libfn) || !TLI.has(libfn))
+  llvm::LibFunc libfn = TLI.getLibFunc(f);
+  if (!TLI.has(libfn))
     return false;
   return implict_attrs_(libfn, attrs, param_attrs,
                         f.getReturnType()->isVoidTy(), args);
@@ -530,8 +530,11 @@ known_call(llvm::CallInst &i, const llvm::TargetLibraryInfo &TLI,
     RETURN_EXACT();
 
   auto decl = i.getCalledFunction();
-  llvm::LibFunc libfn;
-  if (!decl || !TLI.getLibFunc(*decl, libfn))
+  if (!decl)
+    RETURN_EXACT();
+
+  llvm::LibFunc libfn = TLI.getLibFunc(*decl);
+  if (libfn == llvm::NotLibFunc)
     RETURN_EXACT();
 
   auto tci = parse_fn_tailcall(i);

--- a/llvm_util/llvm2alive.cpp
+++ b/llvm_util/llvm2alive.cpp
@@ -1696,6 +1696,14 @@ public:
         ranges::sort(attrs.initializes);
         break;
 
+      case llvm::Attribute::NoFree:
+        attrs.set(ParamAttrs::NoFree);
+        break;
+
+      case llvm::Attribute::NoFreeObj:
+        attrs.set(ParamAttrs::NoFreeObj);
+        break;
+
       default:
         // If it is call site, it should be added at approximation list
         if (!is_callsite)


### PR DESCRIPTION
Fix test failure in tests/alive-tv/bugs/pr1290.srctgt.ll.

This doesn't implement anything. It just suppresses the failure.

Stacked on https://github.com/AliveToolkit/alive2/pull/1336.
