### PR TITLE
Move `PassInfoMixin` to the `llvm::detail` namespace

### DIFF
--- a/tv/tv.cpp
+++ b/tv/tv.cpp
@@ -546,7 +546,7 @@ bool is_terminate_pass(const llvm::StringRef &pass0) {
 }
 
 
-struct TVPass : public llvm::PassInfoMixin<TVPass> {
+struct TVPass : public llvm::detail::PassInfoMixin<TVPass> {
   static string batched_pass_begin_name;
   static bool batch_started;
   // # of run passes when batching is enabled
@@ -682,7 +682,7 @@ void runTVPass(Ty &M) {
   tv.run(M, get_TLI);
 }
 
-struct ClangTVFinalizePass : public llvm::PassInfoMixin<ClangTVFinalizePass> {
+struct ClangTVFinalizePass : public llvm::detail::PassInfoMixin<ClangTVFinalizePass> {
   llvm::PreservedAnalyses run(llvm::Module &M,
                               llvm::ModuleAnalysisManager &AM) {
     if (is_clangtv) {


### PR DESCRIPTION
Related https://github.com/llvm/llvm-project/pull/218198